### PR TITLE
Add downside rate stress calculator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -423,11 +423,30 @@
                     <span>Borrow headroom</span><strong id="prev-headroom" class="mono">—</strong>
                   </div>
                   <div class="preview-row preview-net-apr">
-                    <span>Est. net APY <span class="tooltip" id="prev-net-tip" data-tip="">?</span></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
+                    <span>Est. net APY <span class="tooltip" id="prev-net-tip" data-tip="">?</span> <button type="button" id="downside-toggle" class="downside-link">Rate stress</button></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
                   </div>
                   <div class="preview-row">
                     <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
                   </div>
+                </div>
+                <div id="downside-calculator" class="downside-calculator hidden">
+                  <div class="downside-head">
+                    <strong>What if rates move against you?</strong>
+                    <label>Future utilization <input type="number" id="downside-util-input" min="1" max="99.9" step="0.1" value="97" class="input mono downside-input" />%</label>
+                  </div>
+                  <div class="downside-grid">
+                    <div><span>Net APY at scenario</span><strong id="downside-net-apy">—</strong></div>
+                    <div><span>HF decay rate</span><strong id="downside-hf-decay">—</strong></div>
+                    <div><span>Time to liquidation</span><strong id="downside-liq-days">—</strong></div>
+                  </div>
+                  <table class="downside-table">
+                    <thead><tr><th>Scenario</th><th>Util</th><th>Net APY</th><th>HF decay</th><th>Liquidation</th></tr></thead>
+                    <tbody>
+                      <tr><td>Current projection</td><td id="downside-current-util">—</td><td id="downside-current-apy">—</td><td id="downside-current-decay">—</td><td id="downside-current-liq">—</td></tr>
+                      <tr><td>Future utilization</td><td id="downside-target-util">—</td><td id="downside-target-apy">—</td><td id="downside-target-decay">—</td><td id="downside-target-liq">—</td></tr>
+                    </tbody>
+                  </table>
+                  <p class="downside-note">Stress output reruns the live rate model at the selected utilization and keeps your current leverage. Liquidation timing is interest-only and excludes oracle moves, price changes, and BLND reward changes.</p>
                 </div>
                 <p class="hf-warning hidden" id="hf-warning">&#9888; HF too low — liquidation risk. Reduce leverage.</p>
                 <p class="hf-warning hidden" id="liquidity-warning"></p>

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -584,6 +584,17 @@ export interface ProjectedRates {
  * @param addBorrow Additional tokens borrowed (user's deposit × (leverage − 1))
  */
 export function projectRates(rs: ReserveStats, addSupply: number, addBorrow: number): ProjectedRates {
+  if (!rs.rateConfig) {
+    return {
+      interestSupplyApr: rs.interestSupplyApr,
+      interestBorrowApr: rs.interestBorrowApr,
+      blndSupplyApr: rs.blndSupplyApr,
+      blndBorrowApr: rs.blndBorrowApr,
+      netSupplyApr: rs.netSupplyApr,
+      netBorrowCost: rs.netBorrowCost,
+    };
+  }
+
   const { rBase, rOne, rTwo, rThree, utilOpt, irMod, backstopFP } = rs.rateConfig;
   const FIXED_95PCT = 9_500_000;
 
@@ -629,6 +640,21 @@ export function projectRates(rs: ReserveStats, addSupply: number, addBorrow: num
     netSupplyApr:  interestSupplyApr + blndSupplyApr,
     netBorrowCost: interestBorrowApr - blndBorrowApr,
   };
+}
+
+// ── Projected stress helpers ─────────────────────────────────────────────────
+
+export function projectRatesAtUtilization(
+  rs: ReserveStats,
+  targetUtilPct: number,
+  addSupply: number,
+): ProjectedRates {
+  const util = Math.max(0, Math.min(99.9, targetUtilPct)) / 100;
+  const currentSupply = Number.isFinite(rs.totalSupply) ? rs.totalSupply : 0;
+  const currentBorrow = Number.isFinite(rs.totalBorrow) ? rs.totalBorrow : 0;
+  const projectedSupply = Math.max(0, currentSupply + addSupply);
+  const targetBorrow = projectedSupply * util;
+  return projectRates(rs, addSupply, targetBorrow - currentBorrow);
 }
 
 // ── User position ─────────────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,6 +51,7 @@ import {
   type AssetPosition,
   type UserPositions,
   projectRates,
+  projectRatesAtUtilization,
 } from "./blend.ts";
 
 import {
@@ -1167,6 +1168,79 @@ function switchAdjustSubTab(sub: "leverage" | "add-funds") {
 
 // ── Leverage preview ──────────────────────────────────────────────────────────
 
+function clampStressUtil(value: number): number {
+  return Math.max(1, Math.min(99.9, value));
+}
+
+function stressDaysToLiquidation(hf: number, spreadPct: number): number {
+  return spreadPct > 0 && isFinite(hf) && hf > 1
+    ? Math.log(hf) / (spreadPct / 100) * 365
+    : Infinity;
+}
+
+function formatStressDays(days: number): string {
+  if (!isFinite(days)) return "Never";
+  return days > 3650 ? ">10y" : `~${Math.round(days)}d`;
+}
+
+function stressDayClass(days: number): string {
+  if (!isFinite(days)) return "hf-ok";
+  return days < 30 ? "hf-bad" : days < 90 ? "hf-warn" : "hf-ok";
+}
+
+function setStressValue(id: string, text: string, className = "") {
+  const el = $(id);
+  el.textContent = text;
+  el.className = className;
+}
+
+function updateDownsideCalculator(
+  rs: ReserveStats,
+  lev: number,
+  equity: number,
+  oldSupply: number,
+  oldBorrow: number,
+  hf: number,
+  currentProj: ReturnType<typeof projectRates>,
+) {
+  const targetInput = $("downside-util-input") as HTMLInputElement;
+  const rawTarget = parseFloat(targetInput.value);
+  const targetUtil = clampStressUtil(isFinite(rawTarget) ? rawTarget : 97);
+  const supplyDelta = equity * lev - oldSupply;
+  const borrowDelta = equity * (lev - 1) - oldBorrow;
+  const baseSupply = Number.isFinite(rs.totalSupply) ? rs.totalSupply : 0;
+  const baseBorrow = Number.isFinite(rs.totalBorrow) ? rs.totalBorrow : 0;
+  const projectedSupply = Math.max(0, baseSupply + supplyDelta);
+  const projectedBorrow = Math.max(0, baseBorrow + borrowDelta);
+  const currentUtil = projectedSupply > 0 ? (projectedBorrow / projectedSupply) * 100 : 0;
+  const targetProj = projectRatesAtUtilization(rs, targetUtil, supplyDelta);
+
+  const currentNetApr = currentProj.netSupplyApr * lev - currentProj.netBorrowCost * (lev - 1);
+  const targetNetApr = targetProj.netSupplyApr * lev - targetProj.netBorrowCost * (lev - 1);
+  const currentNetApy = aprToApy(currentNetApr);
+  const targetNetApy = aprToApy(targetNetApr);
+  const currentSpread = currentProj.interestBorrowApr - currentProj.interestSupplyApr;
+  const targetSpread = targetProj.interestBorrowApr - targetProj.interestSupplyApr;
+  const currentDays = stressDaysToLiquidation(hf, currentSpread);
+  const targetDays = stressDaysToLiquidation(hf, targetSpread);
+  const targetDecay = targetSpread / 365;
+  const currentDecay = currentSpread / 365;
+
+  setStressValue("downside-net-apy", `${targetNetApy >= 0 ? "+" : ""}${fmt(targetNetApy, 2)}%`, targetNetApy >= 0 ? "hf-ok" : "hf-bad");
+  setStressValue("downside-hf-decay", `${targetDecay >= 0 ? "+" : ""}${fmt(targetDecay, 4)}%/day`, targetDecay > 0.02 ? "hf-bad" : targetDecay > 0.005 ? "hf-warn" : "hf-ok");
+  setStressValue("downside-liq-days", formatStressDays(targetDays), stressDayClass(targetDays));
+
+  setStressValue("downside-current-util", `${fmt(currentUtil, 1)}%`);
+  setStressValue("downside-current-apy", `${currentNetApy >= 0 ? "+" : ""}${fmt(currentNetApy, 2)}%`, currentNetApy >= 0 ? "hf-ok" : "hf-bad");
+  setStressValue("downside-current-decay", `${currentDecay >= 0 ? "+" : ""}${fmt(currentDecay, 4)}%/day`, currentDecay > 0.02 ? "hf-bad" : currentDecay > 0.005 ? "hf-warn" : "hf-ok");
+  setStressValue("downside-current-liq", formatStressDays(currentDays), stressDayClass(currentDays));
+
+  setStressValue("downside-target-util", `${fmt(targetUtil, 1)}%`);
+  setStressValue("downside-target-apy", `${targetNetApy >= 0 ? "+" : ""}${fmt(targetNetApy, 2)}%`, targetNetApy >= 0 ? "hf-ok" : "hf-bad");
+  setStressValue("downside-target-decay", `${targetDecay >= 0 ? "+" : ""}${fmt(targetDecay, 4)}%/day`, targetDecay > 0.02 ? "hf-bad" : targetDecay > 0.005 ? "hf-warn" : "hf-ok");
+  setStressValue("downside-target-liq", formatStressDays(targetDays), stressDayClass(targetDays));
+}
+
 function updatePreview() {
   const slider = $("leverage-slider") as HTMLInputElement;
   const numIn  = $("leverage-input")  as HTMLInputElement;
@@ -1233,6 +1307,8 @@ function updatePreview() {
       prevLiqEl.textContent = "\u2014";
       prevLiqEl.className   = "";
     }
+
+    updateDownsideCalculator(rs, lev, equity, oldSupply, oldBorrow, hf, proj);
 
     // APY chart (#14)
     renderApyChart(rs, lev, equity, oldSupply, oldBorrow);
@@ -2224,6 +2300,16 @@ async function refreshAddFundsBalance() {
 });
 ($("initial-input")   as HTMLInputElement).addEventListener("input",  () => { refreshTabData(); updatePreview(); });
 ($("initial-input")   as HTMLInputElement).addEventListener("change", () => { refreshTabData(); updatePreview(); });
+$("downside-toggle").addEventListener("click", () => {
+  $("downside-calculator").classList.toggle("hidden");
+  updatePreview();
+});
+($("downside-util-input") as HTMLInputElement).addEventListener("input", updatePreview);
+($("downside-util-input") as HTMLInputElement).addEventListener("change", () => {
+  const input = $("downside-util-input") as HTMLInputElement;
+  input.value = clampStressUtil(parseFloat(input.value) || 97).toFixed(1);
+  updatePreview();
+});
 
 // ── Demo mode (#17) ──────────────────────────────────────────────────────────
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -639,6 +639,35 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .preview-row strong { font-family: var(--mono); color: var(--text); font-weight: 600; }
 .preview-net-apr { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
 .prev-net-apr { font-size: 16px !important; font-weight: 700 !important; }
+.downside-link {
+  border: none; background: transparent; color: var(--primary); cursor: pointer;
+  padding: 0; font: inherit; font-size: 11px; font-weight: 700;
+}
+.downside-link:hover { text-decoration: underline; }
+.downside-calculator {
+  margin-top: 10px; border: 1px solid var(--border); border-radius: var(--r);
+  background: var(--surface); padding: 12px; font-size: 12px;
+}
+.downside-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  margin-bottom: 10px; color: var(--text);
+}
+.downside-head label { display: flex; align-items: center; gap: 5px; color: var(--text-2); font-size: 11px; }
+.downside-input { width: 72px; padding: 5px 7px; text-align: right; }
+.downside-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 10px;
+}
+.downside-grid div {
+  background: var(--metric-bg); border: 1px solid var(--border); border-radius: var(--r-xs);
+  padding: 8px;
+}
+.downside-grid span { display: block; color: var(--text-3); font-size: 10px; margin-bottom: 3px; }
+.downside-grid strong { font-family: var(--mono); color: var(--text); font-size: 13px; }
+.downside-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.downside-table th, .downside-table td { text-align: right; padding: 5px 4px; border-top: 1px solid var(--border); }
+.downside-table th:first-child, .downside-table td:first-child { text-align: left; color: var(--text-2); }
+.downside-table th { color: var(--text-3); font-weight: 700; }
+.downside-note { color: var(--text-3); line-height: 1.45; margin: 8px 0 0; }
 
 .hf-ok   { color: var(--success) !important; }
 .hf-warn { color: var(--warning) !important; }
@@ -1177,6 +1206,9 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   .toast { max-width: 100%; }
   .tx-stepper { left: 12px; right: 12px; transform: none; }
   .portfolio-summary { flex-wrap: wrap; }
+  .downside-head { align-items: flex-start; flex-direction: column; }
+  .downside-grid { grid-template-columns: 1fr; }
+  .downside-table { font-size: 10px; }
   .landing-hero { padding: 50px 16px 40px; }
   .landing-hero h1 { font-size: 28px; }
   .landing-stats { gap: 20px; }


### PR DESCRIPTION
Resolves #26.

## Summary
- adds a trade-view Rate stress panel next to the estimated net APY display
- lets users enter a future utilization scenario and see stressed net APY, HF decay rate, and interest-only time to liquidation
- adds projectRatesAtUtilization, which derives the target utilization scenario through the existing projectRates rate model

## Verification
- 
pm run build passes
- 
px tsc --noEmit still fails on existing project-level issues: .ts import extension config, wallet auth modal 
etwork typing, and demo ReserveStats mocks missing full fields
- git diff --check passes
- Browser smoke at http://127.0.0.1:5192/: demo opened, Rate stress panel opened, target utilization changed to 99.0%, and target APY/HF decay/liquidation values populated