### PR TITLE
feat: annualize 30-day realized harvest revenue and add to vault APY

### DIFF
--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -417,17 +417,17 @@ pub fn claim(e: &Env, config: &Config) -> i128 {
 // ── Harvest: claim + swap + re-leverage ──────────────────────────────────────
 
 /// Claim BLND, swap to underlying via Soroswap, and re-leverage the proceeds.
-/// Returns the additional (b_tokens, d_tokens) from re-leveraging.
+/// Returns (b_tokens_delta, d_tokens_delta, realized_underlying).
 pub fn perform_reinvest(
     e: &Env,
     config: &Config,
     amount_out_min: i128,
-) -> Result<(i128, i128), StrategyError> {
+) -> Result<(i128, i128, i128), StrategyError> {
     let blnd_balance =
         TokenClient::new(e, &config.blend_token).balance(&e.current_contract_address());
 
     if blnd_balance < config.reward_threshold {
-        return Ok((0, 0));
+        return Ok((0, 0, 0));
     }
 
     let swap_path = vec![e, config.blend_token.clone(), config.asset.clone()];
@@ -454,13 +454,13 @@ pub fn perform_reinvest(
         .ok_or(StrategyError::InternalSwapError)?;
 
     if amount_out <= 0 {
-        return Ok((0, 0));
+        return Ok((0, 0, 0));
     }
 
     // Re-leverage the swapped proceeds
     let (b_delta, d_delta) = submit_leverage_loop(e, amount_out, config)?;
 
-    Ok((b_delta, d_delta))
+    Ok((b_delta, d_delta, amount_out))
 }
 
 // ── Pool state queries ───────────────────────────────────────────────────────

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -229,7 +229,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
         };
 
         // Swap BLND → underlying, then re-leverage
-        let (b_delta, d_delta) = blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
+        let (b_delta, d_delta, realized_underlying) = blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
 
         // Update reserves without minting shares (yield accrues to existing holders)
         if b_delta > 0 {
@@ -240,6 +240,12 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
                 harvested_blnd,
                 keeper,
                 shares_to_underlying(SCALAR_12, &updated_reserves)?,
+            );
+
+            // Emit custom event for realized underlying
+            e.events().publish(
+                (Symbol::new(&e, "harvest_realized"), String::from_str(&e, STRATEGY_NAME)),
+                realized_underlying,
             );
         }
 

--- a/doc.md
+++ b/doc.md
@@ -30,6 +30,30 @@ With collateral factor `c = 0.95`:
 | Health factor | `(total_supplied × c) / total_borrowed` |
 | Net APY on initial | `(supply_rate × supplied − borrow_rate × borrowed) / initial` |
 
+## Harvest APY Methodology
+
+The Vault APY includes both the base lending APY (from interest and emissions) and the realized revenue from harvesting BLND rewards.
+
+### Realized Harvest Revenue
+
+When the vault harvests BLND rewards, it swaps them for the underlying asset via Soroswap and reinvests them into the leverage loop. This increases the per-share equity of the vault without minting new shares.
+
+The harvest APY is computed by:
+1. Fetching all `harvest_realized` events for the vault from the last 30 days.
+2. Summing the total amount of underlying asset realized from these swaps.
+3. Annualizing the revenue relative to the current total equity:
+   ```
+   Harvest APY = (Total Realized 30d / Current Total Equity) * (365 / 30)
+   ```
+
+### Reported APY
+
+The reported APY is the sum of:
+- **Base APY**: `(Supply APR * Leverage) - (Borrow APR * (Leverage - 1))` (annualized)
+- **Harvest APY**: The annualized realized swap revenue from the last 30 days.
+
+This provides a more accurate representation of the total yield, including the "real yield" generated from compounding rewards.
+
 **Maximum leverage** (n → ∞):
 
 ```

--- a/frontend/src/defindex.ts
+++ b/frontend/src/defindex.ts
@@ -93,6 +93,7 @@ export interface VaultStats {
   debtValue: number;       // d_tokens * d_rate in underlying
   leverage: number;        // collateralValue / equity
   netApy: number | null;   // Estimated leveraged APY (null if unavailable)
+  harvestApy: number | null; // Realized harvest APY from BLND swaps
   supplyApr: number | null;
   borrowApr: number | null;
 }
@@ -180,6 +181,9 @@ export async function fetchVaultStats(
       }
     }
 
+    // Fetch realized harvest APY (30-day lookback)
+    const harvestApy = await fetchHarvestApy(vault, totalEquity);
+
     return {
       totalEquity,
       totalShares,
@@ -193,10 +197,62 @@ export async function fetchVaultStats(
       debtValue,
       leverage,
       netApy,
+      harvestApy,
       supplyApr,
       borrowApr,
     };
   } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch and annualize realized harvest revenue from on-chain logs.
+ * Looks back 30 days.
+ */
+async function fetchHarvestApy(
+  vault: VaultConfig,
+  currentEquity: number
+): Promise<number | null> {
+  if (!vault.vaultId || currentEquity <= 0) return 0;
+
+  try {
+    // 1. Get current ledger to compute start point
+    const latest = await blendServer.getLatestLedger();
+    const curSeq = latest.sequence;
+
+    // 2. Compute start ledger (~5s per ledger, 30 days = 518,400 ledgers)
+    const LOOKBACK_LEDGERS = 518400;
+    const startLedger = Math.max(1, curSeq - LOOKBACK_LEDGERS);
+
+    // 3. Fetch events with topic "harvest_realized"
+    const topicRealized = xdr.ScVal.scvSymbol("harvest_realized").toXDR("base64");
+
+    const result = await blendServer.getEvents({
+      startLedger,
+      filters: [
+        {
+          type: "contract",
+          contractIds: [vault.vaultId],
+          topics: [[topicRealized]],
+        },
+      ],
+    });
+
+    let totalRealized = 0;
+    for (const event of result.events) {
+      const val = scValToNative(event.value);
+      totalRealized += Number(val);
+    }
+
+    // 4. Annualize: (total_30d / current_equity) * (365 / 30)
+    const scalar = 10 ** vault.decimals;
+    const realizedUnderlying = totalRealized / scalar;
+    const apy = (realizedUnderlying / currentEquity) * (365 / 30);
+
+    return apy;
+  } catch (e) {
+    console.warn(`fetchHarvestApy: failed for ${vault.name}:`, e);
     return null;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2522,12 +2522,22 @@ async function refreshVaultView() {
     // Net APY (stats.netApy is actually APR — convert for display)
     const apyEl = $("vault-apy");
     if (stats.netApy !== null) {
-      const vaultApy = aprToApy(stats.netApy);
-      apyEl.textContent = (vaultApy >= 0 ? "+" : "") + vaultApy.toFixed(2) + "%";
-      apyEl.className = "stat-value mono " + (vaultApy > 0 ? "hf-ok" : "hf-bad");
+      const baseApy = aprToApy(stats.netApy);
+      const harvestApy = stats.harvestApy ? stats.harvestApy * 100 : 0;
+      const totalApy = baseApy + harvestApy;
+
+      apyEl.textContent = (totalApy >= 0 ? "+" : "") + totalApy.toFixed(2) + "%";
+      apyEl.className = "stat-value mono " + (totalApy > 0 ? "hf-ok" : "hf-bad");
+
       const vaultTip = $("vault-apy-tip");
-      if (vaultTip) vaultTip.setAttribute("data-tip",
-        `Approximate APY — Blend interest does not auto-compound. Actual net APR: ${fmt(stats.netApy, 2)}%`);
+      if (vaultTip) {
+        let tip = `Base APY: ${baseApy.toFixed(2)}% (from interest/emissions)`;
+        if (harvestApy > 0) {
+          tip += `\nHarvest APY: +${harvestApy.toFixed(2)}% (30-day realized BLND swaps)`;
+        }
+        tip += `\nTotal: ${totalApy.toFixed(2)}%`;
+        vaultTip.setAttribute("data-tip", tip);
+      }
     } else {
       apyEl.textContent = "--";
       apyEl.className = "stat-value mono";


### PR DESCRIPTION
closes #40 

## Summary 
  
This PR updates the Vault APY calculation to include realized revenue from BLND-to-underlying swaps, providing a more accurate "real yield" representation.

- **Contract**: Updated [lib.rs](file:///c:/Users/yunus/Desktop/TurboLong/contracts/strategies/blend_leverage/src/lib.rs) and [blend_pool.rs](file:///c:/Users/yunus/Desktop/TurboLong/contracts/strategies/blend_leverage/src/blend_pool.rs) to track and emit `harvest_realized` events containing the underlying asset amount obtained during harvests.
- **Frontend**: Modified [defindex.ts](file:///c:/Users/yunus/Desktop/TurboLong/frontend/src/defindex.ts) to fetch these on-chain events from the last 30 days and compute an annualized Harvest APY. Updated [main.ts](file:///c:/Users/yunus/Desktop/TurboLong/frontend/src/main.ts) to display the combined APY with a detailed breakdown in the tooltip.
- **Docs**: Updated [doc.md](file:///c:/Users/yunus/Desktop/TurboLong/doc.md) to explain the new methodology.

 ## Related Issue 
    
 ## Checks 
  
 - [x] I read the [contribution guide][contribution-guide]. 
 - [x] I kept this pull request scoped to the linked issue. 
 - [x] I ran the relevant local checks or explained why they were skipped. 
 - [x] For Drips wave issues, I claimed the issue before opening this pull request. 
  
 ## Notes for Reviewers 
  
- The harvest APY uses a 30-day rolling window (~518,400 ledgers) for its lookback.
- The base APY remains calculated from current pool reserves, while the harvest component is purely based on realized historical performance.
- Screenshots of the updated APY tooltip would show: `Base APY`, `Harvest APY`, and the combined `Total`.
  
 [contribution-guide]: `https://github.com/Dgetsylver/TurboLong/blob/main/CONTRIBUTING.md`