### PR TITLE
Add subscribe rate limiting

### DIFF
--- a/alerts/package-lock.json
+++ b/alerts/package-lock.json
@@ -8,6 +8,8 @@
       "name": "turbolong-alerts",
       "version": "1.0.0",
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260516.0",
+        "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "wrangler": "^3.99.0"
       }
@@ -126,6 +128,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260519.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260519.1.tgz",
+      "integrity": "sha512-BMWAwg4RyyZn3zcdoXbqpfogm2DGfNb83DXNCM1oFUMhYtEX8I+B+oxf67YPKvSiAEbzd7nHzW2mLv3eBH8Etw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -172,6 +181,23 @@
       },
       "peerDependencies": {
         "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -446,6 +472,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
@@ -463,6 +506,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
@@ -478,6 +538,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1478,6 +1555,441 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/alerts/package.json
+++ b/alerts/package.json
@@ -6,9 +6,12 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "db:create": "wrangler d1 create turbolong-alerts",
-    "db:migrate": "wrangler d1 execute turbolong-alerts --file=src/schema.sql"
+    "db:migrate": "wrangler d1 execute turbolong-alerts --file=src/schema.sql",
+    "test:rate-limit": "tsx --test test/rate-limit.test.ts"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260516.0",
+    "tsx": "^4.19.2",
     "wrangler": "^3.99.0",
     "typescript": "^5.7.3"
   }

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -13,11 +13,14 @@
 import { POOLS, LEVERAGE_BRACKETS, POOL_NAMES, fetchReserveRates, computeNetApy, type ReserveRates } from "./stellar.ts";
 import { sendVerificationEmail, sendApyAlert } from "./email.ts";
 
-interface Env {
+export interface Env {
   DB: D1Database;
   RESEND_API_KEY: string;
   RESEND_FROM: string;
   FRONTEND_ORIGIN: string;
+  SUBSCRIBE_RATE_LIMIT_WINDOW_SECONDS?: string;
+  SUBSCRIBE_RATE_LIMIT_EMAIL_MAX?: string;
+  SUBSCRIBE_RATE_LIMIT_IP_MAX?: string;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -49,6 +52,146 @@ function corsHeaders(env: Env): Record<string, string> {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export interface SubscribeRateLimitConfig {
+  windowSeconds: number;
+  emailMax: number;
+  ipMax: number;
+}
+
+type SubscribeRateLimitScope = "email" | "ip";
+
+export interface SubscribeRateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds: number;
+  scope?: SubscribeRateLimitScope;
+}
+
+export const DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG: SubscribeRateLimitConfig = {
+  windowSeconds: 60 * 60,
+  emailMax: 5,
+  ipMax: 20,
+};
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getSubscribeRateLimitConfig(env: Env): SubscribeRateLimitConfig {
+  return {
+    windowSeconds: parsePositiveInteger(
+      env.SUBSCRIBE_RATE_LIMIT_WINDOW_SECONDS,
+      DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG.windowSeconds,
+    ),
+    emailMax: parsePositiveInteger(
+      env.SUBSCRIBE_RATE_LIMIT_EMAIL_MAX,
+      DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG.emailMax,
+    ),
+    ipMax: parsePositiveInteger(
+      env.SUBSCRIBE_RATE_LIMIT_IP_MAX,
+      DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG.ipMax,
+    ),
+  };
+}
+
+export function decideSubscribeRateLimit(
+  emailAttempts: number,
+  ipAttempts: number,
+  config: SubscribeRateLimitConfig,
+): SubscribeRateLimitDecision {
+  if (emailAttempts >= config.emailMax) {
+    return { allowed: false, retryAfterSeconds: config.windowSeconds, scope: "email" };
+  }
+  if (ipAttempts >= config.ipMax) {
+    return { allowed: false, retryAfterSeconds: config.windowSeconds, scope: "ip" };
+  }
+  return { allowed: true, retryAfterSeconds: config.windowSeconds };
+}
+
+function rateLimitResponse(decision: SubscribeRateLimitDecision, env: Env): Response {
+  const target = decision.scope === "ip" ? "this network" : "this email";
+  return new Response(JSON.stringify({
+    ok: false,
+    error: `Too many subscribe attempts for ${target}. Try again later.`,
+    rate_limit: {
+      scope: decision.scope,
+      retry_after_seconds: decision.retryAfterSeconds,
+    },
+  }), {
+    status: 429,
+    headers: {
+      "Content-Type": "application/json",
+      "Retry-After": String(decision.retryAfterSeconds),
+      ...corsHeaders(env),
+    },
+  });
+}
+
+function requestIp(request: Request): string {
+  const cfIp = request.headers.get("CF-Connecting-IP")?.trim();
+  if (cfIp) return cfIp;
+
+  const forwarded = request.headers.get("X-Forwarded-For")
+    ?.split(",")
+    .map(value => value.trim())
+    .find(Boolean);
+  return forwarded || "unknown";
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function countRecentAttempts(
+  env: Env,
+  column: "email" | "ip_hash",
+  value: string,
+  sinceSeconds: number,
+): Promise<number> {
+  const count = await env.DB.prepare(`
+    SELECT COUNT(*) AS count
+    FROM subscribe_attempts
+    WHERE ${column} = ?1
+      AND created_at >= ?2
+  `).bind(value, sinceSeconds).first("count");
+  return Number(count ?? 0);
+}
+
+async function enforceSubscribeRateLimit(
+  request: Request,
+  env: Env,
+  email: string,
+): Promise<SubscribeRateLimitDecision> {
+  const config = getSubscribeRateLimitConfig(env);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const sinceSeconds = nowSeconds - config.windowSeconds;
+  const ipHash = await sha256Hex(requestIp(request));
+
+  await env.DB.prepare(
+    "DELETE FROM subscribe_attempts WHERE created_at < ?1"
+  ).bind(sinceSeconds).run();
+
+  const [emailAttempts, ipAttempts] = await Promise.all([
+    countRecentAttempts(env, "email", email, sinceSeconds),
+    countRecentAttempts(env, "ip_hash", ipHash, sinceSeconds),
+  ]);
+
+  const decision = decideSubscribeRateLimit(emailAttempts, ipAttempts, config);
+  if (!decision.allowed) return decision;
+
+  await env.DB.prepare(`
+    INSERT INTO subscribe_attempts (email, ip_hash, created_at)
+    VALUES (?1, ?2, ?3)
+  `).bind(email, ipHash, nowSeconds).run();
+
+  return decision;
+}
+
 /** Known pool IDs for validation. */
 const KNOWN_POOL_IDS = new Set(POOLS.flatMap(p => [p.id]));
 
@@ -78,7 +221,8 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ ok: false, error: "Invalid JSON" }, 400, env);
   }
 
-  const { email, pool_id, asset_symbol, leverage_bracket } = body;
+  const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  const { pool_id, asset_symbol, leverage_bracket } = body;
 
   // Validate
   if (!email || !EMAIL_RE.test(email)) {
@@ -93,6 +237,18 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
   const lev = Number(leverage_bracket);
   if (!LEVERAGE_BRACKETS.includes(lev)) {
     return jsonResponse({ ok: false, error: "Invalid leverage bracket. Must be one of: " + LEVERAGE_BRACKETS.join(", ") }, 400, env);
+  }
+
+  let rateLimitDecision: SubscribeRateLimitDecision;
+  try {
+    rateLimitDecision = await enforceSubscribeRateLimit(request, env, email);
+  } catch (e: any) {
+    console.error("Subscribe rate-limit check failed:", e);
+    return jsonResponse({ ok: false, error: "Rate-limit check failed" }, 500, env);
+  }
+
+  if (!rateLimitDecision.allowed) {
+    return rateLimitResponse(rateLimitDecision, env);
   }
 
   const verifyToken = generateToken();

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -14,3 +14,16 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 
 CREATE INDEX IF NOT EXISTS idx_subs_pool_asset_lev
   ON subscriptions(pool_id, asset_symbol, leverage_bracket);
+
+CREATE TABLE IF NOT EXISTS subscribe_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  ip_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_attempts_email_created
+  ON subscribe_attempts(email, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_subscribe_attempts_ip_created
+  ON subscribe_attempts(ip_hash, created_at);

--- a/alerts/src/stellar.ts
+++ b/alerts/src/stellar.ts
@@ -66,24 +66,6 @@ for (const p of POOLS) POOL_NAMES[p.id] = p.name;
 // ── Soroban XDR helpers ──────────────────────────────────────────────────────
 // Minimal XDR encoding/decoding — avoids pulling in the full Stellar SDK.
 
-/** Encode a Stellar address as an ScVal (ScAddress::Account or ::Contract). */
-function addressToScVal(addr: string): string {
-  // We use the JSON representation that soroban-rpc accepts
-  return JSON.stringify({ type: "Address", value: addr });
-}
-
-/** Build a simulateTransaction JSON-RPC request body. */
-function buildSimulateBody(contractId: string, method: string, args: any[]): object {
-  return {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "simulateTransaction",
-    params: {
-      transaction: buildInvokeXdr(contractId, method, args),
-    },
-  };
-}
-
 // We need proper XDR encoding. Since we can't use the SDK in a worker easily,
 // we'll use the soroban-rpc's native JSON interface via stellar-sdk-like encoding.
 // Actually, the simplest approach: build a minimal transaction envelope in base64.

--- a/alerts/test/rate-limit.test.ts
+++ b/alerts/test/rate-limit.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker, {
+  DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG,
+  decideSubscribeRateLimit,
+  type Env,
+} from "../src/index.ts";
+import { LEVERAGE_BRACKETS, POOLS } from "../src/stellar.ts";
+
+interface RateLimitPayload {
+  ok: boolean;
+  rate_limit: {
+    scope: "email" | "ip";
+  };
+}
+
+class FakePreparedStatement {
+  private args: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeD1Database,
+    private readonly sql: string,
+  ) {}
+
+  bind(...args: unknown[]): FakePreparedStatement {
+    this.args = args;
+    return this;
+  }
+
+  async first(column?: string): Promise<unknown> {
+    if (this.sql.includes("WHERE email = ?1")) {
+      return column ? this.db.emailAttempts : { count: this.db.emailAttempts };
+    }
+    if (this.sql.includes("WHERE ip_hash = ?1")) {
+      return column ? this.db.ipAttempts : { count: this.db.ipAttempts };
+    }
+    throw new Error(`Unexpected first() SQL: ${this.sql}`);
+  }
+
+  async run(): Promise<{ success: boolean; meta: { changes: number } }> {
+    if (this.sql.includes("DELETE FROM subscribe_attempts")) {
+      return { success: true, meta: { changes: 0 } };
+    }
+    if (this.sql.includes("INSERT INTO subscribe_attempts")) {
+      this.db.insertedAttempts.push(this.args);
+      return { success: true, meta: { changes: 1 } };
+    }
+    throw new Error(`Unexpected run() SQL: ${this.sql}`);
+  }
+}
+
+class FakeD1Database {
+  readonly insertedAttempts: unknown[][] = [];
+
+  constructor(
+    readonly emailAttempts: number,
+    readonly ipAttempts: number,
+  ) {}
+
+  prepare(sql: string): FakePreparedStatement {
+    return new FakePreparedStatement(this, sql);
+  }
+}
+
+function envWithDb(db: FakeD1Database): Env {
+  return {
+    DB: db as unknown as D1Database,
+    RESEND_API_KEY: "test-key",
+    RESEND_FROM: "alerts@example.com",
+    FRONTEND_ORIGIN: "https://app.example.com",
+    SUBSCRIBE_RATE_LIMIT_WINDOW_SECONDS: "3600",
+    SUBSCRIBE_RATE_LIMIT_EMAIL_MAX: "5",
+    SUBSCRIBE_RATE_LIMIT_IP_MAX: "20",
+  };
+}
+
+function subscribeRequest(): Request {
+  const pool = POOLS[0];
+  return new Request("https://alerts.example.com/subscribe", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "CF-Connecting-IP": "203.0.113.42",
+    },
+    body: JSON.stringify({
+      email: "USER@example.com",
+      pool_id: pool.id,
+      asset_symbol: pool.assets[0].symbol,
+      leverage_bracket: LEVERAGE_BRACKETS[0],
+    }),
+  });
+}
+
+test("rejects subscribe requests once the email reaches the configured limit", async () => {
+  const db = new FakeD1Database(5, 0);
+  const response = await worker.fetch(subscribeRequest(), envWithDb(db));
+  const payload = await response.json() as RateLimitPayload;
+
+  assert.equal(response.status, 429);
+  assert.equal(response.headers.get("Retry-After"), "3600");
+  assert.equal(payload.ok, false);
+  assert.equal(payload.rate_limit.scope, "email");
+  assert.equal(db.insertedAttempts.length, 0);
+});
+
+test("rejects subscribe requests once the IP reaches the configured limit", async () => {
+  const db = new FakeD1Database(0, 20);
+  const response = await worker.fetch(subscribeRequest(), envWithDb(db));
+  const payload = await response.json() as RateLimitPayload;
+
+  assert.equal(response.status, 429);
+  assert.equal(response.headers.get("Retry-After"), "3600");
+  assert.equal(payload.ok, false);
+  assert.equal(payload.rate_limit.scope, "ip");
+  assert.equal(db.insertedAttempts.length, 0);
+});
+
+test("allows a reasonable burst below both configured limits", () => {
+  const decision = decideSubscribeRateLimit(
+    4,
+    19,
+    DEFAULT_SUBSCRIBE_RATE_LIMIT_CONFIG,
+  );
+
+  assert.equal(decision.allowed, true);
+});

--- a/alerts/tsconfig.json
+++ b/alerts/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,

--- a/alerts/wrangler.toml
+++ b/alerts/wrangler.toml
@@ -13,4 +13,8 @@ database_id = "<run `npm run db:create` and paste the ID here>"
 [vars]
 RESEND_FROM = "alerts@turbolong.com"
 FRONTEND_ORIGIN = "https://app.turbolong.com"
+# Subscribe throttling defaults: 5 attempts per email and 20 attempts per IP per hour.
+SUBSCRIBE_RATE_LIMIT_WINDOW_SECONDS = "3600"
+SUBSCRIBE_RATE_LIMIT_EMAIL_MAX = "5"
+SUBSCRIBE_RATE_LIMIT_IP_MAX = "20"
 # RESEND_API_KEY: set via `wrangler secret put RESEND_API_KEY`


### PR DESCRIPTION
Resolves #66.

Summary:
- Added configurable per-email and per-IP subscribe throttling backed by D1.
- Store hashed client IPs and prune old attempts within the configured window.
- Documented defaults in `wrangler.toml`: 5 attempts per email and 20 attempts per IP per hour.
- Added focused tests covering 429 responses at both email and IP limits.
- Enabled alert package type-checking by allowing `.ts` source imports and removing a dead helper that referenced a missing XDR builder.

Verification:
- `npm ci`
- `npm run test:rate-limit`
- `npx tsc --noEmit`
- `git diff --check`