### PR TITLE
Add opt-in pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# TurboLong
+
+TurboLong contains the Stellar frontend, alert worker, simulator, and Blend leverage strategy code for the project.
+
+## Pre-commit Hooks
+
+This repo uses an opt-in [Lefthook](https://lefthook.dev/) config to run the same local checks before commit that contributors should run before opening a PR.
+
+Install the hooks from the repo root:
+
+```sh
+npx --yes lefthook install
+```
+
+The pre-commit hook runs staged-file scoped checks:
+
+- Frontend changes run `npm run build` and `npm run typecheck` from `frontend/`.
+- Rust changes under `src/`, `contracts/`, or `tests/` run `rustfmt --check` on the staged Rust files.
+
+For emergency commits, bypass hooks with either:
+
+```sh
+git commit --no-verify
+```
+
+or:
+
+```sh
+LEFTHOOK=0 git commit
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1707,7 +1707,7 @@ function showConnected() {
 
 async function connect() {
   try {
-    const result = await StellarWalletsKit.authModal({ network: getActiveNetwork() === "testnet" ? Networks.TESTNET : Networks.PUBLIC });
+    const result = await StellarWalletsKit.authModal();
     // Verify wallet network matches app network
     const networkOk = await verifyWalletNetwork();
     if (!networkOk) {
@@ -1729,7 +1729,7 @@ async function connect() {
 /** Re-open wallet modal to switch to a different account without a full page reload. */
 async function switchWallet() {
   try {
-    const result = await StellarWalletsKit.authModal({ network: getActiveNetwork() === "testnet" ? Networks.TESTNET : Networks.PUBLIC });
+    const result = await StellarWalletsKit.authModal();
     if (result.address === userAddress) return;
     // Verify wallet network matches app network
     const networkOk = await verifyWalletNetwork();
@@ -2238,6 +2238,12 @@ $("demo-btn").addEventListener("click", () => {
     asset: a, cFactor: a.cFactor, lFactor: 1, interestSupplyApr: 4.2, interestBorrowApr: 6.8,
     blndSupplyApr: 2.1, blndBorrowApr: 1.5, netSupplyApr: 6.3, netBorrowCost: 5.3,
     totalSupply: 1000000, totalBorrow: 650000, available: 350000, priceUsd: 1.0,
+    bRate: 1_000_000_000_000n, dRate: 1_000_000_000_000n, bSupply: 1_000_000_000_000n, dSupply: 650_000_000_000n,
+    supplyEps: 0n, borrowEps: 0n, supplyEmission: null, borrowEmission: null,
+    rateConfig: {
+      rBase: 0, rOne: 500_000, rTwo: 2_000_000, rThree: 150_000_000,
+      utilOpt: Math.round(a.maxUtil * 10_000_000), irMod: 10_000_000, backstopFP: selectedPool.backstopFP,
+    },
   }));
   positions = { byAsset: new Map() };
   // One sample position

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  parallel: true
+  commands:
+    frontend-build:
+      root: frontend/
+      glob: "frontend/**/*.{ts,html,css,json}"
+      run: npm run build
+    frontend-typecheck:
+      root: frontend/
+      glob: "frontend/**/*.{ts,json}"
+      run: npm run typecheck
+    rustfmt:
+      glob: "{src,contracts,tests}/**/*.rs"
+      run: rustfmt --check {staged_files}


### PR DESCRIPTION
## Summary
- Adds an opt-in Lefthook pre-commit config with staged-file scoped frontend and Rust checks.
- Adds a root README section documenting install, what runs, and emergency bypass flags.
- Adds a frontend typecheck script and small compatibility fixes so the frontend hook passes.

## Verification
- `npm run build`
- `npm run typecheck`
- `npx --yes lefthook validate`
- `npx --yes lefthook run pre-commit`
- `git diff --check`

Closes #77