### PR TITLE
Document Blend leverage loop cap

### DIFF
--- a/contracts/strategies/blend_leverage/README.md
+++ b/contracts/strategies/blend_leverage/README.md
@@ -1,0 +1,21 @@
+# Blend Leverage Strategy
+
+This module contains the Soroban-side helpers for a Blend leverage-loop strategy. A deposit is expanded into an atomic sequence of Blend pool requests:
+
+1. supply the initial asset as collateral,
+2. borrow against the collateral,
+3. re-supply the borrowed amount,
+4. repeat until the configured loop target is reached,
+5. finish with a final supply-only step.
+
+The request sequence is built by `src/leverage.rs` and submitted through `src/blend_pool.rs`.
+
+## Loop Cap
+
+`MAX_LOOP_PAIRS` is set to 20, which produces at most 21 steps: 20 supply/borrow pairs plus one final supply-only step.
+
+The cap is intentional rather than a precision limit. It keeps the request vector, WASM stack usage, and transaction gas bounded when a caller supplies `target_loops`. Without a cap, a large loop target could grow the Blend submit request list until it becomes too expensive or exceeds Soroban execution limits.
+
+The cap also matches the fixed-size arrays used by the test-only `compute_loop_pairs` helper. Production code uses `compute_step` iteratively so it can build bounded request vectors without allocating larger arrays.
+
+If this becomes configurable later, the init argument should still be validated against a conservative upper bound before any request vector is built.

--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -11,7 +11,7 @@ use crate::{
         REQUEST_TYPE_BORROW, REQUEST_TYPE_REPAY, REQUEST_TYPE_SUPPLY_COLLATERAL,
         REQUEST_TYPE_WITHDRAW_COLLATERAL, SCALAR_12,
     },
-    leverage::{compute_step, loop_step_count},
+    leverage::{compute_step, loop_step_count, MAX_LOOP_PAIRS},
     soroswap::internal_swap_exact_tokens_for_tokens,
     storage::Config,
 };
@@ -55,7 +55,7 @@ pub fn submit_leverage_loop(
     let mut balance = initial_amount;
 
     for i in 0..count {
-        let is_final = i == config.target_loops.min(20);
+        let is_final = i == config.target_loops.min(MAX_LOOP_PAIRS);
         let (supply, borrow) = compute_step(balance, config.c_factor, is_final);
         balance = borrow;
 
@@ -327,7 +327,7 @@ pub fn submit_deleverage(
     let mut layers: Vec<i128> = Vec::new(e);
     let mut orig_balance = pre_b; // approximate with total collateral
     for i in 0..count {
-        let is_final = i == config.target_loops.min(20);
+        let is_final = i == config.target_loops.min(MAX_LOOP_PAIRS);
         let (_, borrow) = compute_step(orig_balance, config.c_factor, is_final);
         if borrow > 0 {
             layers.push_back(borrow);

--- a/contracts/strategies/blend_leverage/src/leverage.rs
+++ b/contracts/strategies/blend_leverage/src/leverage.rs
@@ -14,6 +14,13 @@ use soroban_sdk::{panic_with_error, Env};
 // …
 // Loop n-1: supply initial × c^(n-1), borrow initial × c^n
 // Final:    supply initial × c^n      (no borrow)
+//
+// The strategy caps the loop at 20 supply/borrow pairs plus one final
+// supply-only step. This keeps Soroban request growth, WASM stack usage, and
+// transaction gas bounded even if a caller supplies a larger target loop count.
+pub const MAX_LOOP_PAIRS: u32 = 20;
+pub const MAX_LOOP_STEPS: u32 = MAX_LOOP_PAIRS + 1;
+const MAX_LOOP_STEPS_USIZE: usize = MAX_LOOP_STEPS as usize;
 
 /// Compute supply and borrow amount for a single loop step.
 /// Call repeatedly with updated `balance` to build the full loop.
@@ -35,7 +42,7 @@ pub fn compute_step(balance: i128, c_factor: i128, is_final: bool) -> (i128, i12
 /// Total number of steps in a leverage loop (n_loops supply+borrow pairs + 1 final supply).
 #[inline]
 pub fn loop_step_count(n_loops: u32) -> u32 {
-    (n_loops + 1).min(21)
+    (n_loops + 1).min(MAX_LOOP_STEPS)
 }
 
 /// Compute supply and borrow amounts for each loop iteration.
@@ -48,14 +55,15 @@ pub fn compute_loop_pairs(
     initial_amount: i128,
     c_factor: i128,
     n_loops: u32,
-) -> ([i128; 21], [i128; 21], u32) {
-    let mut supplies = [0i128; 21];
-    let mut borrows = [0i128; 21];
+) -> ([i128; MAX_LOOP_STEPS_USIZE], [i128; MAX_LOOP_STEPS_USIZE], u32) {
+    let mut supplies = [0i128; MAX_LOOP_STEPS_USIZE];
+    let mut borrows = [0i128; MAX_LOOP_STEPS_USIZE];
     let count = loop_step_count(n_loops);
+    let capped_loops = n_loops.min(MAX_LOOP_PAIRS);
 
     let mut balance = initial_amount;
     for i in 0..count as usize {
-        let is_final = i as u32 == n_loops.min(20);
+        let is_final = i as u32 == capped_loops;
         let (s, b) = compute_step(balance, c_factor, is_final);
         supplies[i] = s;
         borrows[i] = b;
@@ -72,12 +80,13 @@ pub fn compute_totals(
     n_loops: u32,
 ) -> (i128, i128) {
     let count = loop_step_count(n_loops);
+    let capped_loops = n_loops.min(MAX_LOOP_PAIRS);
     let mut total_supply = 0i128;
     let mut total_borrow = 0i128;
     let mut balance = initial_amount;
 
     for i in 0..count {
-        let is_final = i == n_loops.min(20);
+        let is_final = i == capped_loops;
         let (s, b) = compute_step(balance, c_factor, is_final);
         total_supply = total_supply.checked_add(s).unwrap_or(total_supply);
         total_borrow = total_borrow.checked_add(b).unwrap_or(total_borrow);


### PR DESCRIPTION
Closes #49

## Summary
- Replace the hardcoded 20/21 loop limits with named MAX_LOOP_PAIRS and MAX_LOOP_STEPS constants.
- Reuse the cap constant from Blend pool request construction/deleverage logic so the rationale is tied to the code path.
- Add contracts/strategies/blend_leverage/README.md documenting the 20-pair cap rationale and future parameterization guidance.

## Verification
- cargo test test_loop_pairs_capped_at_20 -- --nocapture with a fresh CARGO_TARGET_DIR passed.
- git diff --check

Note: a first plain cargo test attempt failed before crate compilation due Windows filesystem errors in Cargo build-script output/cache paths. Retrying with a fresh target directory succeeded for the focused cap test.