### PR TITLE
Add per-module READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Turbolong
+
+Turbolong is a Stellar DeFi project for opening and managing leveraged Blend positions, a DeFindex-style USDC vault strategy, alerting, and supporting research scripts.
+
+## Module Documentation
+
+- [Frontend app](frontend/README.md)
+- [Alert worker](alerts/README.md)
+- [Contracts](contracts/README.md)
+- [CLI binaries](src/README.md)
+- [Operational scripts](scripts/README.md)
+
+## Additional Docs
+
+- [Blend USDC leverage loop simulation](doc.md)
+- [Profitability analysis](profitability_analysis.md)
+- [UX audit](UX-AUDIT.md)
+- [Blend bug bounty report](BLEND-BUG-BOUNTY-REPORT.md)

--- a/alerts/README.md
+++ b/alerts/README.md
@@ -1,0 +1,34 @@
+# Alerts
+
+## Purpose
+
+This module is a Cloudflare Worker that manages APY alert subscriptions. It verifies subscribers, stores alert preferences in D1, checks Blend reserve rates on a cron schedule, and sends email when a subscribed leverage bracket turns negative.
+
+## How To Run
+
+```bash
+cd alerts
+npm install
+npm run dev
+```
+
+Common maintenance commands:
+
+```bash
+npm run db:create
+npm run db:migrate
+npm run deploy
+```
+
+Configure Worker bindings and secrets in Cloudflare/Wrangler before deploying. `RESEND_API_KEY`, `RESEND_FROM`, `FRONTEND_ORIGIN`, and the D1 binding are required by `src/index.ts`.
+
+## File Map
+
+- `package.json`: Wrangler scripts and TypeScript dependency.
+- `wrangler.toml`: Worker, cron, and D1 binding configuration.
+- `tsconfig.json`: TypeScript compiler settings.
+- `src/index.ts`: routes for subscribe, verify, unsubscribe, and scheduled checks.
+- `src/schema.sql`: D1 schema for alert subscriptions.
+- `src/email.ts`: Resend email templates and sending helpers.
+- `src/stellar.ts`: Blend reserve-rate fetching and APY calculations.
+- `src/xdr.ts`: minimal XDR helpers for Soroban simulation calls.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,29 @@
+# Contracts
+
+## Purpose
+
+This directory contains Soroban smart contracts for Turbolong strategy automation. The current contract package implements a leveraged Blend strategy intended to be managed through DeFindex-style vault flows.
+
+## How To Run
+
+From the strategy package:
+
+```bash
+cd contracts/strategies/blend_leverage
+cargo test
+cargo build --release
+```
+
+For optimized Soroban/WASM builds, use the target and tooling configured in your local Stellar contract environment.
+
+## File Map
+
+- `strategies/blend_leverage/Cargo.toml`: contract package manifest and release profile.
+- `strategies/blend_leverage/src/lib.rs`: contract entry points and module wiring.
+- `strategies/blend_leverage/src/leverage.rs`: leverage-loop strategy logic.
+- `strategies/blend_leverage/src/blend_pool.rs`: Blend pool integration helpers.
+- `strategies/blend_leverage/src/reserves.rs`: reserve accounting helpers.
+- `strategies/blend_leverage/src/soroswap.rs`: Soroswap integration surface.
+- `strategies/blend_leverage/src/storage.rs`: contract storage helpers.
+- `strategies/blend_leverage/src/constants.rs`: shared constants.
+- `strategies/blend_leverage/src/test_*.rs`: unit and integration coverage.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,32 @@
+# Frontend
+
+## Purpose
+
+This module is the Vite/TypeScript browser app for Turbolong. It provides wallet connection, Blend leverage actions, DeFindex vault controls, swaps through Stellar Broker, dashboard views, testnet support, and alert subscription UI.
+
+## How To Run
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Production build and preview:
+
+```bash
+npm run build
+npm run preview
+```
+
+`vite.config.ts` uses `/over_leveraging/` as the base path when `GITHUB_PAGES` is set.
+
+## File Map
+
+- `index.html`: app shell, navigation, modals, and static UI structure.
+- `src/main.ts`: UI state, wallet flows, view rendering, transaction actions, dashboard, swaps, vault UI, and alerts.
+- `src/blend.ts`: Blend pool configuration, reserve fetching, position actions, safety checks, and transaction builders.
+- `src/defindex.ts`: DeFindex vault configuration, stats, balances, and transaction builders.
+- `src/style.css`: theme variables, layout, component styles, responsive behavior, and modal styling.
+- `public/`: static assets served by Vite.
+- `vite.config.ts`: Vite build configuration.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# Scripts
+
+## Purpose
+
+This directory contains TypeScript and Python utilities for inspecting Blend pools, querying oracle state, testing leverage-loop flows, generating landing assets, and executing operational loops.
+
+## How To Run
+
+```bash
+cd scripts
+npm install
+npm run testnet-loop
+```
+
+Run one-off TypeScript scripts with `npx tsx`:
+
+```bash
+npx tsx discover_pools.ts
+npx tsx mainnet_loop.ts --help
+```
+
+Never pass Stellar secret keys directly on the command line. Use the key-file or wallet flow expected by each script.
+
+## File Map
+
+- `package.json`: script dependencies and the `testnet-loop` command.
+- `testnet_loop.ts`: testnet leverage-loop exercise.
+- `mainnet_loop.ts`: mainnet loop workflow and fee/op-count reference logic.
+- `test_strategy.ts`: strategy test harness.
+- `deploy_strategy.ts`: deployment helper for the strategy contract.
+- `discover_pools.ts`: pool discovery helper.
+- `debug_*.ts`: focused debugging helpers for pools and BLND.
+- `get_oracle*.ts`, `oracle_deep*.ts`, `query_oracle.ts`: oracle inspection utilities.
+- `identify_tokens.ts`: token identification helper.
+- `gen_thumbnail.py`: landing/social thumbnail generation script.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,21 @@
+# CLI Binaries
+
+## Purpose
+
+The root Rust crate contains command-line binaries for simulating and executing the USDC leverage-loop strategy against Blend pool state.
+
+## How To Run
+
+From the repository root:
+
+```bash
+cargo run --bin simulate -- --loops 13
+cargo run --bin execute_loop -- --key-file path/to/stellar-secret.txt --dry-run
+```
+
+Use `--dry-run` before any live submission. Secret key files should stay outside source control and must not be pasted into terminal history.
+
+## File Map
+
+- `bin/simulate.rs`: reads live pool state through `stellar-cli` and prints leverage, rate, and health-factor tables.
+- `bin/execute_loop.rs`: builds and submits or dry-runs an atomic Blend `pool.submit()` leverage loop.


### PR DESCRIPTION
## Summary
- add a root README with links to each module README
- document purpose, run commands, and file maps for contracts, alerts, scripts, src, and frontend
- preserve links to the existing deeper reports and analyses from the root docs entry point

## Verification
- checked all requested README paths exist
- checked root README links to all five module READMEs
- `git diff --check`

Fixes #80