### PR TITLE
Add landing SEO metadata

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -5,6 +5,44 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Turbolong — Leveraged DeFi on Stellar</title>
   <meta name="description" content="Turbolong lets you open leveraged DeFi positions on Stellar's Blend Protocol. Multi-protocol leverage, vault, and swap — all in one place." />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+  <meta name="theme-color" content="#0B0E14" />
+  <link rel="canonical" href="https://turbolong.com/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Turbolong" />
+  <meta property="og:title" content="Turbolong - Leveraged DeFi on Stellar" />
+  <meta property="og:description" content="Open leveraged Blend positions, manage vault exposure, and route Stellar swaps from one DeFi interface." />
+  <meta property="og:url" content="https://turbolong.com/" />
+  <meta property="og:image" content="https://turbolong.com/scf-thumbnail.png" />
+  <meta property="og:image:alt" content="Turbolong leveraged DeFi dashboard preview" />
+  <meta property="og:locale" content="en_US" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Turbolong - Leveraged DeFi on Stellar" />
+  <meta name="twitter:description" content="Open leveraged Blend positions, manage vault exposure, and route Stellar swaps from one DeFi interface." />
+  <meta name="twitter:image" content="https://turbolong.com/scf-thumbnail.png" />
+  <meta name="twitter:image:alt" content="Turbolong leveraged DeFi dashboard preview" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Turbolong",
+    "url": "https://turbolong.com/",
+    "image": "https://turbolong.com/scf-thumbnail.png",
+    "description": "Turbolong lets you open leveraged DeFi positions on Stellar's Blend Protocol with vault and swap workflows in one web app.",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Web",
+    "browserRequirements": "Requires a modern browser and a Stellar wallet.",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "potentialAction": {
+      "@type": "UseAction",
+      "target": "https://app.turbolong.com"
+    }
+  }
+  </script>
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- add canonical, robots, Open Graph, and Twitter card metadata to the landing page
- add schema.org WebApplication JSON-LD with Turbolong app details and preview image

## Verification
- `node` metadata check confirms required tags exist and JSON-LD parses as WebApplication
- `git diff --check` passes (only existing Windows LF-to-CRLF warning)

Fixes #95