### PR TITLE
Make testnet banner dismissible

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -126,6 +126,7 @@
         <span class="testnet-banner-sep">&middot;</span>
         <span class="testnet-banner-hint">Using Stellar Testnet &mdash; no real funds at risk</span>
         <button id="fund-testnet-btn" class="btn btn-sm testnet-fund-btn" data-tip="Fund with Friendbot XLM, open USDC trustline, swap XLM for USDC">Fund Wallet</button>
+        <button id="testnet-banner-dismiss" class="testnet-banner-dismiss" aria-label="Dismiss testnet banner">&times;</button>
       </div>
 
       <!-- Asset tabs bar (below nav, visible on trade view) -->

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -89,6 +89,13 @@ let positions:   UserPositions   = { byAsset: new Map() };
 let selectedPool: PoolDef        = getKnownPools()[0]; // default: Etherfuse
 let assets: AssetInfo[]          = getPoolAssets(selectedPool);
 let selectedAsset: AssetInfo     = assets[2]; // default: CETES (index 2 in Etherfuse)
+let testnetBannerDismissed = false;
+
+function updateTestnetBanner(resetDismissed = false) {
+  if (resetDismissed) testnetBannerDismissed = false;
+  const isTestnet = getActiveNetwork() === "testnet";
+  $("testnet-banner").classList.toggle("hidden", !isTestnet || testnetBannerDismissed);
+}
 
 // ── Network switching ────────────────────────────────────────────────────────
 
@@ -128,7 +135,7 @@ async function switchNetwork(net: NetworkMode) {
   const btn = $("network-toggle");
   btn.textContent = net === "testnet" ? "Testnet" : "Mainnet";
   btn.classList.toggle("testnet-active", net === "testnet");
-  $("testnet-banner").classList.toggle("hidden", net !== "testnet");
+  updateTestnetBanner(true);
   ($("fund-testnet-btn") as HTMLButtonElement).disabled = false;
   ($("fund-testnet-btn") as HTMLButtonElement).textContent = "Fund Wallet";
 
@@ -1763,6 +1770,8 @@ async function disconnect() {
 
 function switchView(view: AppView) {
   activeView = view;
+  updateTestnetBanner(true);
+
   // Top nav active states
   const overviewBtn = $("proto-overview");
   const blendBtn = $("proto-blend");
@@ -2038,6 +2047,10 @@ $("network-toggle").addEventListener("click", () => {
 
 // Fund testnet wallet
 $("fund-testnet-btn").addEventListener("click", fundTestnetWallet);
+$("testnet-banner-dismiss").addEventListener("click", () => {
+  testnetBannerDismissed = true;
+  updateTestnetBanner();
+});
 
 // Protocol nav (desktop top nav)
 $("proto-overview").addEventListener("click", () => switchView("overview"));
@@ -2724,7 +2737,7 @@ $("vault-rebalance-btn").addEventListener("click", async () => {
     selectedAsset = assets[0];
     $("network-toggle").textContent = "Testnet";
     $("network-toggle").classList.add("testnet-active");
-    $("testnet-banner").classList.remove("hidden");
+    updateTestnetBanner(true);
   }
 
   const saved = localStorage.getItem("walletAddress");

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -667,7 +667,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 /* Testnet banner */
 .testnet-banner {
   display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
-  padding: 6px 24px; background: rgba(255,181,71,.06); border-bottom: 1px solid rgba(255,181,71,.15);
+  padding: 8px 24px; background: rgba(255,181,71,.16); border-bottom: 1px solid rgba(255,181,71,.38);
   font-size: 12px; color: var(--warning); font-weight: 600;
 }
 .testnet-banner-sep { opacity: .4; }
@@ -679,6 +679,13 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .testnet-fund-btn:hover:not(:disabled) {
   background: rgba(255,181,71,.2) !important; border-color: rgba(255,181,71,.5) !important;
 }
+.testnet-banner-dismiss {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border: 1px solid rgba(255,181,71,.35);
+  border-radius: var(--r-xs); background: rgba(255,181,71,.08);
+  color: var(--warning); cursor: pointer; font-size: 18px; line-height: 1;
+}
+.testnet-banner-dismiss:hover { background: rgba(255,181,71,.18); border-color: rgba(255,181,71,.55); }
 
 /* Theme toggle — now in settings dropdown */
 .theme-toggle { font-size: 14px; line-height: 1; }


### PR DESCRIPTION
## Summary
- add a dismiss control to the existing testnet banner
- centralize banner visibility so testnet mode stays visually distinct and hides on mainnet
- reset the session dismissal on app view changes so the banner reappears across routes
- strengthen the banner styling for a clearer yellow testnet warning

## Verification
- `npm run build`
- `git diff --check` passes (only existing Windows LF-to-CRLF warning)
- Browser smoke check: switching Mainnet -> Testnet shows the banner; dismiss hides it; navigating to another view shows it again
- `npx tsc --noEmit` still fails on existing repo issues: .ts import extension config, wallet auth modal network typing, and demo ReserveStats mock shape

Fixes #19