### PR TITLE
Add Dependabot and cargo audit workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /alerts
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      alerts-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /scripts
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      scripts-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /contracts/strategies/blend_leverage
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:15"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      blend-leverage-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,38 @@
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "contracts/**/Cargo.toml"
+      - "contracts/**/Cargo.lock"
+      - ".github/workflows/security-audit.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "contracts/**/Cargo.toml"
+      - "contracts/**/Cargo.lock"
+      - ".github/workflows/security-audit.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Rust toolchain
+        run: cargo --version
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings


### PR DESCRIPTION
## Summary

- adds weekly Dependabot coverage for the frontend, alerts worker, scripts package, root Cargo project, and Blend leverage contract
- adds a dedicated Security Audit workflow that runs `cargo audit --deny warnings` on Rust dependency changes and on demand

## Verification

- `git diff --cached --check`
- `cargo --version` could not be run locally because Rust/Cargo is not installed in this Windows environment; the new workflow runs on `ubuntu-latest` where Cargo is available.

Closes #85