### PR TITLE
docs: add contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+-
+
+## Related Issue
+
+Closes #
+
+## Checks
+
+-
+
+## Contributor Checklist
+
+- [ ] I read [CONTRIBUTING.md](https://github.com/Dgetsylver/TurboLong/blob/main/CONTRIBUTING.md).
+- [ ] This pull request stays within the linked issue scope.
+- [ ] For Drips issues, I checked for duplicate open pull requests before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Thanks for helping improve TurboLong. This guide keeps issue claims, pull
+requests, and Drips wave work easy to review.
+
+## Branches
+
+Use short, descriptive branch names that include the work area:
+
+- `docs/<topic>` for documentation changes.
+- `fix/<topic>` for bug fixes.
+- `feat/<topic>` for new behavior.
+- `test/<topic>` for test-only changes.
+
+For Drips issues, include the issue number when practical, such as
+`docs/81-contributing-guide`.
+
+## Claiming Drips Issues
+
+Issues labeled `drips` are available in the current Drips wave.
+
+Before starting:
+
+1. Check that no open pull request already addresses the issue.
+2. Comment on the issue with the scope you plan to cover.
+3. Keep the implementation limited to the issue acceptance criteria.
+4. Open a pull request that links the issue with `Closes #<issue-number>`.
+
+If you need to change the scope after starting, leave a short update on the
+issue or pull request so reviewers can follow the decision.
+
+## Pull Request Etiquette
+
+Please keep pull requests focused and reviewable:
+
+- Explain what changed and why.
+- Link the related issue.
+- Include screenshots for visible UI changes.
+- Mention any tests or checks that were run.
+- Call out follow-up work instead of bundling unrelated changes.
+
+Small, complete pull requests are preferred over broad rewrites.
+
+## Commits
+
+Conventional Commits are welcome but not required. If you use them, prefer
+types such as `docs:`, `fix:`, `feat:`, `test:`, and `chore:`.
+
+## Code of Conduct
+
+Be respectful, constructive, and specific in discussions. If a formal code of
+conduct is added later, this section should link to it.
+
+## CLA
+
+No contributor license agreement is currently required. By contributing, you
+confirm that you have the right to submit your work under the repository's
+project terms.


### PR DESCRIPTION
## Summary
- Add a root `CONTRIBUTING.md` with branch naming, PR etiquette, Drips issue claiming, commit guidance, code of conduct expectations, and CLA status.
- Add a pull request template that links contributors back to the guide and includes Drips duplicate-check reminders.

## Acceptance mapping
- File committed at repo root: `CONTRIBUTING.md`
- Referenced from the pull-request template: `.github/pull_request_template.md` now links to the guide
- Drips wave workflow documented: the guide includes issue selection, duplicate checks, claim comments, PR linking, and review expectations
- CLA/code of conduct status covered: documented as not currently present in this repository, with contributor conduct expectations stated directly

## Related Issue
Closes #81

## Checks
- Documentation-only change; no runtime tests were run.
