### PR TITLE
Add yield explainer page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -311,7 +311,7 @@
                 <div class="apr-card">
                   <div class="apr-card-label">Supply</div>
                   <div class="apr-row">
-                    <span class="apr-key">Interest APY</span>
+                    <span class="apr-key">Interest APY <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                     <span class="apr-val" id="supply-interest-apr">—</span>
                   </div>
                   <div class="apr-row">
@@ -319,14 +319,14 @@
                     <span class="apr-val apr-blnd" id="supply-blnd-apr">—</span>
                   </div>
                   <div class="apr-row apr-net-row">
-                    <span class="apr-key">Net supply APY <span class="tooltip" id="supply-net-tip" data-tip="">?</span></span>
+                    <span class="apr-key">Net supply APY <span class="tooltip" id="supply-net-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                     <span class="apr-val" id="supply-net-apr">—</span>
                   </div>
                 </div>
                 <div class="apr-card">
                   <div class="apr-card-label">Borrow</div>
                   <div class="apr-row">
-                    <span class="apr-key">Interest cost</span>
+                    <span class="apr-key">Interest cost APY <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                     <span class="apr-val" id="borrow-interest-apr">—</span>
                   </div>
                   <div class="apr-row">
@@ -334,7 +334,7 @@
                     <span class="apr-val apr-blnd" id="borrow-blnd-apr">—</span>
                   </div>
                   <div class="apr-row apr-net-row">
-                    <span class="apr-key">Net borrow cost <span class="tooltip" id="borrow-net-tip" data-tip="">?</span></span>
+                    <span class="apr-key">Net borrow cost APY <span class="tooltip" id="borrow-net-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                     <span class="apr-val" id="borrow-net-cost">—</span>
                   </div>
                 </div>
@@ -406,6 +406,7 @@
                 </div>
                 <p class="hf-warning hidden" id="non-borrowable-notice"></p>
                 <div id="apy-chart" class="apy-chart"></div>
+                <button type="button" class="yield-link apy-chart-yield-link" data-yield-link>Yield math</button>
                 <div class="leverage-preview">
                   <div class="preview-row">
                     <span>Leverage</span><strong id="prev-lev">—</strong>
@@ -423,7 +424,7 @@
                     <span>Borrow headroom</span><strong id="prev-headroom" class="mono">—</strong>
                   </div>
                   <div class="preview-row preview-net-apr">
-                    <span>Est. net APY <span class="tooltip" id="prev-net-tip" data-tip="">?</span></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
+                    <span>Est. net APY <span class="tooltip" id="prev-net-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
                   </div>
                   <div class="preview-row">
                     <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
@@ -457,7 +458,7 @@
                   <span class="metric-hero-value" id="hero-leverage">—</span>
                 </div>
                 <div class="metric-hero">
-                  <span class="metric-hero-label">Net APY <span class="tooltip" id="hero-net-apy-tip" data-tip="">?</span></span>
+                  <span class="metric-hero-label">Net APY <span class="tooltip" id="hero-net-apy-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                   <span class="metric-hero-value" id="hero-net-apy">—</span>
                 </div>
               </div>
@@ -512,7 +513,7 @@
                     <span class="metric-value" id="pos-pool-hf">—</span>
                   </div>
                   <div class="position-metric">
-                    <span class="metric-label">Net APY <span class="tooltip" id="pos-net-apr-tip" data-tip="">?</span></span>
+                    <span class="metric-label">Net APY <span class="tooltip" id="pos-net-apr-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                     <span class="metric-value" id="pos-net-apr">—</span>
                   </div>
                   <div class="position-metric">
@@ -630,7 +631,7 @@
                   <span class="stat-value mono" id="vault-share-price">--</span>
                 </div>
                 <div class="stat-card">
-                  <span class="stat-label">Net APY <span class="tooltip" id="vault-apy-tip" data-tip="">?</span></span>
+                  <span class="stat-label">Net APY <span class="tooltip" id="vault-apy-tip" data-tip="">?</span> <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                   <span class="stat-value mono" id="vault-apy">--</span>
                 </div>
               </div>
@@ -667,11 +668,11 @@
                   <span class="metric-value mono" id="vault-equity">--</span>
                 </div>
                 <div class="position-metric">
-                  <span class="metric-label">Supply APY</span>
+                  <span class="metric-label">Supply APY <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                   <span class="metric-value mono" id="vault-supply-apr">--</span>
                 </div>
                 <div class="position-metric">
-                  <span class="metric-label">Borrow APY</span>
+                  <span class="metric-label">Borrow APY <button type="button" class="yield-link" data-yield-link>Yield math</button></span>
                   <span class="metric-value mono" id="vault-borrow-apr">--</span>
                 </div>
                 <div class="position-metric">
@@ -758,6 +759,15 @@
 
         <!-- TX Stepper -->
         <div id="tx-stepper" class="tx-stepper hidden" role="status"></div>
+
+        <!-- Yield explainer modal -->
+        <div id="yield-explainer-overlay" class="yield-modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="yield-explainer-title">
+          <div class="yield-modal">
+            <button id="yield-explainer-close" class="yield-modal-close" aria-label="Close yield explainer">&times;</button>
+            <h3 id="yield-explainer-title">Where does the yield come from?</h3>
+            <div id="yield-explainer-body" class="yield-modal-body"></div>
+          </div>
+        </div>
 
         <!-- APY Alert modal -->
         <div id="alert-modal-overlay" class="alert-modal-overlay hidden">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -338,6 +338,143 @@ const fmtAddr = (addr: string) => addr.slice(0, 6) + "…" + addr.slice(-4);
 
 // ── Skeleton loading (#3) ────────────────────────────────────────────────────
 
+type YieldExplainerSnapshot = {
+  rs: ReserveStats;
+  lev: number;
+  equity: number;
+  supply: number;
+  borrow: number;
+  oldSupply: number;
+  oldBorrow: number;
+  proj: ReturnType<typeof projectRates>;
+  netApr: number;
+  netApy: number;
+  spread: number;
+  hf: number;
+  days: number;
+};
+
+function readNumericInput(id: string): number {
+  const input = document.getElementById(id) as HTMLInputElement | null;
+  const val = parseFloat(input?.value ?? "");
+  return Number.isFinite(val) ? val : 0;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, ch => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[ch]!));
+}
+
+function formatSignedPct(value: number): string {
+  return `${value >= 0 ? "+" : ""}${fmt(value, 2)}%`;
+}
+
+function formatYieldDays(days: number): string {
+  if (!Number.isFinite(days)) return "Never from interest spread alone";
+  if (days > 3650) return ">10 years";
+  return `~${Math.round(days)} days`;
+}
+
+function getProjectedRatesForExplainer(
+  rs: ReserveStats,
+  addSupply: number,
+  addBorrow: number,
+): ReturnType<typeof projectRates> {
+  try {
+    return projectRates(rs, addSupply, addBorrow);
+  } catch {
+    return {
+      interestSupplyApr: rs.interestSupplyApr,
+      interestBorrowApr: rs.interestBorrowApr,
+      blndSupplyApr: rs.blndSupplyApr,
+      blndBorrowApr: rs.blndBorrowApr,
+      netSupplyApr: rs.netSupplyApr,
+      netBorrowCost: rs.netBorrowCost,
+    };
+  }
+}
+
+function getYieldExplainerSnapshot(): YieldExplainerSnapshot | null {
+  const rs = reserves.find(r => r.asset.id === selectedAsset.id);
+  if (!rs) return null;
+
+  const lev = readNumericInput("leverage-slider") || 1.0;
+  const pos = positions.byAsset.get(selectedAsset.id);
+  const equity = (actionMode === "adjust" && pos) ? pos.equity
+    : actionMode === "add-funds" ? readNumericInput("add-funds-input")
+    : readNumericInput("initial-input");
+  const supply = equity * lev;
+  const borrow = equity * (lev - 1);
+  const oldSupply = (actionMode === "adjust" && pos) ? pos.collateral : 0;
+  const oldBorrow = (actionMode === "adjust" && pos) ? pos.debt : 0;
+  const proj = getProjectedRatesForExplainer(rs, supply - oldSupply, borrow - oldBorrow);
+  const netApr = proj.netSupplyApr * lev - proj.netBorrowCost * (lev - 1);
+  const netApy = aprToApy(netApr);
+  const spread = proj.interestBorrowApr - proj.interestSupplyApr;
+  const hf = hfForLeverage(lev, rs.cFactor, rs.lFactor);
+  const days = spread > 0 && isFinite(hf) && hf > 1
+    ? Math.log(hf) / (spread / 100) * 365
+    : Infinity;
+
+  return { rs, lev, equity, supply, borrow, oldSupply, oldBorrow, proj, netApr, netApy, spread, hf, days };
+}
+
+function openYieldExplainer() {
+  const snap = getYieldExplainerSnapshot();
+  const body = $("yield-explainer-body");
+  const liveHtml = snap ? `
+    <h4>Live estimate</h4>
+    <div class="yield-live-grid">
+      <div class="yield-live-card"><span class="yield-live-label">Pool / asset</span><span class="yield-live-value">${escapeHtml(selectedPool.name)} / ${escapeHtml(snap.rs.asset.symbol)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Leverage</span><span class="yield-live-value">${snap.lev.toFixed(2)}x</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Equity input</span><span class="yield-live-value">${fmt(snap.equity, 2)} ${escapeHtml(snap.rs.asset.symbol)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Projected supply</span><span class="yield-live-value">${fmt(snap.supply, 2)} ${escapeHtml(snap.rs.asset.symbol)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Projected borrow</span><span class="yield-live-value">${fmt(snap.borrow, 2)} ${escapeHtml(snap.rs.asset.symbol)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Health factor</span><span class="yield-live-value">${isFinite(snap.hf) ? fmt(snap.hf, 4) : "Infinity"}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Net supply APR</span><span class="yield-live-value">${formatSignedPct(snap.proj.netSupplyApr)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Net borrow cost APR</span><span class="yield-live-value">${formatSignedPct(snap.proj.netBorrowCost)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Projected net APR</span><span class="yield-live-value">${formatSignedPct(snap.netApr)}</span></div>
+      <div class="yield-live-card"><span class="yield-live-label">Displayed net APY</span><span class="yield-live-value">${formatSignedPct(snap.netApy)}</span></div>
+    </div>
+    <p>The current preview calls <code>projectRates(rs, supply - oldSupply, borrow - oldBorrow)</code> so adjustments only add the net change to pool totals.</p>
+  ` : `
+    <p>Connect a wallet or open demo mode so the app can load Blend reserve data. The formula below is the same one used by the APY preview once rates are available.</p>
+  `;
+
+  body.innerHTML = `
+    ${liveHtml}
+    <h4>Breakdown</h4>
+    <div class="yield-formula">
+      netSupplyApr = interestSupplyApr + blndSupplyApr<br>
+      netBorrowCost = interestBorrowApr - blndBorrowApr<br>
+      projectedNetApr = (netSupplyApr * leverage) - (netBorrowCost * (leverage - 1))<br>
+      displayedNetApy = (e^(projectedNetApr / 100) - 1) * 100
+    </div>
+    <p>Supply interest is the lending rate. BLND supply emissions are added as a linear APR estimate. Borrow interest is the debt cost, and BLND borrow emissions reduce that displayed cost while emissions remain active.</p>
+    <p>BLND emissions are not automatically compounded by Blend. The app compounds the projected net APR into a displayed APY as a UI approximation, while tooltips keep the underlying net APR visible.</p>
+    <h4>Worst case framing</h4>
+    <ul>
+      <li>Borrow APR can rise quickly when utilization moves through a high-utilization kink.</li>
+      <li>Supply APY and BLND emissions can fall, pause, or end after a position is opened.</li>
+      <li>Higher leverage magnifies any negative spread between supply return and borrow cost.</li>
+      <li>Oracle moves, liquidity changes, contract risk, and transaction timing can make realized outcomes worse than this estimate.</li>
+    </ul>
+    <h4>Liquidation mechanics</h4>
+    <p>Health factor compares weighted collateral with debt. At or below 1.0, the position can be liquidated. The days-to-liquidation estimate uses the interest-only spread of borrow APR minus supply APR and ignores BLND emissions, price-path changes, oracle moves, liquidity, and future rate changes.</p>
+    ${snap ? `<p>Current interest-only liquidation estimate: <strong>${formatYieldDays(snap.days)}</strong> using a spread of ${formatSignedPct(snap.spread)}.</p>` : ""}
+  `;
+  $("yield-explainer-overlay").classList.remove("hidden");
+}
+
+function closeYieldExplainer() {
+  $("yield-explainer-overlay").classList.add("hidden");
+}
+
 function setSkeleton(id: string) {
   const el = $(id);
   el.textContent = "\u00A0\u00A0\u00A0\u00A0\u00A0";
@@ -849,9 +986,10 @@ function renderPortfolioSummary() {
       <span class="portfolio-card-symbol">${pos.asset.symbol}</span>
       <span class="portfolio-card-details">
         <span>${fmt(pos.equity, 2)} equity \u00B7 ${fmt(pos.leverage, 1)}\u00D7</span>
-        <span>APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% \u00B7 HF ${fmt(pos.hf, 2)}</span>
+        <span>APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% <button type="button" class="yield-link yield-link-inline" data-yield-link>Yield math</button> \u00B7 HF ${fmt(pos.hf, 2)}</span>
       </span>`;
-    card.addEventListener("click", () => {
+    card.addEventListener("click", (e) => {
+      if ((e.target as HTMLElement).closest("[data-yield-link]")) return;
       const asset = assets.find(a => a.id === assetId);
       if (asset) selectAsset(asset);
     });
@@ -2366,7 +2504,7 @@ function renderOverview(blendPos: OverviewBlendPosition[], vaultPos: OverviewVau
         <thead><tr>
           <th>Asset</th><th>Pool</th><th class="text-right">Equity</th>
           <th class="text-right">Leverage</th><th class="text-right">HF</th>
-          <th class="text-right">Net APY</th><th class="text-right">Debt</th>
+          <th class="text-right">Net APY <button type="button" class="yield-link yield-link-inline" data-yield-link>Yield math</button></th><th class="text-right">Debt</th>
         </tr></thead><tbody>`;
 
     for (const bp of blendPos) {
@@ -2384,7 +2522,7 @@ function renderOverview(blendPos: OverviewBlendPosition[], vaultPos: OverviewVau
         <td class="text-right">${fmt(bp.pos.equity, 2)} ${bp.asset.symbol}</td>
         <td class="text-right">${fmt(bp.pos.leverage, 1)}&times;</td>
         <td class="text-right ${hfColor}">${isFinite(bp.pos.hf) ? fmt(bp.pos.hf, 3) : "\u221E"}</td>
-        <td class="text-right ${netApy > 0 ? "hf-ok" : "hf-bad"}" title="${batchTip}">${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}%</td>
+        <td class="text-right ${netApy > 0 ? "hf-ok" : "hf-bad"}" title="${batchTip}">${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% <button type="button" class="yield-link yield-link-inline" data-yield-link>Yield math</button></td>
         <td class="text-right">${fmt(bp.pos.debt, 2)} ${bp.asset.symbol}</td>
       </tr>`;
     }
@@ -2426,7 +2564,8 @@ function renderOverview(blendPos: OverviewBlendPosition[], vaultPos: OverviewVau
 
   // Wire up click navigation for Blend table rows
   container.querySelectorAll<HTMLElement>("tr[data-nav-pool]").forEach(row => {
-    row.addEventListener("click", () => {
+    row.addEventListener("click", (e) => {
+      if ((e.target as HTMLElement).closest("[data-yield-link]")) return;
       const poolId = row.dataset.navPool!;
       const assetId = row.dataset.navAsset!;
       const pool = getKnownPools().find(p => p.id === poolId);
@@ -2755,7 +2894,27 @@ document.addEventListener("keydown", (e) => {
     $("pool-dropdown").classList.add("hidden");
     $("settings-dropdown").classList.add("hidden");
     $("alert-modal-overlay").classList.add("hidden");
+    closeYieldExplainer();
     closeDrawer();
+  }
+});
+
+// ── Yield explainer ─────────────────────────────────────────────────────────
+
+document.addEventListener("click", (e) => {
+  const target = e.target as HTMLElement | null;
+  const link = target?.closest("[data-yield-link]");
+  if (!link) return;
+  e.preventDefault();
+  e.stopPropagation();
+  openYieldExplainer();
+});
+
+$("yield-explainer-close").addEventListener("click", closeYieldExplainer);
+
+$("yield-explainer-overlay").addEventListener("click", (e) => {
+  if (e.target === $("yield-explainer-overlay")) {
+    closeYieldExplainer();
   }
 });
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -940,6 +940,56 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 
 /* ── APY Alert modal ─────────────────────────────────────────────────────── */
 
+.yield-link {
+  border: none; background: transparent; color: var(--primary); cursor: pointer;
+  padding: 0; font: inherit; font-size: 11px; font-weight: 600;
+}
+.yield-link:hover { text-decoration: underline; }
+.yield-link-inline { margin-left: 4px; }
+.yield-modal-overlay {
+  position: fixed; inset: 0; z-index: 1000;
+  background: rgba(0,0,0,.7); backdrop-filter: blur(8px);
+  display: flex; align-items: center; justify-content: center;
+  padding: 20px;
+}
+.yield-modal {
+  position: relative; background: var(--surface-solid); border: 1px solid var(--border);
+  border-radius: var(--r); padding: 28px 24px; max-width: 720px; width: min(720px, 100%);
+  max-height: min(760px, 90vh); overflow: auto; box-shadow: var(--shadow);
+}
+.yield-modal-close {
+  position: absolute; top: 12px; right: 14px;
+  background: none; border: none; color: var(--text-2); font-size: 22px;
+  cursor: pointer; line-height: 1; padding: 0;
+}
+.yield-modal-close:hover { color: var(--text); }
+.yield-modal h3 { font-size: 18px; font-weight: 700; margin: 0 0 8px; letter-spacing: -.3px; }
+.yield-modal-body { font-size: 13px; color: var(--text-2); line-height: 1.55; }
+.yield-modal-body h4 { color: var(--text); font-size: 13px; margin: 18px 0 6px; }
+.yield-modal-body p { margin: 0 0 10px; }
+.yield-modal-body ul { margin: 0 0 10px 18px; padding: 0; }
+.yield-modal-body li { margin: 4px 0; }
+.yield-formula {
+  background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--r-xs);
+  padding: 10px 12px; font-family: var(--mono); color: var(--text); font-size: 12px;
+  overflow-x: auto; margin: 8px 0 12px;
+}
+.yield-live-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin: 10px 0 12px;
+}
+.yield-live-card {
+  background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--r-xs);
+  padding: 10px;
+}
+.yield-live-label { display: block; color: var(--text-3); font-size: 11px; margin-bottom: 4px; }
+.yield-live-value { color: var(--text); font-family: var(--mono); font-weight: 700; }
+.apy-chart-yield-link { display: inline-block; margin: -6px 0 10px; }
+
+@media (max-width: 640px) {
+  .yield-live-grid { grid-template-columns: 1fr; }
+  .yield-modal { padding: 24px 18px; }
+}
+
 .alert-bell-btn { font-size: 16px; line-height: 1; }
 .alert-modal-overlay {
   position: fixed; inset: 0; z-index: 1000;


### PR DESCRIPTION
Resolves #25.

## Summary
- adds a yield explainer modal linked from APY figures in the leverage UI, dashboard, portfolio cards, and vault APY labels
- documents the exact projected net APR/APY formula used by projectRates(rs, supply - oldSupply, borrow - oldBorrow)
- includes worst-case framing for high utilization, changing BLND emissions, leverage spread risk, and liquidation mechanics

## Verification
- 
pm run build passes
- 
px tsc --noEmit still fails on existing project-level issues: .ts import extension config, wallet auth modal 
etwork typing, and demo ReserveStats mocks missing full fields
- git diff --check passes
- Browser smoke at http://127.0.0.1:5191/: demo opens, 11 yield links detected, explainer modal opens, required formula/risk/liquidation copy is present, and close button hides the modal