### PR TITLE
Show fee estimates before submit

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -435,6 +435,7 @@
               <button id="open-btn" class="btn btn-primary btn-lg">Open Position</button>
               <button id="adjust-btn" class="btn btn-primary btn-lg hidden">Adjust Leverage</button>
               <button id="add-funds-btn" class="btn btn-primary btn-lg hidden">Add Funds</button>
+              <p class="fee-hint mono" id="open-fee-estimate" aria-live="polite">Est. network fee: --</p>
               <p class="disclaimer" id="open-disclaimer">Two transactions: (1) token approve, (2) <code>submit_with_allowance</code>.</p>
               <p class="disclaimer hidden" id="adjust-disclaimer">Adjusts leverage by borrowing more (increase) or withdrawing &amp; repaying (decrease).</p>
               <p class="disclaimer hidden" id="add-funds-disclaimer">Deposits additional funds into your existing position at the selected leverage.</p>
@@ -530,6 +531,7 @@
                   <button id="repay-btn" class="btn btn-secondary" disabled>Repay Debt</button>
                   <button id="close-btn" class="btn btn-danger" disabled>Close Position</button>
                 </div>
+                <p class="fee-hint mono hidden" id="close-fee-estimate" aria-live="polite">Est. network fee: --</p>
 
                 <details class="tx-history" id="tx-history" style="display:none">
                   <summary class="tx-history-toggle">Recent Transactions</summary>
@@ -682,6 +684,7 @@
               <div class="vault-rebalance-row">
                 <button id="vault-rebalance-btn" class="btn btn-ghost" disabled>Rebalance</button>
                 <span class="vault-rebalance-hint" id="vault-rebalance-hint">HF is healthy</span>
+                <span class="fee-hint mono" id="vault-rebalance-fee-estimate" aria-live="polite">Max network fee: --</span>
               </div>
             </div>
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,7 @@ import { Networks }          from "@creit-tech/stellar-wallets-kit/types";
 import { estimateSwap }      from "@stellar-broker/client";
 import {
   Asset,
+  BASE_FEE,
   Horizon,
   Operation,
   TransactionBuilder,
@@ -334,6 +335,29 @@ const $ = (id: string) => document.getElementById(id)!;
 const fmt  = (n: number, d = 2) =>
   n.toLocaleString("en-US", { maximumFractionDigits: d, minimumFractionDigits: d });
 const aprToApy = (apr: number) => (Math.exp(apr / 100) - 1) * 100;
+const STROOPS_PER_XLM = 10_000_000n;
+const BLEND_SUBMIT_FEE_STROOPS = BigInt(BASE_FEE) * 10n;
+const VAULT_REBALANCE_FEE_STROOPS = 10_000_000n;
+
+function formatFeeXlm(stroops: bigint): string {
+  const whole = stroops / STROOPS_PER_XLM;
+  const fraction = (stroops % STROOPS_PER_XLM).toString().padStart(7, "0");
+  return `${whole}.${fraction} XLM`;
+}
+
+function setActionFeeEstimate(id: string, feePerTx: bigint, txCount: number, label = "Est. network fee") {
+  const el = $(id);
+  const total = feePerTx * BigInt(txCount);
+  el.textContent = `${label}: ${formatFeeXlm(total)} (${txCount} ${txCount === 1 ? "tx" : "txs"})`;
+}
+
+function refreshFeeEstimates() {
+  setActionFeeEstimate("open-fee-estimate", BLEND_SUBMIT_FEE_STROOPS, 2);
+  setActionFeeEstimate("close-fee-estimate", BLEND_SUBMIT_FEE_STROOPS, 1);
+  setActionFeeEstimate("vault-rebalance-fee-estimate", VAULT_REBALANCE_FEE_STROOPS, 1, "Max network fee");
+  $("open-fee-estimate").classList.toggle("hidden", actionMode !== "open");
+  $("close-fee-estimate").classList.toggle("hidden", !positions.byAsset.has(selectedAsset.id));
+}
 const fmtAddr = (addr: string) => addr.slice(0, 6) + "…" + addr.slice(-4);
 
 // ── Skeleton loading (#3) ────────────────────────────────────────────────────
@@ -1304,6 +1328,8 @@ function updatePreview() {
       ? `Add ${fmt(addAmt, 2)} ${selectedAsset.symbol} at ${lev.toFixed(1)}\u00D7`
       : "Add Funds";
   }
+
+  refreshFeeEstimates();
 }
 
 // ── Load data ─────────────────────────────────────────────────────────────────

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1101,10 +1101,18 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .vault-tab.active { background: var(--tab-active-bg); color: var(--primary); border-color: var(--tab-active-border); }
 
 .vault-rebalance-row {
-  display: flex; align-items: center; gap: 12px;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px 12px;
   margin-top: 12px; padding-top: 12px; border-top: 1px dashed var(--border);
 }
 .vault-rebalance-hint { font-size: 12px; }
+.fee-hint {
+  display: block;
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-3);
+}
+.position-actions + .fee-hint { margin-top: 8px; }
+.vault-rebalance-row .fee-hint { margin-top: 0; }
 
 .vault-hf-bar-wrap { margin: 12px 0 20px; }
 .hf-bar {


### PR DESCRIPTION
## Summary
- add visible XLM fee estimates for open, close, and vault rebalance actions
- calculate displayed totals from the same fee budgets used by the transaction builders
- keep the action fee hints refreshed with the current UI state

Closes #18.

## Verification
- npm run build