### PR TITLE
Add one-click unsubscribe headers

### DIFF
--- a/alerts/UNSUBSCRIBE_TESTING.md
+++ b/alerts/UNSUBSCRIBE_TESTING.md
@@ -1,0 +1,25 @@
+# RFC 8058 one-click unsubscribe testing
+
+Turbolong alert emails include both unsubscribe mechanisms required for major email clients:
+
+- `List-Unsubscribe: <https://turbolong-alerts.workers.dev/unsubscribe?token=...>`
+- `List-Unsubscribe-Post: List-Unsubscribe=One-Click`
+
+Verification emails and APY alert emails both include these headers because both are outgoing subscription-related emails.
+
+## Manual email-client test
+
+1. Subscribe to an alert with a mailbox that exposes message headers, such as Gmail or Outlook.
+2. Open the verification email and inspect the raw source.
+3. Confirm both `List-Unsubscribe` and `List-Unsubscribe-Post` are present.
+4. Verify that the `List-Unsubscribe` URL contains the subscription `unsub_token`.
+5. Send a one-click POST request to the URL:
+
+   ```sh
+   curl -i -X POST "https://turbolong-alerts.workers.dev/unsubscribe?token=<token>"
+   ```
+
+6. Expected result: the worker returns `204 No Content` and deletes the subscription.
+7. Repeating the same POST should return `404`, confirming the token was already removed.
+
+The ordinary GET `/unsubscribe?token=...` path remains available for users who click the visible unsubscribe link in the email footer.

--- a/alerts/package-lock.json
+++ b/alerts/package-lock.json
@@ -8,6 +8,7 @@
       "name": "turbolong-alerts",
       "version": "1.0.0",
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260519.1",
         "typescript": "^5.7.3",
         "wrangler": "^3.99.0"
       }
@@ -125,6 +126,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260519.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260519.1.tgz",
+      "integrity": "sha512-BMWAwg4RyyZn3zcdoXbqpfogm2DGfNb83DXNCM1oFUMhYtEX8I+B+oxf67YPKvSiAEbzd7nHzW2mLv3eBH8Etw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/alerts/package.json
+++ b/alerts/package.json
@@ -9,7 +9,8 @@
     "db:migrate": "wrangler d1 execute turbolong-alerts --file=src/schema.sql"
   },
   "devDependencies": {
-    "wrangler": "^3.99.0",
-    "typescript": "^5.7.3"
+    "@cloudflare/workers-types": "^4.20260519.1",
+    "typescript": "^5.7.3",
+    "wrangler": "^3.99.0"
   }
 }

--- a/alerts/src/email.ts
+++ b/alerts/src/email.ts
@@ -12,7 +12,11 @@ interface SendResult {
   error?: string;
 }
 
-async function sendEmail(env: Env, to: string, subject: string, html: string): Promise<SendResult> {
+interface SendOptions {
+  headers?: Record<string, string>;
+}
+
+async function sendEmail(env: Env, to: string, subject: string, html: string, opts: SendOptions = {}): Promise<SendResult> {
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -24,6 +28,7 @@ async function sendEmail(env: Env, to: string, subject: string, html: string): P
       to: [to],
       subject,
       html,
+      ...(opts.headers ? { headers: opts.headers } : {}),
     }),
   });
 
@@ -34,7 +39,14 @@ async function sendEmail(env: Env, to: string, subject: string, html: string): P
   return { ok: true };
 }
 
-export async function sendVerificationEmail(env: Env, to: string, verifyUrl: string): Promise<SendResult> {
+function oneClickUnsubscribeHeaders(unsubscribeUrl: string): Record<string, string> {
+  return {
+    "List-Unsubscribe": `<${unsubscribeUrl}>`,
+    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+  };
+}
+
+export async function sendVerificationEmail(env: Env, to: string, verifyUrl: string, unsubscribeUrl: string): Promise<SendResult> {
   const html = `
 <!DOCTYPE html>
 <html>
@@ -43,11 +55,13 @@ export async function sendVerificationEmail(env: Env, to: string, verifyUrl: str
   <h2 style="margin: 0 0 16px;">Verify your Turbolong alert</h2>
   <p style="line-height: 1.6; color: #555;">Click the button below to verify your email and activate APY alerts.</p>
   <a href="${verifyUrl}" style="display: inline-block; margin: 20px 0; padding: 12px 28px; background: #2DE8A3; color: #0B0E14; text-decoration: none; border-radius: 8px; font-weight: 600;">Verify Subscription</a>
-  <p style="font-size: 13px; color: #888; margin-top: 24px;">If you didn't subscribe, ignore this email.</p>
+  <p style="font-size: 13px; color: #888; margin-top: 24px;">If you didn't subscribe, you can ignore this email or <a href="${unsubscribeUrl}" style="color: #888;">cancel the subscription</a>.</p>
 </body>
 </html>`.trim();
 
-  return sendEmail(env, to, "Verify your Turbolong alert subscription", html);
+  return sendEmail(env, to, "Verify your Turbolong alert subscription", html, {
+    headers: oneClickUnsubscribeHeaders(unsubscribeUrl),
+  });
 }
 
 export async function sendApyAlert(
@@ -98,5 +112,6 @@ export async function sendApyAlert(
     to,
     `\u26A0 Negative APY: ${assetSymbol} at ${leverage}x on ${poolName}`,
     html,
+    { headers: oneClickUnsubscribeHeaders(unsubscribeUrl) },
   );
 }

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -5,6 +5,7 @@
  *   POST /subscribe       — register an alert subscription
  *   GET  /verify?token=   — verify email
  *   GET  /unsubscribe?token= — remove subscription
+ *   POST /unsubscribe?token= — RFC 8058 one-click unsubscribe
  *
  * Cron (every 15 min):
  *   Fetch pool reserve rates, compute APY per bracket, alert subscribers.
@@ -113,11 +114,13 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
   // Send verification email
   const base = workerUrl(request);
   const verifyUrl = `${base}/verify?token=${verifyToken}`;
+  const unsubscribeUrl = `${base}/unsubscribe?token=${unsubToken}`;
 
   const result = await sendVerificationEmail(
     { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
     email,
     verifyUrl,
+    unsubscribeUrl,
   );
 
   if (!result.ok) {
@@ -158,16 +161,22 @@ async function handleVerify(request: Request, env: Env): Promise<Response> {
 async function handleUnsubscribe(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
   const token = url.searchParams.get("token");
+  const oneClick = request.method === "POST";
 
-  if (!token) return htmlResponse("<h2>Missing token.</h2>", 400);
+  if (!token) {
+    return oneClick ? new Response(null, { status: 400 }) : htmlResponse("<h2>Missing token.</h2>", 400);
+  }
 
   const result = await env.DB.prepare(
     "DELETE FROM subscriptions WHERE unsub_token = ?1"
   ).bind(token).run();
 
   if (!result.meta.changes) {
+    if (oneClick) return new Response(null, { status: 404 });
     return htmlResponse("<h2>Subscription not found or already removed.</h2>", 404);
   }
+
+  if (oneClick) return new Response(null, { status: 204 });
 
   return htmlResponse(`
 <!DOCTYPE html>
@@ -276,6 +285,9 @@ export default {
         return handleVerify(request, env);
 
       case "/unsubscribe":
+        if (request.method !== "GET" && request.method !== "POST") {
+          return jsonResponse({ error: "Method not allowed" }, 405, env);
+        }
         return handleUnsubscribe(request, env);
 
       default:


### PR DESCRIPTION
Resolves #67.

## Summary
- adds RFC 8058 List-Unsubscribe and List-Unsubscribe-Post headers to verification and APY alert emails
- adds one-click POST handling on /unsubscribe?token=... with 204 on successful deletion and 404 for already-removed tokens
- documents the manual email-client/source-header test path in lerts/UNSUBSCRIBE_TESTING.md
- adds the missing @cloudflare/workers-types dev dependency already referenced by lerts/tsconfig.json

## Verification
- 
pm ci in lerts: passed
- 
px tsc --noEmit in lerts: reached existing repo issues after worker types installed (.ts import extension config and missing uildInvokeXdr in stellar.ts)
- git diff --check: passed

Resend custom headers reference: https://resend.com/docs/dashboard/emails/custom-headers