### PR TITLE
Add architecture decision records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Turbolong Docs
+
+## Architecture Decision Records
+
+- [ADR index](adr/README.md)

--- a/docs/adr/0001-use-defindex-strategy-pattern.md
+++ b/docs/adr/0001-use-defindex-strategy-pattern.md
@@ -1,0 +1,23 @@
+# 0001: Use The DeFindex Strategy Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+Turbolong needs a vault surface for users who want leveraged exposure without manually operating every loop, rebalance, harvest, and unwind. A custom standalone vault could hold user deposits directly, but that would require Turbolong to own more accounting, share issuance, deposit/withdraw semantics, and strategy lifecycle behavior.
+
+DeFindex already provides a strategy-oriented vault pattern for Soroban. Building around that pattern lets Turbolong focus on the Blend leverage strategy while relying on a familiar vault abstraction for deposits, withdrawals, share accounting, and strategy composition.
+
+## Decision
+
+Turbolong will model automated vault exposure through a DeFindex-style strategy contract. The strategy owns the Blend leveraged position mechanics, while the vault surface represents user deposits and withdrawals through shares.
+
+The frontend will treat the vault as a separate protocol view from direct Blend position management. Contract code will keep leverage-specific logic in the strategy module instead of duplicating vault accounting in the UI.
+
+## Consequences
+
+This keeps the strategy modular and makes future vault integrations easier to reason about. It also gives integrators a clearer boundary: vault shares represent user ownership, while the strategy contract manages Blend collateral, debt, harvest, and rebalance behavior.
+
+The tradeoff is that Turbolong inherits the operational constraints of the DeFindex pattern. Strategy upgrades, share-price reporting, and rebalance permissions must be documented and tested carefully so users understand where vault accounting ends and leveraged-position risk begins.

--- a/docs/adr/0002-cap-leverage-loop-depth.md
+++ b/docs/adr/0002-cap-leverage-loop-depth.md
@@ -1,0 +1,23 @@
+# 0002: Cap Leverage Loop Depth
+
+## Status
+
+Accepted
+
+## Context
+
+Recursive supply can theoretically approach high leverage as collateral is repeatedly supplied and borrowed. With a collateral factor near 0.95, the mathematical limit approaches 20x. In practice, positions near that limit have very thin health-factor margin and become sensitive to interest accrual, utilization spikes, reserve liquidity, and rounding.
+
+The UI and scripts need a concrete upper bound so preview calculations, transaction request vectors, and user expectations remain bounded. Unbounded loops would make it easier to create positions that are technically constructible but operationally fragile.
+
+## Decision
+
+Turbolong will cap leverage-loop depth at 20 internal loop steps. Product surfaces should default users below the theoretical maximum and show health-factor, borrow-headroom, utilization, and liquidation-risk warnings before signing.
+
+The cap is a safety ceiling, not a recommendation. Safe default ranges should remain lower and should be derived from the active pool's collateral factor, liability factor, utilization, and interest-rate curve.
+
+## Consequences
+
+The cap prevents runaway request vectors and keeps simulations predictable. It also creates a clear product invariant for frontend previews, scripts, and strategy code.
+
+The tradeoff is that users cannot express leverage above the cap even if a pool's parameters temporarily appear to allow it. That is acceptable because positions near the theoretical maximum are usually dominated by liquidation and rate risk rather than useful capital efficiency.

--- a/docs/adr/0003-start-with-single-asset-usdc-vault.md
+++ b/docs/adr/0003-start-with-single-asset-usdc-vault.md
@@ -1,0 +1,23 @@
+# 0003: Start With A Single-Asset USDC Vault
+
+## Status
+
+Accepted
+
+## Context
+
+Turbolong can eventually support multiple pools, assets, and vault strategies. Starting with a broad multi-asset vault would increase complexity across deposits, withdrawals, share pricing, oracle handling, risk limits, and rebalance logic.
+
+USDC is the clearest first vault asset because users understand the unit of account, pool accounting is easier to explain, and same-asset recursive lending avoids the extra price-basis risk that appears when collateral and debt are different assets.
+
+## Decision
+
+Turbolong will begin with a single-asset USDC vault strategy. The vault will hold USDC exposure, manage a Blend leveraged USDC position, and report user-facing metrics in USDC terms.
+
+Multi-asset routing, pool selection, and cross-asset vaults will be treated as later features after the single-asset accounting and rebalance behavior are proven.
+
+## Consequences
+
+The first vault is easier to test, document, and monitor. Share price, TVL, debt, collateral, and health factor can be explained in one asset without requiring users to understand cross-asset liquidation mechanics.
+
+The tradeoff is narrower product coverage at launch. Users who want exposure to other assets or cross-asset strategies must use direct Blend flows or wait for later vault versions.

--- a/docs/adr/0004-no-flash-loan-dependency-on-soroban.md
+++ b/docs/adr/0004-no-flash-loan-dependency-on-soroban.md
@@ -1,0 +1,23 @@
+# 0004: Do Not Depend On Flash Loans On Soroban
+
+## Status
+
+Accepted
+
+## Context
+
+On EVM lending markets, some recursive supply, migration, and leverage-management flows use flash loans or flash liquidity to temporarily borrow assets and settle a position change in one transaction. That pattern is powerful but it depends on available flash-loan primitives, liquidity, and route-specific assumptions.
+
+Turbolong is built around Blend request submission on Soroban. The core leverage loop can be expressed as collateralized supply and borrow requests through `pool.submit()` or related Blend calls. It should not assume that uncollateralized flash liquidity exists or that external flash-loan routes are available.
+
+## Decision
+
+Turbolong will not depend on flash loans for core leverage-loop creation, adjustment, or vault rebalance behavior. The product will model loops as collateralized Blend position changes and will reject requests that do not satisfy pool health-factor, utilization, reserve, or allowance constraints.
+
+Documentation and UI copy should avoid presenting Turbolong as a flash-loan product.
+
+## Consequences
+
+This keeps the execution model aligned with the underlying Stellar and Blend primitives. It also makes previews easier to explain: the position has collateral, debt, health factor, and reserve constraints throughout the workflow.
+
+The tradeoff is that some EVM-style one-shot migrations or leverage resizing techniques are out of scope until native, safe, and well-documented Soroban liquidity primitives exist.

--- a/docs/adr/0005-use-wallets-kit-over-freighter-only.md
+++ b/docs/adr/0005-use-wallets-kit-over-freighter-only.md
@@ -1,0 +1,23 @@
+# 0005: Use Stellar Wallets Kit Instead Of Freighter-Only Wallet Support
+
+## Status
+
+Accepted
+
+## Context
+
+Freighter is an important Stellar wallet, but Turbolong is intended for a wider group of Stellar users. Restricting wallet support to a single extension would exclude users who prefer Lobstr, xBull, Albedo, Hana, or other compatible wallets.
+
+The frontend also needs a consistent API for connect, disconnect, account switching, network selection, and transaction signing across mainnet and testnet.
+
+## Decision
+
+Turbolong will use Stellar Wallets Kit as the primary wallet integration layer instead of building a Freighter-only flow. Freighter remains supported through the kit, but it is not the only wallet path.
+
+Wallet-specific behavior should be hidden behind the kit where possible. The app should still verify the selected network and surface clear errors when a wallet cannot sign or is on the wrong network.
+
+## Consequences
+
+This improves wallet reach and reduces future integration work as the wallet ecosystem changes. It also makes the UI less dependent on one provider's extension API.
+
+The tradeoff is another dependency and a need to test across multiple wallet modules. Connection errors, network mismatches, and unsupported wallet capabilities must be handled consistently so broader support does not create ambiguous transaction failures.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+These ADRs use the Michael Nygard template: Status, Context, Decision, and Consequences.
+
+- [0001: Use the DeFindex strategy pattern](0001-use-defindex-strategy-pattern.md)
+- [0002: Cap leverage loop depth](0002-cap-leverage-loop-depth.md)
+- [0003: Start with a single-asset USDC vault](0003-start-with-single-asset-usdc-vault.md)
+- [0004: Do not depend on flash loans on Soroban](0004-no-flash-loan-dependency-on-soroban.md)
+- [0005: Use Stellar Wallets Kit instead of Freighter-only wallet support](0005-use-wallets-kit-over-freighter-only.md)


### PR DESCRIPTION
## Summary
- add five Michael Nygard-style ADRs for the decisions named in the issue
- cover DeFindex strategy pattern, loop cap, single-asset USDC vault, no flash-loan dependency, and Wallets Kit over Freighter-only
- add docs and ADR indexes linking the records

## Verification
- checked ADR count is 5
- checked every ADR is linked from docs/adr/README.md
- checked each ADR includes Status, Context, Decision, and Consequences sections
- checked docs/README.md links to the ADR index
- `git diff --check`

Fixes #83