### PR TITLE
Add live projected HF preview beside leverage slider

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -404,6 +404,11 @@
                   <span class="slider-zone zone-degen" data-zone="degen">Degen</span>
                   <span class="slider-zone zone-maxi-degen hidden" id="zone-maxi-degen" data-zone="maxi-degen">Maxi Degen</span>
                 </div>
+                <div class="hf-live-preview" id="hf-live-preview" aria-live="polite">
+                  <span class="hf-live-label">Projected HF</span>
+                  <strong class="hf-live-value" id="hf-live-value">—</strong>
+                  <span class="hf-live-status" id="hf-live-status">Move leverage to preview risk</span>
+                </div>
                 <p class="hf-warning hidden" id="non-borrowable-notice"></p>
                 <div id="apy-chart" class="apy-chart"></div>
                 <div class="leverage-preview">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1167,6 +1167,25 @@ function switchAdjustSubTab(sub: "leverage" | "add-funds") {
 
 // ── Leverage preview ──────────────────────────────────────────────────────────
 
+function renderLiveHfPreview(hf: number) {
+  const preview = $("hf-live-preview");
+  const value = $("hf-live-value");
+  const status = $("hf-live-status");
+  const min = minHF();
+  const finite = Number.isFinite(hf);
+  const display = finite ? fmt(hf, expertMode ? 5 : 3) : hf > 0 ? "\u221E" : "--";
+  const state = !finite ? (hf > 0 ? "ok" : "bad") : hf >= 1.1 ? "ok" : hf >= min ? "warn" : "bad";
+
+  value.textContent = display;
+  value.className = `hf-live-value ${state === "ok" ? "hf-ok" : state === "warn" ? "hf-warn" : "hf-bad"}`;
+  status.textContent = state === "ok"
+    ? `Safe above ${fmt(min, expertMode ? 5 : 3)} min`
+    : state === "warn"
+      ? `Near ${fmt(min, expertMode ? 5 : 3)} minimum`
+      : `Below ${fmt(min, expertMode ? 5 : 3)} minimum`;
+  preview.className = `hf-live-preview hf-live-${state}`;
+}
+
 function updatePreview() {
   const slider = $("leverage-slider") as HTMLInputElement;
   const numIn  = $("leverage-input")  as HTMLInputElement;
@@ -1178,6 +1197,7 @@ function updatePreview() {
   const l       = rs?.lFactor ?? 1;
   const hf      = hfForLeverage(lev, c, l);
   const pos     = positions.byAsset.get(selectedAsset.id);
+  renderLiveHfPreview(hf);
 
   // In adjust mode, use equity as the base; in add-funds mode, use the add-funds input; in open mode, use initial deposit
   const equity  = (actionMode === "adjust" && pos) ? pos.equity

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -621,6 +621,49 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .slider-zone.active { opacity: 1; font-weight: 800; }
 .slider-zone:not(.active) { opacity: .4; }
 
+.hf-live-preview {
+  min-height: 38px;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  background: var(--metric-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+}
+.hf-live-label {
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .4px;
+  text-transform: uppercase;
+}
+.hf-live-value {
+  font-family: var(--mono);
+  font-size: 16px;
+  line-height: 1;
+}
+.hf-live-status {
+  min-width: 0;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: right;
+}
+.hf-live-preview.hf-live-ok {
+  background: var(--primary-glow);
+  border-color: var(--success-border);
+}
+.hf-live-preview.hf-live-warn {
+  background: var(--warning-bg);
+  border-color: var(--warning-border);
+}
+.hf-live-preview.hf-live-bad {
+  background: var(--danger-bg);
+  border-color: var(--danger-border);
+}
+
 /* APY chart */
 .apy-chart { margin: 4px 0 10px; overflow: visible; }
 .apy-chart svg { width: 100%; height: 120px; display: block; overflow: visible; }
@@ -1192,6 +1235,8 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   .swap-asset-select { width: 100%; }
   .slider-row { flex-wrap: wrap; }
   .leverage-num-input { width: 100%; margin-top: 4px; }
+  .hf-live-preview { grid-template-columns: 1fr auto; }
+  .hf-live-status { grid-column: 1 / -1; text-align: left; }
   #wallet-area { flex-wrap: wrap; gap: 6px; }
   .btn-connect { font-size: 12px; padding: 5px 10px; }
   .slippage-opt { padding: 2px 6px; font-size: 11px; }


### PR DESCRIPTION
## Summary
- add a dedicated projected-HF badge directly under the leverage slider
- update the badge on every leverage preview refresh using the same min-HF thresholds that gate transactions
- show safe / warning / danger styling and mobile wrapping for the live HF status

## Verification
- `npm run build`
- `git diff --check`
- Browser check on `http://127.0.0.1:5201/`: demo mode showed Projected HF `1.600` at `2.0x`, then after changing leverage to `4.8x` updated live to `1.011` with the warning state; current-page console logs were clean

Closes #3