### PR TITLE
Clarify APR and APY rate labels

### DIFF
--- a/docs/rate-glossary.md
+++ b/docs/rate-glossary.md
@@ -1,0 +1,35 @@
+# Rate Glossary
+
+Turbolong uses explicit APR/APY labels so users can tell which values compound and which are linear estimates.
+
+## APR
+
+APR is a simple annualized rate. It does not assume compounding.
+
+Turbolong shows these as APR:
+
+- BLND supply emissions
+- BLND borrow emissions
+- interest spread used for liquidation runway estimates
+- tooltip-only "actual net APR" values behind APY displays
+
+BLND emissions are APR because rewards accrue linearly and Blend does not automatically compound them.
+
+## APY
+
+APY is the displayed annual percentage yield after applying the app's compounding approximation:
+
+```text
+displayed APY = (e^(APR / 100) - 1) * 100
+```
+
+Turbolong shows these as APY:
+
+- supply interest APY
+- net supply APY
+- borrow interest cost APY
+- net borrow cost APY
+- estimated net APY on equity
+- portfolio, position, overview, and vault headline rate values
+
+When BLND emissions are combined with interest APY, the emissions side remains a linear APR approximation. Tooltips keep the underlying APR visible where this matters.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -306,7 +306,7 @@
                 </div>
               </div>
 
-              <!-- APR breakdown -->
+              <!-- Rate breakdown -->
               <div class="apr-grid">
                 <div class="apr-card">
                   <div class="apr-card-label">Supply</div>
@@ -315,7 +315,7 @@
                     <span class="apr-val" id="supply-interest-apr">—</span>
                   </div>
                   <div class="apr-row">
-                    <span class="apr-key">BLND emissions <span class="tooltip" data-tip="BLND token rewards distributed by the pool. Shown as APR since emissions are linear and do not auto-compound.">?</span></span>
+                    <span class="apr-key">BLND emissions APR <span class="tooltip" data-tip="BLND token rewards distributed by the pool. Shown as APR since emissions are linear and do not auto-compound.">?</span></span>
                     <span class="apr-val apr-blnd" id="supply-blnd-apr">—</span>
                   </div>
                   <div class="apr-row apr-net-row">
@@ -326,15 +326,15 @@
                 <div class="apr-card">
                   <div class="apr-card-label">Borrow</div>
                   <div class="apr-row">
-                    <span class="apr-key">Interest cost</span>
+                    <span class="apr-key">Interest cost APY</span>
                     <span class="apr-val" id="borrow-interest-apr">—</span>
                   </div>
                   <div class="apr-row">
-                    <span class="apr-key">BLND emissions <span class="tooltip" data-tip="BLND token rewards that offset borrow cost. Shown as APR since emissions are linear and do not auto-compound.">?</span></span>
+                    <span class="apr-key">BLND emissions APR <span class="tooltip" data-tip="BLND token rewards that offset borrow cost. Shown as APR since emissions are linear and do not auto-compound.">?</span></span>
                     <span class="apr-val apr-blnd" id="borrow-blnd-apr">—</span>
                   </div>
                   <div class="apr-row apr-net-row">
-                    <span class="apr-key">Net borrow cost <span class="tooltip" id="borrow-net-tip" data-tip="">?</span></span>
+                    <span class="apr-key">Net borrow cost APY <span class="tooltip" id="borrow-net-tip" data-tip="">?</span></span>
                     <span class="apr-val" id="borrow-net-cost">—</span>
                   </div>
                 </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:rate-conventions": "node --test test/rate-conventions.test.mjs"
   },
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.1",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -849,7 +849,7 @@ function renderPortfolioSummary() {
       <span class="portfolio-card-symbol">${pos.asset.symbol}</span>
       <span class="portfolio-card-details">
         <span>${fmt(pos.equity, 2)} equity \u00B7 ${fmt(pos.leverage, 1)}\u00D7</span>
-        <span>APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% \u00B7 HF ${fmt(pos.hf, 2)}</span>
+        <span>Net APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% \u00B7 HF ${fmt(pos.hf, 2)}</span>
       </span>`;
     card.addEventListener("click", () => {
       const asset = assets.find(a => a.id === assetId);
@@ -1030,7 +1030,7 @@ function renderPosition() {
         liqDaysEl.textContent = daysLeft > 3650 ? ">10 years" : `~${Math.round(daysLeft)} days`;
       }
       liqDaysEl.className   = `metric-value ${daysLeft < 30 ? "hf-bad" : daysLeft < 90 ? "hf-warn" : "hf-ok"}`;
-      liqNoteEl.textContent = `Interest spread: ${fmt(aprToApy(spreadPct), 2)}%/yr (borrow \u2212 supply). Claim & convert BLND to extend runway.`;
+      liqNoteEl.textContent = `Interest spread APR: ${fmt(spreadPct, 2)} percentage points (borrow \u2212 supply). Claim & convert BLND to extend runway.`;
     }
   } else {
     liqDaysEl.textContent = "\u2014";

--- a/frontend/test/rate-conventions.test.mjs
+++ b/frontend/test/rate-conventions.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = resolve(here, "..");
+const repoRoot = resolve(frontendRoot, "..");
+
+async function readRepoFile(...parts) {
+  return readFile(resolve(repoRoot, ...parts), "utf8");
+}
+
+function countMatches(text, pattern) {
+  return [...text.matchAll(pattern)].length;
+}
+
+test("rate labels explicitly distinguish APR and APY", async () => {
+  const indexHtml = await readRepoFile("frontend", "index.html");
+
+  assert.match(indexHtml, /Interest APY/);
+  assert.match(indexHtml, /Net supply APY/);
+  assert.match(indexHtml, /Interest cost APY/);
+  assert.match(indexHtml, /Net borrow cost APY/);
+  assert.equal(countMatches(indexHtml, /BLND emissions APR/g), 2);
+  assert.doesNotMatch(indexHtml, /<span class="apr-key">Interest cost<\/span>/);
+  assert.doesNotMatch(indexHtml, /<span class="apr-key">Net borrow cost <span/);
+});
+
+test("dynamic rate copy uses the selected convention", async () => {
+  const mainTs = await readRepoFile("frontend", "src", "main.ts");
+
+  assert.match(mainTs, /Net APY \$\{netApy >= 0 \? "\+" : ""\}/);
+  assert.match(mainTs, /Interest spread APR:/);
+  assert.match(mainTs, /Approximate APY/);
+  assert.match(mainTs, /Actual net APR/);
+});
+
+test("glossary documents APR and APY behavior", async () => {
+  const glossary = await readRepoFile("docs", "rate-glossary.md");
+
+  assert.match(glossary, /BLND supply emissions/);
+  assert.match(glossary, /BLND emissions are APR/);
+  assert.match(glossary, /displayed APY =/);
+  assert.match(glossary, /estimated net APY on equity/);
+});


### PR DESCRIPTION
Resolves #38.

## Summary
- labels BLND emissions as APR and borrow-cost displays as APY where the UI is compounding/approximating display values
- changes portfolio card copy from generic APY to Net APY
- fixes the liquidation note to report the interest spread as APR percentage points instead of applying APY conversion
- adds docs/rate-glossary.md covering APR vs APY conventions
- adds 
pm run test:rate-conventions to lock the labels and glossary coverage

## Verification
- 
pm run test:rate-conventions: passed
- 
pm run build: passed
- 
px tsc --noEmit: still fails on existing project-level issues: .ts import extension config, wallet auth modal 
etwork typing, and demo ReserveStats mocks missing full fields
- git diff --check: passed
- Browser smoke at http://127.0.0.1:5193/: demo opened and visible labels included Interest APY, BLND emissions APR, Interest cost APY, Net borrow cost APY, and Est. net APY