### PR TITLE
UI Redesign v2: Sidebar nav, Minswap-inspired layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main, execute-leverage-loop]
+    branches: [main, execute-leverage-loop, ui-redesign-v2]
     paths:
       - "frontend/**"
       - ".github/workflows/deploy.yml"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,245 +7,249 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
   <div id="app">
 
-    <!-- Header -->
-    <header>
-      <div class="header-left">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-top">
         <div class="logo">
           <img src="logo.svg" alt="Blend Leverage" class="logo-icon-img" />
-          <span class="logo-text">Blend Leverage</span>
+          <span class="logo-text">Blend<span class="logo-accent">Lev</span></span>
         </div>
-        <div class="pool-badge">
-          <span class="badge-label">Protocol</span>
-          <span class="badge-value">Blend · Mainnet</span>
-        </div>
-        <button id="expert-toggle" class="btn btn-ghost btn-sm expert-toggle" title="Expert mode: lower minimum HF to 1.005">Expert</button>
-        <button id="theme-toggle" class="theme-toggle" title="Toggle light/dark mode">&#9790;</button>
-      </div>
-      <div id="wallet-area">
-        <button id="connect-btn" class="btn btn-primary">Connect Wallet</button>
-        <div id="wallet-connected" class="wallet-connected hidden">
-          <div class="wallet-info">
-            <span class="wallet-dot"></span>
-            <span id="wallet-address" class="mono"></span>
-          </div>
-          <button id="switch-wallet-btn" class="btn btn-ghost btn-sm" title="Switch to a different account">⟳ Switch</button>
-          <button id="disconnect-btn" class="btn btn-ghost btn-sm">Disconnect</button>
-        </div>
-      </div>
-    </header>
-
-    <main>
-
-      <!-- Connect prompt -->
-      <div id="connect-prompt" class="connect-prompt">
-        <img src="logo.svg" alt="Blend Leverage" class="connect-prompt-logo" />
-        <h2>Connect your wallet</h2>
-        <p>Connect a Stellar wallet to manage leverage positions on Blend Protocol pools.</p>
-        <button class="btn btn-primary btn-lg" onclick="document.getElementById('connect-btn').click()">Connect Wallet</button>
-      </div>
-
-      <!-- Dashboard -->
-      <div id="dashboard" class="hidden">
-
-        <!-- Pool tabs -->
-        <div class="pool-tabs-wrap">
+        <nav class="sidebar-nav">
           <div id="pool-tabs" class="pool-tabs"></div>
-        </div>
-        <div id="pool-frozen-banner" class="pool-frozen-banner hidden">
-          ⚠ This pool is Admin Frozen following the February 2026 oracle exploit. No new positions can be opened.
-        </div>
+        </nav>
+      </div>
+      <div class="sidebar-bottom">
+        <button id="expert-toggle" class="sidebar-btn expert-toggle" title="Expert mode: lower minimum HF to 1.005">Expert</button>
+        <button id="theme-toggle" class="sidebar-btn theme-toggle" title="Toggle light/dark mode">&#9790;</button>
+      </div>
+    </aside>
 
-        <!-- Asset tabs -->
-        <div class="asset-tabs-wrap">
+    <!-- Main content -->
+    <div class="main-wrap">
+      <!-- Top bar -->
+      <header>
+        <div class="header-left">
           <div id="asset-tabs" class="asset-tabs"></div>
         </div>
-
-        <!-- Pool stats bar -->
-        <div class="stats-bar">
-          <div class="stat">
-            <span class="stat-label">c_factor <span class="tooltip" title="Collateral factor — the fraction of your collateral that counts toward borrowing power. 95% means $100 of collateral lets you borrow up to $95.">?</span></span>
-            <span class="stat-value" id="stat-cfactor">—</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Max leverage <span class="tooltip" title="Maximum leverage where Health Factor stays above 1.03 (safe minimum). Derived from the collateral factor: max_lev = 1.03 / (1.03 - c_factor).">?</span></span>
-            <span class="stat-value" id="stat-max-lev">—</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Available <span class="tooltip" title="Tokens currently available to borrow from the pool. If your first borrow step exceeds this (after your deposit adds liquidity), the position cannot be opened.">?</span></span>
-            <span class="stat-value" id="stat-liquidity">—</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Utilization <span class="tooltip" title="Pool utilization = total borrowed / total supplied. Above 85% is dangerous: collateral d-tokens become illiquid, liquidators can't profit, and bad debt accumulates.">?</span></span>
-            <span class="stat-value" id="stat-util">—</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Oracle price</span>
-            <span class="stat-value" id="stat-price">—</span>
+        <div id="wallet-area">
+          <button id="connect-btn" class="btn btn-primary btn-connect">Connect Wallet</button>
+          <div id="wallet-connected" class="wallet-connected hidden">
+            <div class="wallet-info">
+              <span class="wallet-dot"></span>
+              <span id="wallet-address" class="mono"></span>
+            </div>
+            <button id="switch-wallet-btn" class="btn btn-ghost btn-sm" title="Switch to a different account">Switch</button>
+            <button id="disconnect-btn" class="btn btn-ghost btn-sm">Disconnect</button>
           </div>
         </div>
+      </header>
 
-        <!-- APR breakdown card -->
-        <div class="card apr-card">
-          <div class="apr-side">
-            <div class="apr-side-label">Supply</div>
-            <div class="apr-row">
-              <span class="apr-key">Interest APR</span>
-              <span class="apr-val" id="supply-interest-apr">—</span>
-            </div>
-            <div class="apr-row">
-              <span class="apr-key">BLND emissions</span>
-              <span class="apr-val apr-blnd" id="supply-blnd-apr">—</span>
-            </div>
-            <div class="apr-row apr-net-row">
-              <span class="apr-key">Net supply APR</span>
-              <span class="apr-val" id="supply-net-apr">—</span>
-            </div>
-          </div>
-          <div class="apr-divider"></div>
-          <div class="apr-side">
-            <div class="apr-side-label">Borrow</div>
-            <div class="apr-row">
-              <span class="apr-key">Interest cost</span>
-              <span class="apr-val" id="borrow-interest-apr">—</span>
-            </div>
-            <div class="apr-row">
-              <span class="apr-key">BLND emissions</span>
-              <span class="apr-val apr-blnd" id="borrow-blnd-apr">—</span>
-            </div>
-            <div class="apr-row apr-net-row">
-              <span class="apr-key">Net borrow cost</span>
-              <span class="apr-val" id="borrow-net-cost">—</span>
-            </div>
-          </div>
+      <main>
+
+        <!-- Connect prompt -->
+        <div id="connect-prompt" class="connect-prompt">
+          <img src="logo.svg" alt="Blend Leverage" class="connect-prompt-logo" />
+          <h2>Connect your wallet</h2>
+          <p>Manage leverage positions on Blend Protocol pools on Stellar.</p>
+          <button class="btn btn-primary btn-lg" onclick="document.getElementById('connect-btn').click()">Connect Wallet</button>
         </div>
 
-        <div class="two-col">
+        <!-- Dashboard -->
+        <div id="dashboard" class="hidden">
 
-          <!-- Current position -->
-          <section class="card">
-            <div class="card-header">
-              <h2>Your Position</h2>
-              <button id="refresh-btn" class="btn btn-ghost btn-sm">↻</button>
+          <div id="pool-frozen-banner" class="pool-frozen-banner hidden">
+            ⚠ This pool is Admin Frozen following the February 2026 oracle exploit. No new positions can be opened.
+          </div>
+
+          <!-- Stats row -->
+          <div class="stats-row">
+            <div class="stat-card">
+              <span class="stat-label">c_factor <span class="tooltip" title="Collateral factor — the fraction of your collateral that counts toward borrowing power. 95% means $100 of collateral lets you borrow up to $95.">?</span></span>
+              <span class="stat-value" id="stat-cfactor">—</span>
             </div>
-            <div class="pool-blnd-row">
-              <span class="metric-label">Pending BLND (pool)</span>
-              <span class="metric-value mono" id="pos-blnd">—</span>
-              <button id="claim-btn" class="btn btn-secondary btn-sm" disabled>Claim all BLND</button>
+            <div class="stat-card">
+              <span class="stat-label">Max leverage <span class="tooltip" title="Maximum leverage where Health Factor stays above the safe minimum. Derived from the collateral and liability factors.">?</span></span>
+              <span class="stat-value" id="stat-max-lev">—</span>
             </div>
-            <div id="no-position" class="empty-state">No active position for this asset.</div>
-            <div id="position-data" class="hidden">
-              <div class="position-grid">
-                <div class="position-metric">
-                  <span class="metric-label">Collateral</span>
-                  <span class="metric-value mono" id="pos-collateral">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Debt</span>
-                  <span class="metric-value mono" id="pos-debt">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Net equity</span>
-                  <span class="metric-value mono" id="pos-equity">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Leverage</span>
-                  <span class="metric-value mono" id="pos-leverage">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Asset HF <span class="tooltip" title="Health Factor for this asset only. HF = (collateral × c_factor) / debt. Below 1.0 = liquidatable. Below 1.03 = danger zone.">?</span></span>
-                  <span class="metric-value" id="pos-hf">—</span>
-                  <div class="hf-bar-wrap"><div class="hf-bar" id="hf-bar"></div></div>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Pool HF <span class="tooltip" title="Health Factor across ALL your positions in this pool, weighted by oracle price. If you have multiple assets, this is the aggregate liquidation risk.">?</span></span>
-                  <span class="metric-value" id="pos-pool-hf">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Net APY <span class="tooltip" title="Annual return on your initial deposit (equity), not on total collateral. Formula: supplyAPR × leverage − borrowAPR × (leverage − 1). Includes BLND emission value.">?</span></span>
-                  <span class="metric-value" id="pos-net-apr">—</span>
-                </div>
-                <div class="position-metric">
-                  <span class="metric-label">Borrow headroom <span class="tooltip" title="How much more USD you could borrow before Health Factor hits 1.0 (liquidation). Calculated as (collateral × c_factor − debt) × oracle price. When this reaches $0, you can be liquidated.">?</span></span>
-                  <span class="metric-value mono" id="pos-headroom">—</span>
-                </div>
-                <div class="position-metric position-metric-full">
-                  <span class="metric-label">Days until liquidation <span class="tooltip" title="Estimated days before HF drops to 1.0, based on the interest rate spread only (borrow APR − supply APR). BLND emissions are excluded because they accrue as a separate token you must claim and sell. Formula: ln(HF) / (borrowAPR − supplyAPR) × 365.">?</span></span>
-                  <span class="metric-value" id="pos-liq-days">—</span>
-                  <div class="liq-days-note" id="pos-liq-note"></div>
-                </div>
+            <div class="stat-card">
+              <span class="stat-label">Available <span class="tooltip" title="Tokens currently available to borrow from the pool.">?</span></span>
+              <span class="stat-value" id="stat-liquidity">—</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Utilization <span class="tooltip" title="Pool utilization = total borrowed / total supplied.">?</span></span>
+              <span class="stat-value" id="stat-util">—</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Oracle price</span>
+              <span class="stat-value" id="stat-price">—</span>
+            </div>
+          </div>
+
+          <!-- APR breakdown -->
+          <div class="apr-grid">
+            <div class="apr-card">
+              <div class="apr-card-label">Supply</div>
+              <div class="apr-row">
+                <span class="apr-key">Interest APR</span>
+                <span class="apr-val" id="supply-interest-apr">—</span>
               </div>
-              <div class="position-actions">
-                <button id="repay-btn" class="btn btn-secondary" disabled>Repay Debt</button>
-                <button id="close-btn" class="btn btn-danger" disabled>Close Position</button>
+              <div class="apr-row">
+                <span class="apr-key">BLND emissions</span>
+                <span class="apr-val apr-blnd" id="supply-blnd-apr">—</span>
+              </div>
+              <div class="apr-row apr-net-row">
+                <span class="apr-key">Net supply APR</span>
+                <span class="apr-val" id="supply-net-apr">—</span>
               </div>
             </div>
-          </section>
-
-          <!-- Open position -->
-          <section class="card">
-            <div class="card-header">
-              <h2>Open Position</h2>
-            </div>
-            <div class="form-group">
-              <label>Initial deposit</label>
-              <div class="input-wrap">
-                <input type="number" id="initial-input" class="input mono" placeholder="1000" min="0" step="any" value="1000" />
-                <button id="max-btn" class="btn btn-ghost btn-sm input-max-btn">Max</button>
-                <span class="input-suffix" id="asset-symbol-suffix">—</span>
+            <div class="apr-card">
+              <div class="apr-card-label">Borrow</div>
+              <div class="apr-row">
+                <span class="apr-key">Interest cost</span>
+                <span class="apr-val" id="borrow-interest-apr">—</span>
               </div>
-              <span class="balance-hint">Wallet: <span id="asset-balance">—</span></span>
-            </div>
-            <div class="form-group">
-              <label>Leverage <span class="tooltip" title="Multiplier on your deposit. At 5× leverage with 1000 USDC: you supply 5000 USDC collateral and borrow 4000 USDC. Higher leverage amplifies both yield and liquidation risk. Health Factor = c_factor × leverage / (leverage − 1).">?</span></label>
-              <div class="slider-row">
-                <input type="range" id="leverage-slider" min="1.1" max="12.9" step="0.1" value="2.0" class="slider" />
-                <input type="number" id="leverage-input" class="input mono leverage-num-input" min="1.1" max="12.9" step="0.1" value="2.0" />
-                <span class="slider-value-x mono">×</span>
+              <div class="apr-row">
+                <span class="apr-key">BLND emissions</span>
+                <span class="apr-val apr-blnd" id="borrow-blnd-apr">—</span>
               </div>
-              <div class="leverage-preview">
-                <div class="preview-row">
-                  <span>Leverage</span><strong id="prev-lev">—</strong>
+              <div class="apr-row apr-net-row">
+                <span class="apr-key">Net borrow cost</span>
+                <span class="apr-val" id="borrow-net-cost">—</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="two-col">
+
+            <!-- Current position -->
+            <section class="card">
+              <div class="card-header">
+                <h2>Your Position</h2>
+                <button id="refresh-btn" class="btn btn-ghost btn-sm">↻</button>
+              </div>
+              <div class="pool-blnd-row">
+                <span class="metric-label">Pending BLND (pool)</span>
+                <span class="metric-value mono" id="pos-blnd">—</span>
+                <button id="claim-btn" class="btn btn-secondary btn-sm" disabled>Claim all BLND</button>
+              </div>
+              <div id="no-position" class="empty-state">
+                <div class="empty-icon">📭</div>
+                <p>No active position for this asset.</p>
+              </div>
+              <div id="position-data" class="hidden">
+                <div class="position-grid">
+                  <div class="position-metric">
+                    <span class="metric-label">Collateral</span>
+                    <span class="metric-value mono" id="pos-collateral">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Debt</span>
+                    <span class="metric-value mono" id="pos-debt">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Net equity</span>
+                    <span class="metric-value mono" id="pos-equity">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Leverage</span>
+                    <span class="metric-value mono" id="pos-leverage">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Asset HF <span class="tooltip" title="Health Factor for this asset only. HF = (collateral × c_factor) / (debt / l_factor). Below 1.0 = liquidatable.">?</span></span>
+                    <span class="metric-value" id="pos-hf">—</span>
+                    <div class="hf-bar-wrap"><div class="hf-bar" id="hf-bar"></div></div>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Pool HF <span class="tooltip" title="Health Factor across ALL your positions in this pool, weighted by oracle price.">?</span></span>
+                    <span class="metric-value" id="pos-pool-hf">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Net APY <span class="tooltip" title="Annual return on your initial deposit (equity). Formula: supplyAPR × leverage − borrowAPR × (leverage − 1). Includes BLND emission value.">?</span></span>
+                    <span class="metric-value" id="pos-net-apr">—</span>
+                  </div>
+                  <div class="position-metric">
+                    <span class="metric-label">Borrow headroom <span class="tooltip" title="How much more USD you could borrow before Health Factor hits 1.0 (liquidation).">?</span></span>
+                    <span class="metric-value mono" id="pos-headroom">—</span>
+                  </div>
+                  <div class="position-metric position-metric-full">
+                    <span class="metric-label">Days until liquidation <span class="tooltip" title="Estimated days before HF drops to 1.0, based on the interest rate spread only (borrow APR − supply APR). Formula: ln(HF) / (borrowAPR − supplyAPR) × 365.">?</span></span>
+                    <span class="metric-value" id="pos-liq-days">—</span>
+                    <div class="liq-days-note" id="pos-liq-note"></div>
+                  </div>
                 </div>
-                <div class="preview-row">
-                  <span>Health Factor</span><strong id="prev-hf">—</strong>
-                </div>
-                <div class="preview-row">
-                  <span>Total supply</span><strong id="prev-supply">—</strong>
-                </div>
-                <div class="preview-row">
-                  <span>Total borrow</span><strong id="prev-borrow">—</strong>
-                </div>
-                <div class="preview-row preview-net-apr">
-                  <span>Est. net APR</span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
-                </div>
-                <div class="preview-row">
-                  <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
+                <div class="position-actions">
+                  <button id="repay-btn" class="btn btn-secondary" disabled>Repay Debt</button>
+                  <button id="close-btn" class="btn btn-danger" disabled>Close Position</button>
                 </div>
               </div>
-              <p class="hf-warning hidden" id="hf-warning">⚠ HF too low — liquidation risk. Reduce leverage.</p>
-              <p class="hf-warning hidden" id="liquidity-warning"></p>
-            </div>
-            <button id="open-btn" class="btn btn-primary btn-lg">Open Position</button>
-            <p class="disclaimer">Two transactions: (1) token approve, (2) <code>submit_with_allowance</code>.</p>
-          </section>
+            </section>
 
-        </div><!-- .two-col -->
-      </div><!-- #dashboard -->
+            <!-- Open position -->
+            <section class="card">
+              <div class="card-header">
+                <h2>Open Position</h2>
+              </div>
+              <div class="form-group">
+                <label>Initial deposit</label>
+                <div class="input-wrap">
+                  <input type="number" id="initial-input" class="input mono" placeholder="1000" min="0" step="any" value="1000" />
+                  <button id="max-btn" class="btn btn-ghost btn-sm input-max-btn">Max</button>
+                  <span class="input-suffix" id="asset-symbol-suffix">—</span>
+                </div>
+                <span class="balance-hint">Wallet: <span id="asset-balance">—</span></span>
+              </div>
+              <div class="form-group">
+                <label>Leverage <span class="tooltip" title="Multiplier on your deposit. Higher leverage amplifies both yield and liquidation risk.">?</span></label>
+                <div class="slider-row">
+                  <input type="range" id="leverage-slider" min="1.1" max="12.9" step="0.1" value="2.0" class="slider" />
+                  <input type="number" id="leverage-input" class="input mono leverage-num-input" min="1.1" max="12.9" step="0.1" value="2.0" />
+                  <span class="slider-value-x mono">×</span>
+                </div>
+                <div class="leverage-preview">
+                  <div class="preview-row">
+                    <span>Leverage</span><strong id="prev-lev">—</strong>
+                  </div>
+                  <div class="preview-row">
+                    <span>Health Factor</span><strong id="prev-hf">—</strong>
+                  </div>
+                  <div class="preview-row">
+                    <span>Total supply</span><strong id="prev-supply">—</strong>
+                  </div>
+                  <div class="preview-row">
+                    <span>Total borrow</span><strong id="prev-borrow">—</strong>
+                  </div>
+                  <div class="preview-row preview-net-apr">
+                    <span>Est. net APR</span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
+                  </div>
+                  <div class="preview-row">
+                    <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
+                  </div>
+                </div>
+                <p class="hf-warning hidden" id="hf-warning">⚠ HF too low — liquidation risk. Reduce leverage.</p>
+                <p class="hf-warning hidden" id="liquidity-warning"></p>
+              </div>
+              <button id="open-btn" class="btn btn-primary btn-lg">Open Position</button>
+              <p class="disclaimer">Two transactions: (1) token approve, (2) <code>submit_with_allowance</code>.</p>
+            </section>
 
-      <!-- Toast -->
-      <div id="toast" class="toast hidden">
-        <span id="toast-icon"></span>
-        <span id="toast-msg"></span>
-        <a id="toast-link" class="toast-link hidden" target="_blank" rel="noopener">View →</a>
-      </div>
+          </div><!-- .two-col -->
+        </div><!-- #dashboard -->
 
-    </main>
+        <!-- Toast -->
+        <div id="toast" class="toast hidden">
+          <span id="toast-icon"></span>
+          <span id="toast-msg"></span>
+          <a id="toast-link" class="toast-link hidden" target="_blank" rel="noopener">View →</a>
+        </div>
+
+      </main>
+    </div><!-- .main-wrap -->
   </div>
 
   <script type="module" src="/src/main.ts"></script>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -7,222 +7,274 @@
 :root {
   --mono:     'JetBrains Mono', monospace;
   --sans:     'Inter', sans-serif;
-  --r:        16px;
-  --r-sm:     10px;
-  --glass:    saturate(180%) blur(20px);
-
-  /* Semantic colors (unchanged across themes) */
-  --danger:   #f56565;
-  --success:  #34d399;
-  --warning:  #fbbf24;
+  --r:        20px;
+  --r-sm:     12px;
+  --r-xs:     8px;
+  --glass:    saturate(180%) blur(24px);
+  --sidebar-w: 220px;
+  --danger:   #ef4444;
+  --success:  #22c55e;
+  --warning:  #f59e0b;
   --blnd:     #a78bfa;
 }
 
-/* ── Dark theme (default) ────────────────────────────────────────────────── */
+/* ── Dark theme ──────────────────────────────────────────────────────────── */
 
 :root, [data-theme="dark"] {
-  --bg:           #060b18;
-  --bg-gradient1: rgba(123,143,248,.08);
-  --bg-gradient2: rgba(167,139,250,.04);
-  --surface:      rgba(14, 20, 40, .85);
-  --surface2:     rgba(20, 28, 52, .65);
-  --surface-solid: #0e1428;
-  --border:       rgba(80, 100, 160, .15);
-  --border-h:     rgba(100, 130, 220, .25);
-  --primary:      #7b8ff8;
-  --primary-h:    #9aadff;
-  --primary-glow: rgba(123, 143, 248, .15);
-  --primary-btn-shadow: rgba(123,143,248,.2);
-  --primary-btn-shadow-h: rgba(123,143,248,.35);
-  --primary-grad2: #6366f1;
+  --bg:             #06070d;
+  --bg-gradient1:   rgba(99,102,241,.06);
+  --bg-gradient2:   rgba(139,92,246,.03);
+  --sidebar-bg:     #0c0e18;
+  --sidebar-border: rgba(255,255,255,.04);
+  --surface:        rgba(16,18,30,.9);
+  --surface2:       rgba(22,25,40,.7);
+  --surface-solid:  #10121e;
+  --border:         rgba(255,255,255,.06);
+  --border-h:       rgba(255,255,255,.1);
+  --primary:        #818cf8;
+  --primary-h:      #a5b4fc;
+  --primary-glow:   rgba(129,140,248,.12);
+  --primary-btn-shadow: rgba(99,102,241,.25);
+  --primary-btn-shadow-h: rgba(99,102,241,.4);
+  --primary-grad2:  #6366f1;
   --primary-grad2-h: #818cf8;
-  --text:         #e8ecf4;
-  --text-2:       #8b95ab;
-  --text-3:       #4f5b73;
-  --shadow:       0 8px 32px rgba(0,0,0,.5);
-  --header-bg:    rgba(10, 16, 32, .8);
-  --input-bg:     rgba(14, 20, 40, .6);
-  --metric-bg:    rgba(14, 20, 40, .6);
-  --slider-bg1:   rgba(80,100,160,.3);
-  --slider-bg2:   rgba(123,143,248,.3);
-  --slider-glow:  rgba(123,143,248,.4);
-  --slider-glow-h: rgba(123,143,248,.6);
-  --toast-bg:     rgba(14, 20, 40, .9);
-  --tab-active-bg: rgba(123,143,248,.1);
-  --tab-hover-bg:  rgba(123,143,248,.08);
-  --tab-active-border: rgba(123,143,248,.4);
-  --btn-secondary-bg: rgba(20,28,52,.8);
-  --btn-secondary-bg-h: rgba(40,50,80,.6);
-  --btn-ghost-hover: rgba(123,143,248,.06);
-  --danger-bg:    rgba(245,101,101,.1);
-  --danger-bg-h:  rgba(245,101,101,.18);
-  --danger-border: rgba(245,101,101,.25);
-  --danger-border-h: rgba(245,101,101,.4);
-  --warning-bg:   rgba(251,191,36,.06);
-  --warning-border: rgba(251,191,36,.25);
-  --success-border: rgba(52,211,153,.5);
-  --tooltip-bg:   rgba(80,100,160,.25);
-  --tooltip-hover: rgba(123,143,248,.3);
-  --hf-bar-bg:    rgba(80,100,160,.2);
-  --expert-hover-bg: rgba(251,191,36,.06);
-  --expert-active-bg: rgba(251,191,36,.12);
-  --expert-border: rgba(251,191,36,.4);
-  --expert-active-border: rgba(251,191,36,.5);
-  --spinner-ring: rgba(255,255,255,.2);
-  --spinner-top:  #fff;
+  --text:           #f1f3f9;
+  --text-2:         #7c8296;
+  --text-3:         #454b5e;
+  --shadow:         0 8px 40px rgba(0,0,0,.4);
+  --header-bg:      rgba(12,14,24,.85);
+  --input-bg:       rgba(12,14,24,.6);
+  --metric-bg:      rgba(12,14,24,.5);
+  --slider-bg:      rgba(255,255,255,.06);
+  --slider-glow:    rgba(129,140,248,.4);
+  --slider-glow-h:  rgba(129,140,248,.7);
+  --toast-bg:       rgba(16,18,30,.95);
+  --tab-hover-bg:   rgba(129,140,248,.06);
+  --tab-active-bg:  rgba(129,140,248,.1);
+  --tab-active-border: rgba(129,140,248,.3);
+  --btn-secondary-bg: rgba(22,25,40,.8);
+  --btn-secondary-bg-h: rgba(40,44,66,.7);
+  --btn-ghost-hover: rgba(129,140,248,.06);
+  --danger-bg:      rgba(239,68,68,.08);
+  --danger-bg-h:    rgba(239,68,68,.15);
+  --danger-border:  rgba(239,68,68,.2);
+  --danger-border-h:rgba(239,68,68,.35);
+  --warning-bg:     rgba(245,158,11,.05);
+  --warning-border: rgba(245,158,11,.2);
+  --success-border: rgba(34,197,94,.4);
+  --tooltip-bg:     rgba(255,255,255,.06);
+  --tooltip-hover:  rgba(129,140,248,.15);
+  --hf-bar-bg:      rgba(255,255,255,.06);
+  --expert-hover-bg:rgba(245,158,11,.06);
+  --expert-active-bg:rgba(245,158,11,.1);
+  --expert-border:  rgba(245,158,11,.3);
+  --expert-active-border: rgba(245,158,11,.5);
+  --spinner-ring:   rgba(255,255,255,.15);
+  --spinner-top:    #fff;
   --asset-active-color: #fff;
+  --stat-card-bg:   rgba(16,18,30,.7);
+  --apr-card-bg:    rgba(16,18,30,.6);
   color-scheme: dark;
 }
 
 /* ── Light theme ─────────────────────────────────────────────────────────── */
 
 [data-theme="light"] {
-  --bg:           #f0f2f7;
-  --bg-gradient1: rgba(123,143,248,.06);
-  --bg-gradient2: rgba(167,139,250,.03);
-  --surface:      rgba(255, 255, 255, .85);
-  --surface2:     rgba(240, 243, 250, .8);
-  --surface-solid: #ffffff;
-  --border:       rgba(60, 75, 110, .12);
-  --border-h:     rgba(60, 75, 110, .22);
-  --primary:      #5b6ef0;
-  --primary-h:    #4a5ce0;
-  --primary-glow: rgba(91, 110, 240, .12);
-  --primary-btn-shadow: rgba(91,110,240,.2);
-  --primary-btn-shadow-h: rgba(91,110,240,.3);
-  --primary-grad2: #4f46e5;
+  --bg:             #f4f5f9;
+  --bg-gradient1:   rgba(99,102,241,.04);
+  --bg-gradient2:   rgba(139,92,246,.02);
+  --sidebar-bg:     #ffffff;
+  --sidebar-border: rgba(0,0,0,.06);
+  --surface:        rgba(255,255,255,.92);
+  --surface2:       rgba(244,245,249,.9);
+  --surface-solid:  #ffffff;
+  --border:         rgba(0,0,0,.06);
+  --border-h:       rgba(0,0,0,.1);
+  --primary:        #6366f1;
+  --primary-h:      #4f46e5;
+  --primary-glow:   rgba(99,102,241,.1);
+  --primary-btn-shadow: rgba(99,102,241,.2);
+  --primary-btn-shadow-h: rgba(99,102,241,.35);
+  --primary-grad2:  #4f46e5;
   --primary-grad2-h: #6366f1;
-  --text:         #1a1f36;
-  --text-2:       #5a6178;
-  --text-3:       #8a91a8;
-  --shadow:       0 8px 32px rgba(0,0,0,.08);
-  --header-bg:    rgba(255, 255, 255, .85);
-  --input-bg:     rgba(240, 243, 250, .8);
-  --metric-bg:    rgba(240, 243, 250, .7);
-  --slider-bg1:   rgba(60,75,110,.12);
-  --slider-bg2:   rgba(91,110,240,.2);
-  --slider-glow:  rgba(91,110,240,.3);
-  --slider-glow-h: rgba(91,110,240,.5);
-  --toast-bg:     rgba(255, 255, 255, .95);
-  --tab-active-bg: rgba(91,110,240,.08);
-  --tab-hover-bg:  rgba(91,110,240,.05);
-  --tab-active-border: rgba(91,110,240,.35);
-  --btn-secondary-bg: rgba(240,243,250,.9);
-  --btn-secondary-bg-h: rgba(220,225,240,.9);
-  --btn-ghost-hover: rgba(91,110,240,.06);
-  --danger-bg:    rgba(245,101,101,.08);
-  --danger-bg-h:  rgba(245,101,101,.14);
-  --danger-border: rgba(245,101,101,.2);
-  --danger-border-h: rgba(245,101,101,.35);
-  --warning-bg:   rgba(217,160,0,.06);
-  --warning-border: rgba(217,160,0,.2);
-  --success-border: rgba(16,185,129,.4);
-  --tooltip-bg:   rgba(60,75,110,.12);
-  --tooltip-hover: rgba(91,110,240,.18);
-  --hf-bar-bg:    rgba(60,75,110,.12);
-  --expert-hover-bg: rgba(217,160,0,.06);
-  --expert-active-bg: rgba(217,160,0,.1);
-  --expert-border: rgba(217,160,0,.35);
-  --expert-active-border: rgba(217,160,0,.5);
-  --spinner-ring: rgba(0,0,0,.15);
-  --spinner-top:  var(--primary);
+  --text:           #111827;
+  --text-2:         #6b7280;
+  --text-3:         #9ca3af;
+  --shadow:         0 8px 40px rgba(0,0,0,.06);
+  --header-bg:      rgba(255,255,255,.88);
+  --input-bg:       rgba(244,245,249,.8);
+  --metric-bg:      rgba(244,245,249,.7);
+  --slider-bg:      rgba(0,0,0,.06);
+  --slider-glow:    rgba(99,102,241,.3);
+  --slider-glow-h:  rgba(99,102,241,.5);
+  --toast-bg:       rgba(255,255,255,.96);
+  --tab-hover-bg:   rgba(99,102,241,.04);
+  --tab-active-bg:  rgba(99,102,241,.06);
+  --tab-active-border: rgba(99,102,241,.25);
+  --btn-secondary-bg: rgba(244,245,249,.9);
+  --btn-secondary-bg-h: rgba(229,231,235,.9);
+  --btn-ghost-hover:rgba(99,102,241,.04);
+  --danger:         #dc2626;
+  --danger-bg:      rgba(220,38,38,.06);
+  --danger-bg-h:    rgba(220,38,38,.1);
+  --danger-border:  rgba(220,38,38,.15);
+  --danger-border-h:rgba(220,38,38,.3);
+  --success:        #16a34a;
+  --warning:        #d97706;
+  --blnd:           #7c3aed;
+  --warning-bg:     rgba(217,119,6,.04);
+  --warning-border: rgba(217,119,6,.15);
+  --success-border: rgba(22,163,74,.3);
+  --tooltip-bg:     rgba(0,0,0,.05);
+  --tooltip-hover:  rgba(99,102,241,.1);
+  --hf-bar-bg:      rgba(0,0,0,.06);
+  --expert-hover-bg:rgba(217,119,6,.05);
+  --expert-active-bg:rgba(217,119,6,.08);
+  --expert-border:  rgba(217,119,6,.25);
+  --expert-active-border: rgba(217,119,6,.45);
+  --spinner-ring:   rgba(0,0,0,.1);
+  --spinner-top:    var(--primary);
   --asset-active-color: #fff;
-  --danger:   #dc2626;
-  --success:  #16a34a;
-  --warning:  #d97706;
-  --blnd:     #7c3aed;
+  --stat-card-bg:   rgba(255,255,255,.8);
+  --apr-card-bg:    rgba(255,255,255,.75);
   color-scheme: light;
 }
 
-/* ── Base styles ─────────────────────────────────────────────────────────── */
+/* ── Base ────────────────────────────────────────────────────────────────── */
 
-html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--sans); font-size: 15px; line-height: 1.6; }
-
-body {
-  background-image:
-    radial-gradient(ellipse 80% 50% at 50% -20%, var(--bg-gradient1), transparent),
-    radial-gradient(circle at 80% 80%, var(--bg-gradient2), transparent);
+html, body {
+  height: 100%; background: var(--bg); color: var(--text);
+  font-family: var(--sans); font-size: 14px; line-height: 1.6;
   transition: background-color .3s, color .3s;
 }
+body {
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, var(--bg-gradient1), transparent),
+    radial-gradient(circle at 90% 80%, var(--bg-gradient2), transparent);
+}
 
-/* ── Layout ──────────────────────────────────────────────────────────────── */
+/* ── App layout: sidebar + main ──────────────────────────────────────────── */
 
-#app { min-height: 100vh; display: flex; flex-direction: column; }
+#app { display: flex; min-height: 100vh; }
+
+/* ── Sidebar ─────────────────────────────────────────────────────────────── */
+
+.sidebar {
+  width: var(--sidebar-w); flex-shrink: 0; position: fixed; top: 0; left: 0; bottom: 0;
+  background: var(--sidebar-bg); border-right: 1px solid var(--sidebar-border);
+  display: flex; flex-direction: column; justify-content: space-between;
+  padding: 20px 14px; z-index: 150; transition: background .3s, border-color .3s;
+}
+.sidebar-top { display: flex; flex-direction: column; gap: 28px; }
+.sidebar-nav { display: flex; flex-direction: column; gap: 4px; }
+.sidebar-bottom { display: flex; gap: 8px; }
+.sidebar-btn {
+  flex: 1; padding: 7px 0; border-radius: var(--r-xs); border: 1px solid var(--border);
+  background: transparent; color: var(--text-3); font-size: 12px; font-weight: 500;
+  cursor: pointer; transition: all .2s; font-family: var(--sans);
+}
+.sidebar-btn:hover { color: var(--text-2); border-color: var(--border-h); }
+
+.logo { display: flex; align-items: center; gap: 10px; padding: 0 6px; }
+.logo-icon-img { width: 32px; height: 32px; }
+.logo-text { font-weight: 800; font-size: 18px; letter-spacing: -.5px; }
+.logo-accent { color: var(--primary); }
+
+/* Pool tabs in sidebar */
+.pool-tabs { display: flex; flex-direction: column; gap: 2px; }
+.pool-tab {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px; border-radius: var(--r-xs); border: none;
+  background: transparent; color: var(--text-2); font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: all .15s; text-align: left; font-family: var(--sans);
+}
+.pool-tab:hover { background: var(--tab-hover-bg); color: var(--text); }
+.pool-tab.active {
+  background: var(--tab-active-bg); color: var(--primary); font-weight: 600;
+  box-shadow: inset 3px 0 0 var(--primary);
+}
+.pool-tab-frozen { color: var(--warning) !important; }
+.pool-tab-frozen.active { box-shadow: inset 3px 0 0 var(--warning); color: var(--warning) !important; }
+
+/* ── Main wrap ───────────────────────────────────────────────────────────── */
+
+.main-wrap { flex: 1; margin-left: var(--sidebar-w); display: flex; flex-direction: column; min-height: 100vh; }
 
 header {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 0 28px; height: 62px;
-  background: var(--header-bg);
-  backdrop-filter: var(--glass); -webkit-backdrop-filter: var(--glass);
+  padding: 0 28px; height: 60px;
+  background: var(--header-bg); backdrop-filter: var(--glass); -webkit-backdrop-filter: var(--glass);
   border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 100;
-  transition: background .3s, border-color .3s;
+  position: sticky; top: 0; z-index: 100; transition: background .3s, border-color .3s;
 }
-.header-left { display: flex; align-items: center; gap: 16px; }
-.logo { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 17px; letter-spacing: -.2px; }
-.logo-icon-img { width: 30px; height: 30px; }
-.connect-prompt-logo { width: 88px; height: 88px; margin-bottom: 16px; }
-.pool-badge {
-  display: flex; align-items: center; gap: 5px; padding: 4px 12px;
-  border-radius: 20px; background: var(--surface2); backdrop-filter: var(--glass);
-  border: 1px solid var(--border); font-size: 12px;
-}
-.badge-label { color: var(--text-3); }
-.badge-value { color: var(--text-2); font-weight: 500; }
+.header-left { display: flex; align-items: center; gap: 6px; }
 
-/* Theme toggle */
-.theme-toggle {
-  font-size: 16px; width: 32px; height: 32px;
-  border: 1px solid var(--border); border-radius: 50%;
-  background: transparent; color: var(--text-2); cursor: pointer;
-  display: inline-flex; align-items: center; justify-content: center;
-  transition: all .25s; line-height: 1;
-}
-.theme-toggle:hover { border-color: var(--border-h); color: var(--text); background: var(--btn-ghost-hover); }
-
-.expert-toggle {
-  font-size: 11px; color: var(--text-3); border: 1px solid var(--border);
-  border-radius: 20px; padding: 3px 12px; transition: all .25s;
-  background: transparent; cursor: pointer;
-}
-.expert-toggle:hover { color: var(--warning); border-color: var(--expert-border); background: var(--expert-hover-bg); }
-.expert-toggle.expert-active { color: var(--warning); border-color: var(--expert-active-border); background: var(--expert-active-bg); }
-
-#wallet-area { display: flex; align-items: center; gap: 10px; }
-.wallet-connected { display: flex; align-items: center; gap: 10px; }
-.wallet-info {
-  display: flex; align-items: center; gap: 7px; padding: 6px 14px;
-  border-radius: 20px; background: var(--surface2); border: 1px solid var(--border);
-  backdrop-filter: var(--glass);
-}
-.wallet-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success); flex-shrink: 0; box-shadow: 0 0 6px var(--success); }
-
-main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20px 60px; }
+main { flex: 1; max-width: 1060px; width: 100%; margin: 0 auto; padding: 24px 28px 60px; }
 
 /* ── Connect prompt ──────────────────────────────────────────────────────── */
 
-.connect-prompt { text-align: center; padding: 100px 20px; color: var(--text-2); }
-.connect-prompt h2 { font-size: 24px; color: var(--text); margin-bottom: 10px; font-weight: 700; letter-spacing: -.3px; }
-.connect-prompt p { margin-bottom: 28px; max-width: 400px; margin-inline: auto; line-height: 1.7; }
+.connect-prompt { text-align: center; padding: 120px 20px; color: var(--text-2); }
+.connect-prompt-logo { width: 96px; height: 96px; margin-bottom: 20px; opacity: .8; }
+.connect-prompt h2 { font-size: 26px; color: var(--text); margin-bottom: 10px; font-weight: 800; letter-spacing: -.4px; }
+.connect-prompt p { margin-bottom: 32px; max-width: 380px; margin-inline: auto; line-height: 1.7; font-size: 15px; }
 
-/* ── Pool tabs ───────────────────────────────────────────────────────────── */
+/* ── Asset tabs (top bar) ────────────────────────────────────────────────── */
 
-.pool-tabs-wrap { margin-bottom: 12px; }
-.pool-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
-.pool-tab {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 9px 22px; border-radius: var(--r-sm); border: 1px solid var(--border);
-  background: var(--surface2); backdrop-filter: var(--glass);
-  color: var(--text-2); font-size: 14px; font-weight: 600;
-  cursor: pointer; transition: all .2s; letter-spacing: .2px;
+.asset-tabs-wrap { margin-bottom: 18px; }
+.asset-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
+.asset-tab {
+  display: flex; align-items: center; gap: 5px;
+  padding: 6px 14px; border-radius: 99px; border: 1px solid transparent;
+  background: transparent; color: var(--text-2); font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: all .15s;
 }
-.pool-tab:hover { background: var(--tab-hover-bg); border-color: var(--border-h); color: var(--text); }
-.pool-tab.active {
-  background: var(--tab-active-bg); border-color: var(--tab-active-border);
-  color: var(--primary); box-shadow: 0 0 20px var(--primary-glow);
+.asset-tab:hover { background: var(--tab-hover-bg); color: var(--text); }
+.asset-tab.active {
+  background: var(--primary); color: var(--asset-active-color);
+  box-shadow: 0 2px 12px var(--primary-btn-shadow);
 }
-.pool-tab-frozen { color: var(--warning) !important; border-color: var(--warning-border) !important; }
-.pool-tab-frozen.active { box-shadow: 0 0 20px var(--warning-bg); border-color: var(--expert-active-border) !important; color: var(--warning) !important; }
+.tab-symbol { font-family: var(--mono); font-weight: 600; font-size: 12px; }
+
+/* ── Stats row ───────────────────────────────────────────────────────────── */
+
+.stats-row {
+  display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-bottom: 16px;
+}
+.stat-card {
+  background: var(--stat-card-bg); backdrop-filter: var(--glass);
+  border: 1px solid var(--border); border-radius: var(--r-sm);
+  padding: 14px 16px; transition: border-color .2s;
+}
+.stat-card:hover { border-color: var(--border-h); }
+.stat-label { display: block; font-size: 11px; color: var(--text-3); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 4px; font-weight: 500; }
+.stat-value { font-size: 17px; font-weight: 700; font-family: var(--mono); display: block; }
+
+/* ── APR grid ────────────────────────────────────────────────────────────── */
+
+.apr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 16px; }
+.apr-card {
+  background: var(--apr-card-bg); backdrop-filter: var(--glass);
+  border: 1px solid var(--border); border-radius: var(--r-sm); padding: 18px 20px;
+}
+.apr-card-label {
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .8px;
+  color: var(--text-3); margin-bottom: 14px;
+}
+.apr-row { display: flex; justify-content: space-between; align-items: center; padding: 4px 0; font-size: 13px; }
+.apr-key { color: var(--text-2); }
+.apr-val { font-family: var(--mono); font-size: 13px; font-weight: 600; }
+.apr-net-row { border-top: 1px solid var(--border); margin-top: 8px; padding-top: 10px; }
+.apr-net-row .apr-key { color: var(--text); font-weight: 600; }
+.apr-net-row .apr-val { font-size: 15px; }
+
+.apr-blnd   { color: var(--blnd); }
+.apr-great  { color: var(--success); }
+.apr-ok     { color: var(--text); }
+.apr-dim    { color: var(--text-2); }
+.apr-warn   { color: var(--warning); }
+.apr-bad    { color: var(--danger); }
+
+/* ── Frozen banner ───────────────────────────────────────────────────────── */
 
 .pool-frozen-banner {
   display: flex; align-items: center; gap: 9px;
@@ -231,117 +283,62 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
   margin-bottom: 14px;
 }
 
-/* ── Asset tabs ──────────────────────────────────────────────────────────── */
-
-.asset-tabs-wrap { margin-bottom: 18px; }
-.asset-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
-.asset-tab {
-  display: flex; align-items: center; gap: 6px;
-  padding: 7px 18px; border-radius: var(--r-sm); border: 1px solid var(--border);
-  background: var(--surface2); color: var(--text-2); font-size: 14px; font-weight: 500;
-  cursor: pointer; transition: all .2s;
-}
-.asset-tab:hover { background: var(--tab-hover-bg); border-color: var(--border-h); color: var(--text); }
-.asset-tab.active {
-  background: linear-gradient(135deg, var(--primary), var(--primary-grad2));
-  border-color: transparent; color: var(--asset-active-color);
-  box-shadow: 0 4px 16px var(--primary-btn-shadow);
-}
-.tab-symbol { font-family: var(--mono); font-weight: 600; }
-
-/* ── Stats bar ───────────────────────────────────────────────────────────── */
-
-.stats-bar {
-  display: flex; background: var(--surface); backdrop-filter: var(--glass);
-  border: 1px solid var(--border); border-radius: var(--r); overflow: hidden; margin-bottom: 16px;
-}
-.stat { flex: 1; padding: 14px 20px; border-right: 1px solid var(--border); }
-.stat:last-child { border-right: none; }
-.stat-label { display: block; font-size: 11px; color: var(--text-3); text-transform: uppercase; letter-spacing: .6px; margin-bottom: 4px; font-weight: 500; }
-.stat-value { font-size: 16px; font-weight: 600; font-family: var(--mono); }
-
-/* ── APR breakdown card ──────────────────────────────────────────────────── */
-
-.apr-card {
-  display: flex; gap: 0; padding: 0; overflow: hidden; margin-bottom: 18px;
-  background: var(--surface); backdrop-filter: var(--glass);
-  border: 1px solid var(--border); border-radius: var(--r);
-}
-.apr-side { flex: 1; padding: 20px 24px; }
-.apr-divider { width: 1px; background: var(--border); flex-shrink: 0; }
-.apr-side-label {
-  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .8px;
-  color: var(--text-3); margin-bottom: 14px;
-}
-.apr-row { display: flex; justify-content: space-between; align-items: center; padding: 5px 0; font-size: 13px; }
-.apr-key { color: var(--text-2); }
-.apr-val { font-family: var(--mono); font-size: 13px; font-weight: 600; }
-.apr-net-row { border-top: 1px solid var(--border); margin-top: 8px; padding-top: 12px; }
-.apr-net-row .apr-key { color: var(--text); font-weight: 600; }
-.apr-net-row .apr-val { font-size: 14px; }
-
-/* APR colour classes */
-.apr-blnd   { color: var(--blnd); }
-.apr-great  { color: var(--success); }
-.apr-ok     { color: var(--text); }
-.apr-dim    { color: var(--text-2); }
-.apr-warn   { color: var(--warning); }
-.apr-bad    { color: var(--danger); }
-
 /* ── Two-column grid ─────────────────────────────────────────────────────── */
 
-.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
 
 /* ── Cards ───────────────────────────────────────────────────────────────── */
 
 .card {
   background: var(--surface); backdrop-filter: var(--glass);
-  border: 1px solid var(--border); border-radius: var(--r); padding: 22px;
+  border: 1px solid var(--border); border-radius: var(--r); padding: 24px;
   transition: border-color .3s, background .3s;
 }
 .card:hover { border-color: var(--border-h); }
 .card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
-.card-header h2 { font-size: 16px; font-weight: 700; letter-spacing: -.2px; }
+.card-header h2 { font-size: 17px; font-weight: 700; letter-spacing: -.2px; }
 
 /* ── Position grid ───────────────────────────────────────────────────────── */
 
-.position-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 18px; }
+.position-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 18px; }
 .position-metric {
   background: var(--metric-bg); border: 1px solid var(--border);
-  border-radius: var(--r-sm); padding: 14px 16px;
-  transition: border-color .2s, background .3s;
+  border-radius: var(--r-xs); padding: 12px 14px; transition: border-color .2s;
 }
 .position-metric:hover { border-color: var(--border-h); }
-.metric-label { display: block; font-size: 11px; color: var(--text-3); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 4px; font-weight: 500; }
-.metric-value { font-size: 16px; font-weight: 600; display: block; }
+.metric-label { display: block; font-size: 10px; color: var(--text-3); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 3px; font-weight: 600; }
+.metric-value { font-size: 15px; font-weight: 700; display: block; }
 .position-metric-full { grid-column: 1 / -1; }
-.liq-days-note { font-size: 11px; color: var(--text-3); margin-top: 5px; line-height: 1.4; }
-.hf-bar-wrap { height: 3px; background: var(--hf-bar-bg); border-radius: 2px; margin-top: 8px; overflow: hidden; }
+.liq-days-note { font-size: 11px; color: var(--text-3); margin-top: 4px; line-height: 1.4; }
+.hf-bar-wrap { height: 3px; background: var(--hf-bar-bg); border-radius: 2px; margin-top: 7px; overflow: hidden; }
 .hf-bar { height: 100%; border-radius: 2px; transition: width .4s, background .4s; }
-.empty-state { color: var(--text-2); font-size: 14px; padding: 10px 0; }
+
+.empty-state { color: var(--text-3); font-size: 14px; padding: 24px 0; text-align: center; }
+.empty-icon { font-size: 36px; margin-bottom: 8px; opacity: .5; }
+
 .position-actions { display: flex; gap: 10px; }
 .pool-blnd-row {
   display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
-  padding: 12px 0 16px; border-bottom: 1px solid var(--border); margin-bottom: 14px;
+  padding: 10px 0 14px; border-bottom: 1px solid var(--border); margin-bottom: 14px;
 }
-.pool-blnd-row .metric-label { color: var(--text-2); font-size: 12px; min-width: 0; }
+.pool-blnd-row .metric-label { color: var(--text-2); font-size: 11px; min-width: 0; }
 .pool-blnd-row .metric-value { font-family: var(--mono); font-size: 14px; margin-right: auto; }
 
 /* ── Open form ───────────────────────────────────────────────────────────── */
 
 .form-group { margin-bottom: 20px; }
-.form-group label { display: block; font-size: 13px; font-weight: 500; color: var(--text-2); margin-bottom: 8px; }
+.form-group label { display: block; font-size: 13px; font-weight: 600; color: var(--text-2); margin-bottom: 8px; }
 .tooltip {
-  display: inline-flex; align-items: center; justify-content: center; width: 15px; height: 15px;
-  border-radius: 50%; background: var(--tooltip-bg); color: var(--text-3); font-size: 10px;
-  cursor: help; margin-left: 4px; transition: background .2s;
+  display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px;
+  border-radius: 50%; background: var(--tooltip-bg); color: var(--text-3); font-size: 9px;
+  cursor: help; margin-left: 3px; transition: background .2s;
 }
 .tooltip:hover { background: var(--tooltip-hover); color: var(--text-2); }
 .input-wrap { position: relative; }
 .input {
-  width: 100%; padding: 11px 16px; padding-right: 100px;
+  width: 100%; padding: 12px 16px; padding-right: 100px;
   background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--r-sm);
-  color: var(--text); font-size: 14px; outline: none; transition: border-color .2s, box-shadow .2s;
+  color: var(--text); font-size: 15px; outline: none; transition: border-color .2s, box-shadow .2s;
 }
 .input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-glow); }
 .input-suffix { position: absolute; right: 14px; top: 50%; transform: translateY(-50%); font-size: 12px; color: var(--text-3); pointer-events: none; font-family: var(--mono); }
@@ -351,26 +348,25 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
 .slider-row { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
 .slider {
   flex: 1; -webkit-appearance: none; height: 4px; border-radius: 2px;
-  background: linear-gradient(90deg, var(--slider-bg1), var(--slider-bg2));
-  cursor: pointer;
+  background: var(--slider-bg); cursor: pointer;
 }
 .slider::-webkit-slider-thumb {
-  -webkit-appearance: none; width: 18px; height: 18px; border-radius: 50%;
+  -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%;
   background: var(--primary); cursor: pointer; transition: all .15s;
-  box-shadow: 0 0 8px var(--slider-glow);
+  box-shadow: 0 0 0 4px var(--slider-glow);
 }
-.slider::-webkit-slider-thumb:hover { background: var(--primary-h); box-shadow: 0 0 12px var(--slider-glow-h); transform: scale(1.1); }
+.slider::-webkit-slider-thumb:hover { background: var(--primary-h); box-shadow: 0 0 0 6px var(--slider-glow-h); }
 .leverage-num-input { width: 72px; padding: 6px 8px; font-size: 15px; text-align: right; padding-right: 4px; }
-.slider-value-x { font-family: var(--mono); font-size: 18px; font-weight: 600; color: var(--text-2); margin-left: -6px; }
+.slider-value-x { font-family: var(--mono); font-size: 18px; font-weight: 700; color: var(--text-3); margin-left: -4px; }
 
 .leverage-preview {
   background: var(--metric-bg); border: 1px solid var(--border); border-radius: var(--r-sm);
-  padding: 14px 16px; display: flex; flex-direction: column; gap: 7px;
+  padding: 14px 16px; display: flex; flex-direction: column; gap: 6px;
 }
 .preview-row { display: flex; justify-content: space-between; align-items: center; font-size: 13px; }
 .preview-row span { color: var(--text-2); }
-.preview-row strong { font-family: var(--mono); color: var(--text); }
-.preview-net-apr { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 10px; }
+.preview-row strong { font-family: var(--mono); color: var(--text); font-weight: 600; }
+.preview-net-apr { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
 .prev-net-apr { font-size: 14px !important; }
 
 .hf-ok   { color: var(--success) !important; }
@@ -381,39 +377,37 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
 
 .hf-warning {
   background: var(--danger-bg); border: 1px solid var(--danger-border);
-  border-radius: var(--r-sm); padding: 10px 14px; font-size: 13px; color: var(--danger); margin-top: 12px;
+  border-radius: var(--r-xs); padding: 10px 14px; font-size: 13px; color: var(--danger); margin-top: 12px;
 }
 .disclaimer { font-size: 12px; color: var(--text-3); margin-top: 12px; }
 
-/* ── Safety guard warnings ─────────────────────────────────────────────── */
-.safety-warnings { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
-.safety-error {
-  background: var(--danger-bg); border: 1px solid var(--danger-border);
-  border-radius: var(--r-sm); padding: 10px 14px; font-size: 13px; color: var(--danger);
-}
-.safety-warn {
-  background: var(--warning-bg); border: 1px solid var(--warning-border);
-  border-radius: var(--r-sm); padding: 10px 14px; font-size: 13px; color: var(--warning);
-}
+/* ── Expert toggle ───────────────────────────────────────────────────────── */
+.expert-toggle:hover { color: var(--warning) !important; border-color: var(--expert-border) !important; background: var(--expert-hover-bg) !important; }
+.expert-toggle.expert-active { color: var(--warning) !important; border-color: var(--expert-active-border) !important; background: var(--expert-active-bg) !important; }
+
+/* Theme toggle in sidebar */
+.theme-toggle { font-size: 15px; line-height: 1; }
 
 /* ── Buttons ──────────────────────────────────────────────────────────────── */
 
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 6px;
-  padding: 9px 18px; border-radius: var(--r-sm); border: none; cursor: pointer;
+  padding: 9px 18px; border-radius: var(--r-xs); border: none; cursor: pointer;
   font-size: 13px; font-weight: 600; font-family: var(--sans);
-  transition: all .2s; white-space: nowrap; outline: none; letter-spacing: .1px;
+  transition: all .2s; white-space: nowrap; outline: none;
 }
 .btn:active:not(:disabled) { transform: scale(.97); }
-.btn:disabled { opacity: .35; cursor: not-allowed; }
+.btn:disabled { opacity: .3; cursor: not-allowed; }
 .btn-primary {
   background: linear-gradient(135deg, var(--primary), var(--primary-grad2));
-  color: #fff; box-shadow: 0 4px 16px var(--primary-btn-shadow);
+  color: #fff; box-shadow: 0 2px 12px var(--primary-btn-shadow);
+  border-radius: 99px;
 }
 .btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--primary-h), var(--primary-grad2-h));
   box-shadow: 0 4px 20px var(--primary-btn-shadow-h);
+  filter: brightness(1.1);
 }
+.btn-connect { padding: 8px 20px; font-size: 13px; }
 .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); border: 1px solid var(--border); }
 .btn-secondary:hover:not(:disabled) { background: var(--btn-secondary-bg-h); border-color: var(--border-h); }
 .btn-danger { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger-border); }
@@ -421,7 +415,7 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
 .btn-ghost { background: transparent; color: var(--text-2); border: 1px solid var(--border); }
 .btn-ghost:hover:not(:disabled) { background: var(--btn-ghost-hover); border-color: var(--border-h); color: var(--text); }
 .btn-sm { padding: 5px 12px; font-size: 12px; }
-.btn-lg { width: 100%; padding: 13px; font-size: 14px; }
+.btn-lg { width: 100%; padding: 14px; font-size: 15px; font-weight: 700; border-radius: var(--r-sm); }
 .btn-loading { position: relative; color: transparent !important; }
 .btn-loading::after {
   content: ''; position: absolute; width: 16px; height: 16px;
@@ -429,6 +423,16 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
   border-radius: 50%; animation: spin .7s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Wallet area ─────────────────────────────────────────────────────────── */
+
+#wallet-area { display: flex; align-items: center; gap: 10px; }
+.wallet-connected { display: flex; align-items: center; gap: 8px; }
+.wallet-info {
+  display: flex; align-items: center; gap: 7px; padding: 6px 14px;
+  border-radius: 99px; background: var(--surface2); border: 1px solid var(--border);
+}
+.wallet-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success); flex-shrink: 0; box-shadow: 0 0 6px var(--success); }
 
 /* ── Toast ────────────────────────────────────────────────────────────────── */
 
@@ -451,14 +455,18 @@ main { flex: 1; max-width: 960px; width: 100%; margin: 0 auto; padding: 24px 20p
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
-@media (max-width: 700px) {
+@media (max-width: 900px) {
+  .sidebar { display: none; }
+  .main-wrap { margin-left: 0; }
   .two-col { grid-template-columns: 1fr; }
-  .stats-bar { flex-wrap: wrap; }
-  .stat { min-width: 50%; border-right: none; border-bottom: 1px solid var(--border); }
-  .stat:last-child { border-bottom: none; }
-  .apr-card { flex-direction: column; }
-  .apr-divider { width: auto; height: 1px; }
+  .stats-row { grid-template-columns: repeat(3, 1fr); }
+  .apr-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 600px) {
+  .stats-row { grid-template-columns: 1fr 1fr; }
   header { padding: 0 14px; }
-  .pool-badge { display: none; }
-  .expert-toggle { display: none; }
+  main { padding: 16px 14px 40px; }
+  .asset-tabs { gap: 2px; }
+  .asset-tab { padding: 5px 10px; font-size: 12px; }
 }


### PR DESCRIPTION
## Summary
- Sidebar navigation with pool tabs (Minswap-style left nav with active accent bar)
- Asset tabs moved to top header bar as pill buttons
- Stats displayed as individual cards in a 5-column grid
- APR breakdown split into two separate cards (Supply / Borrow)
- Empty state with icon for "no position"
- Rounder corners (20px), more spacious cards, pill-shaped buttons
- Better responsive breakpoints (sidebar hides on mobile, stats reflow)
- Full light/dark mode support

## Test plan
- [ ] Switch GitHub Pages source branch to `ui-redesign-v2` to preview live
- [ ] Verify all functionality works: connect wallet, open/close/repay positions
- [ ] Test light and dark mode toggle
- [ ] Test on mobile viewport (sidebar should hide)
- [ ] Compare with current `main` design and decide which to keep

🤖 Generated with [Claude Code](https://claude.com/claude-code)