### PR TITLE
Add BLND price assumption control

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -306,6 +306,16 @@
                 </div>
               </div>
 
+              <div class="blnd-price-assumption">
+                <label for="blnd-price-input">BLND price assumption</label>
+                <div class="blnd-price-control">
+                  <span class="blnd-price-prefix">$</span>
+                  <input type="number" id="blnd-price-input" class="input mono" min="0" step="0.0001" placeholder="Market" />
+                  <button id="blnd-price-reset" class="btn btn-ghost btn-sm" type="button">Reset</button>
+                </div>
+                <span class="blnd-price-status" id="blnd-price-status">Using market price</span>
+              </div>
+
               <!-- APR breakdown -->
               <div class="apr-grid">
                 <div class="apr-card">

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -255,6 +255,7 @@ export function setNetwork(net: NetworkMode) {
   horizon = new Horizon.Server(_cfg.horizonUrl);
   // Reset BLND price cache
   _blndPriceCache = null;
+  _blndPriceOverride = null;
 }
 
 /** Exported getters for active config — used by main.ts and other modules */
@@ -367,12 +368,31 @@ async function simulate(op: xdr.Operation): Promise<any> {
 // ── BLND price from CoinGecko ─────────────────────────────────────────────────
 
 let _blndPriceCache: number | null = null;
+let _blndPriceOverride: number | null = null;
+
+function activeBlndPrice(): number {
+  return _blndPriceOverride ?? _blndPriceCache ?? 0;
+}
+
+export function getBlndPriceAssumption(): number | null {
+  return _blndPriceOverride;
+}
+
+export function getDefaultBlndPrice(): number | null {
+  return _blndPriceCache;
+}
+
+export function setBlndPriceAssumption(price: number | null): number | null {
+  _blndPriceOverride = price !== null && Number.isFinite(price) && price > 0 ? price : null;
+  return _blndPriceOverride;
+}
 
 /**
  * Fetch BLND price. Goes straight to CoinGecko since no pool oracle lists BLND.
  * The pool parameter is accepted for API consistency but currently unused.
  */
 export async function fetchBlndPrice(pool: PoolDef, userAddress: string): Promise<number> {
+  if (_blndPriceOverride !== null) return _blndPriceOverride;
   if (_blndPriceCache !== null) return _blndPriceCache;
 
   // CoinGecko free API
@@ -392,6 +412,23 @@ export async function fetchBlndPrice(pool: PoolDef, userAddress: string): Promis
   _blndPriceCache = 0;
   console.warn("[blend] BLND price unavailable — emissions APR will show 0");
   return 0;
+}
+
+export function withBlndPriceAssumption(rs: ReserveStats, blndPrice = activeBlndPrice()): ReserveStats {
+  const supplyBlndYr = Number(rs.supplyEps) * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
+  const borrowBlndYr = Number(rs.borrowEps) * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
+  const totalSupplyUsd = rs.totalSupply * rs.priceUsd;
+  const totalBorrowUsd = rs.totalBorrow * rs.priceUsd;
+  const blndSupplyApr = totalSupplyUsd > 0 ? (supplyBlndYr * blndPrice / totalSupplyUsd) * 100 : 0;
+  const blndBorrowApr = totalBorrowUsd > 0 ? (borrowBlndYr * blndPrice / totalBorrowUsd) * 100 : 0;
+
+  return {
+    ...rs,
+    blndSupplyApr,
+    blndBorrowApr,
+    netSupplyApr: rs.interestSupplyApr + blndSupplyApr,
+    netBorrowCost: rs.interestBorrowApr - blndBorrowApr,
+  };
 }
 
 // ── Per-asset pool data ───────────────────────────────────────────────────────
@@ -617,7 +654,7 @@ export function projectRates(rs: ReserveStats, addSupply: number, addBorrow: num
   const projSupplyUsd = projSupply * rs.priceUsd;
   const projBorrowUsd = projBorrow * rs.priceUsd;
 
-  const bp = _blndPriceCache ?? 0;
+  const bp = activeBlndPrice();
   const blndSupplyApr = projSupplyUsd > 0 ? (supplyBlndYr * bp / projSupplyUsd) * 100 : 0;
   const blndBorrowApr = projBorrowUsd > 0 ? (borrowBlndYr * bp / projBorrowUsd) * 100 : 0;
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,6 +44,10 @@ import {
   submitClassicXdr,
   hfForLeverage,
   maxLeverageFor,
+  getBlndPriceAssumption,
+  getDefaultBlndPrice,
+  setBlndPriceAssumption,
+  withBlndPriceAssumption,
   type NetworkMode,
   type AssetInfo,
   type PoolDef,
@@ -659,6 +663,32 @@ function selectAsset(asset: AssetInfo) {
   if (userAddress) refreshTabData();
 }
 
+function refreshBlndPriceControl() {
+  const input = $("blnd-price-input") as HTMLInputElement;
+  const status = $("blnd-price-status");
+  const override = getBlndPriceAssumption();
+  const fallback = getDefaultBlndPrice();
+  const active = override ?? fallback ?? 0;
+
+  if (document.activeElement !== input) {
+    input.value = active > 0 ? active.toFixed(4) : "";
+  }
+
+  if (override !== null) {
+    status.textContent = `Using custom BLND price: $${fmt(override, 4)}`;
+  } else if (fallback !== null && fallback > 0) {
+    status.textContent = `Using market BLND price: $${fmt(fallback, 4)}`;
+  } else {
+    status.textContent = "Market BLND price unavailable";
+  }
+}
+
+function applyBlndPriceAssumption(price: number | null) {
+  const active = setBlndPriceAssumption(price) ?? getDefaultBlndPrice() ?? 0;
+  reserves = reserves.map(rs => withBlndPriceAssumption(rs, active));
+  renderSelectedAsset();
+}
+
 /** Fetch only balance for the current asset (BLND is pool-wide, fetched in loadAll). */
 async function refreshTabData() {
   if (!userAddress) return;
@@ -779,6 +809,7 @@ function renderSelectedAsset() {
   utilBar.style.background = util > 0.90 ? "var(--danger)" : util > 0.75 ? "var(--warning)" : "var(--success)";
 
   $("stat-price").textContent      = rs.priceUsd > 0 ? `$${fmt(rs.priceUsd, 4)}` : "\u2014";
+  refreshBlndPriceControl();
 
   renderAprLine("supply-interest-apr", rs.interestSupplyApr, false);
   renderAprLine("supply-blnd-apr",     rs.blndSupplyApr,     false, true);
@@ -2022,6 +2053,26 @@ function toggleTheme() {
 }
 $("theme-toggle").addEventListener("click", toggleTheme);
 document.getElementById("mobile-theme-toggle")?.addEventListener("click", toggleTheme);
+
+$("blnd-price-input").addEventListener("input", () => {
+  const input = $("blnd-price-input") as HTMLInputElement;
+  const raw = input.value.trim();
+  if (raw === "") {
+    applyBlndPriceAssumption(null);
+    return;
+  }
+  const price = Number(raw);
+  if (Number.isFinite(price) && price > 0) {
+    applyBlndPriceAssumption(price);
+  } else {
+    $("blnd-price-status").textContent = "Enter a positive USD price";
+  }
+});
+
+$("blnd-price-reset").addEventListener("click", () => {
+  applyBlndPriceAssumption(null);
+  refreshBlndPriceControl();
+});
 
 // Settings dropdown toggle
 $("settings-btn").addEventListener("click", (e) => {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -404,6 +404,23 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 
 /* ── APR grid ────────────────────────────────────────────────────────────── */
 
+.blnd-price-assumption {
+  display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 6px 12px;
+  margin-bottom: 12px; padding: 10px 12px;
+  border: 1px solid var(--border); border-radius: var(--r);
+  background: var(--surface);
+}
+.blnd-price-assumption label {
+  font-size: 11px; color: var(--text-3); text-transform: uppercase;
+  letter-spacing: .5px; font-weight: 600;
+}
+.blnd-price-control { display: flex; align-items: center; gap: 6px; }
+.blnd-price-prefix { color: var(--text-3); font-family: var(--mono); font-size: 13px; }
+.blnd-price-control .input { width: 110px; height: 32px; padding: 0 8px; }
+.blnd-price-status {
+  grid-column: 1 / -1; font-size: 12px; color: var(--text-3);
+}
+
 .apr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 12px; }
 .apr-card {
   background: var(--surface); border: 1px solid var(--border);
@@ -1184,6 +1201,8 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 
 @media (max-width: 480px) {
   .stats-row { grid-template-columns: 1fr; }
+  .blnd-price-assumption { grid-template-columns: 1fr; }
+  .blnd-price-control .input { width: 100%; }
   .position-grid { grid-template-columns: 1fr; }
   .vault-pos-grid { grid-template-columns: 1fr; }
   .card { padding: 14px; }


### PR DESCRIPTION
## Summary
- add a BLND USD price assumption input with reset-to-default control
- expose BLND price override helpers and reprice emission APRs locally
- refresh APY cards, preview, positions, and portfolio summaries immediately when the assumption changes

Closes #37.

## Verification
- npm run build
- local UI render check for the BLND price assumption control