### PR TITLE
Add BLND price override

### DIFF
--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -367,12 +367,53 @@ async function simulate(op: xdr.Operation): Promise<any> {
 // ── BLND price from CoinGecko ─────────────────────────────────────────────────
 
 let _blndPriceCache: number | null = null;
+let _blndPriceOverride: number | null = null;
+
+export function getBlndPriceOverride(): number | null {
+  return _blndPriceOverride;
+}
+
+export function getCachedBlndPrice(): number | null {
+  return _blndPriceCache;
+}
+
+export function getEffectiveBlndPrice(): number {
+  return _blndPriceOverride ?? _blndPriceCache ?? 0;
+}
+
+export function setBlndPriceOverride(price: number) {
+  _blndPriceOverride = Number.isFinite(price) && price > 0 ? price : null;
+}
+
+export function resetBlndPriceOverride() {
+  _blndPriceOverride = null;
+}
+
+export function applyBlndPriceToReserveStats(rs: ReserveStats, blndPrice = getEffectiveBlndPrice()): ReserveStats {
+  if (typeof rs.supplyEps !== "bigint" || typeof rs.borrowEps !== "bigint") return rs;
+
+  const totalSupplyUsd = rs.totalSupply * rs.priceUsd;
+  const totalBorrowUsd = rs.totalBorrow * rs.priceUsd;
+  const supplyBlndYr = Number(rs.supplyEps) * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
+  const borrowBlndYr = Number(rs.borrowEps) * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
+  const blndSupplyApr = totalSupplyUsd > 0 ? (supplyBlndYr * blndPrice / totalSupplyUsd) * 100 : 0;
+  const blndBorrowApr = totalBorrowUsd > 0 ? (borrowBlndYr * blndPrice / totalBorrowUsd) * 100 : 0;
+
+  return {
+    ...rs,
+    blndSupplyApr,
+    blndBorrowApr,
+    netSupplyApr: rs.interestSupplyApr + blndSupplyApr,
+    netBorrowCost: rs.interestBorrowApr - blndBorrowApr,
+  };
+}
 
 /**
  * Fetch BLND price. Goes straight to CoinGecko since no pool oracle lists BLND.
  * The pool parameter is accepted for API consistency but currently unused.
  */
 export async function fetchBlndPrice(pool: PoolDef, userAddress: string): Promise<number> {
+  if (_blndPriceOverride !== null) return _blndPriceOverride;
   if (_blndPriceCache !== null) return _blndPriceCache;
 
   // CoinGecko free API
@@ -584,6 +625,16 @@ export interface ProjectedRates {
  * @param addBorrow Additional tokens borrowed (user's deposit × (leverage − 1))
  */
 export function projectRates(rs: ReserveStats, addSupply: number, addBorrow: number): ProjectedRates {
+  if (!rs.rateConfig) {
+    return {
+      interestSupplyApr: rs.interestSupplyApr,
+      interestBorrowApr: rs.interestBorrowApr,
+      blndSupplyApr: rs.blndSupplyApr,
+      blndBorrowApr: rs.blndBorrowApr,
+      netSupplyApr: rs.netSupplyApr,
+      netBorrowCost: rs.netBorrowCost,
+    };
+  }
   const { rBase, rOne, rTwo, rThree, utilOpt, irMod, backstopFP } = rs.rateConfig;
   const FIXED_95PCT = 9_500_000;
 
@@ -617,7 +668,7 @@ export function projectRates(rs: ReserveStats, addSupply: number, addBorrow: num
   const projSupplyUsd = projSupply * rs.priceUsd;
   const projBorrowUsd = projBorrow * rs.priceUsd;
 
-  const bp = _blndPriceCache ?? 0;
+  const bp = getEffectiveBlndPrice();
   const blndSupplyApr = projSupplyUsd > 0 ? (supplyBlndYr * bp / projSupplyUsd) * 100 : 0;
   const blndBorrowApr = projBorrowUsd > 0 ? (borrowBlndYr * bp / projBorrowUsd) * 100 : 0;
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,6 +24,11 @@ import {
   getActiveNetwork,
   getHorizonUrl,
   getBlndId,
+  getBlndPriceOverride,
+  getCachedBlndPrice,
+  setBlndPriceOverride,
+  resetBlndPriceOverride,
+  applyBlndPriceToReserveStats,
   setNetwork,
   fetchAllReserves,
   fetchUserPositions,
@@ -817,6 +822,85 @@ function renderAprLine(id: string, val: number, isCost: boolean, isBlnd = false,
 
 // ── Pool-wide health factor ───────────────────────────────────────────────────
 
+const BLND_PRICE_OVERRIDE_KEY = "turbolong_blnd_price_override_usd";
+
+function ensureBlndPriceOverrideControls() {
+  if ($("blnd-price-override")) return;
+  const aprGrid = document.querySelector(".apr-grid");
+  if (!aprGrid) return;
+
+  const panel = document.createElement("div");
+  panel.id = "blnd-price-override";
+  panel.className = "apr-card";
+  panel.style.gridColumn = "1 / -1";
+  panel.innerHTML = `
+    <div class="apr-card-label">BLND price assumption</div>
+    <div class="apr-row">
+      <span class="apr-key">USD price</span>
+      <span id="blnd-price-source" class="apr-val apr-dim">Default</span>
+    </div>
+    <div class="apr-row" style="gap:8px;align-items:center">
+      <input id="blnd-price-input" class="input mono" type="number" min="0" step="0.0001" placeholder="Auto" style="width:120px;text-align:right;padding:6px 8px" />
+      <button id="blnd-price-reset" type="button" class="btn btn-ghost btn-sm">Reset</button>
+    </div>`;
+  aprGrid.insertAdjacentElement("afterend", panel);
+
+  $("blnd-price-input").addEventListener("input", handleBlndPriceInput);
+  $("blnd-price-reset").addEventListener("click", () => {
+    resetBlndPriceOverride();
+    localStorage.removeItem(BLND_PRICE_OVERRIDE_KEY);
+    ($("blnd-price-input") as HTMLInputElement).value = "";
+    applyBlndPriceOverrideToCurrentReserves();
+  });
+}
+
+function refreshBlndPriceOverrideControls() {
+  ensureBlndPriceOverrideControls();
+  const source = $("blnd-price-source");
+  const input = $("blnd-price-input") as HTMLInputElement | null;
+  const override = getBlndPriceOverride();
+  const cached = getCachedBlndPrice();
+  if (input && cached && cached > 0) input.placeholder = fmt(cached, 4);
+  if (!source) return;
+  source.textContent = override && override > 0
+    ? `Override $${fmt(override, 4)}`
+    : cached && cached > 0
+      ? `Default $${fmt(cached, 4)}`
+      : "Default";
+}
+
+function applyBlndPriceOverrideToCurrentReserves() {
+  reserves = reserves.map(rs => applyBlndPriceToReserveStats(rs));
+  refreshBlndPriceOverrideControls();
+  renderSelectedAsset();
+}
+
+function handleBlndPriceInput() {
+  const input = $("blnd-price-input") as HTMLInputElement;
+  const raw = input.value.trim();
+  if (!raw) {
+    resetBlndPriceOverride();
+    localStorage.removeItem(BLND_PRICE_OVERRIDE_KEY);
+    applyBlndPriceOverrideToCurrentReserves();
+    return;
+  }
+  const price = parseFloat(raw);
+  if (!Number.isFinite(price) || price <= 0) return;
+  setBlndPriceOverride(price);
+  localStorage.setItem(BLND_PRICE_OVERRIDE_KEY, String(price));
+  applyBlndPriceOverrideToCurrentReserves();
+}
+
+function initBlndPriceOverride() {
+  ensureBlndPriceOverrideControls();
+  const saved = parseFloat(localStorage.getItem(BLND_PRICE_OVERRIDE_KEY) ?? "");
+  if (Number.isFinite(saved) && saved > 0) {
+    setBlndPriceOverride(saved);
+    ($("blnd-price-input") as HTMLInputElement).value = String(saved);
+  }
+  refreshBlndPriceOverrideControls();
+}
+
 function computePoolHF(): number {
   let weightedCollateral = 0;
   let totalDebt          = 0;
@@ -1321,8 +1405,10 @@ async function loadAll() {
   skeletonIds.forEach(setSkeleton);
 
   try {
-    reserves  = await fetchAllReserves(selectedPool, userAddress);
+    reserves  = (await fetchAllReserves(selectedPool, userAddress))
+      .map(rs => applyBlndPriceToReserveStats(rs));
     positions = await fetchUserPositions(selectedPool, userAddress, reserves);
+    refreshBlndPriceOverrideControls();
 
     // Balance for selected asset
     const bal = await fetchAssetBalance(userAddress, selectedAsset.id);
@@ -2238,7 +2324,8 @@ $("demo-btn").addEventListener("click", () => {
     asset: a, cFactor: a.cFactor, lFactor: 1, interestSupplyApr: 4.2, interestBorrowApr: 6.8,
     blndSupplyApr: 2.1, blndBorrowApr: 1.5, netSupplyApr: 6.3, netBorrowCost: 5.3,
     totalSupply: 1000000, totalBorrow: 650000, available: 350000, priceUsd: 1.0,
-  }));
+  })).map(rs => applyBlndPriceToReserveStats(rs as ReserveStats));
+  refreshBlndPriceOverrideControls();
   positions = { byAsset: new Map() };
   // One sample position
   const sampleAsset = assets[0];
@@ -2259,6 +2346,7 @@ $("demo-btn").addEventListener("click", () => {
 updatePreview();
 renderTxHistory();
 renderPoolFooter();
+initBlndPriceOverride();
 initTooltips();
 
 // ── Overview (cross-protocol dashboard) ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- add BLND price override state in the Blend calculation layer
- make fetched reserve emission APRs and projected APY calculations use the effective override/default BLND price
- add a BLND price assumption control with USD input and reset-to-default button in the APR section
- persist the override locally and refresh displayed APRs immediately when the value changes

## Verification
- npm run build
- npx tsc --noEmit (still fails on existing repo issues: .ts import extension config and wallet auth modal network typing)
- Browser check on http://127.0.0.1:5186/: BLND price panel renders, input accepts 0.2500 and shows Override $0.2500, Reset clears input and returns source to Default

Fixes #37