### PR TITLE
feat(A25): position-event timeline

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -535,6 +535,11 @@
                   <summary class="tx-history-toggle">Recent Transactions</summary>
                   <div id="tx-history-list" class="tx-history-list"></div>
                 </details>
+
+                <details class="pos-timeline" id="position-timeline" style="display:none">
+                  <summary class="tx-history-toggle">Position History</summary>
+                  <div id="position-timeline-list" class="pos-timeline-list"></div>
+                </details>
               </div>
             </section>
 

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -1340,3 +1340,68 @@ export async function submitClassicXdr(signedXdr: string): Promise<string> {
   const result = await horizon.submitTransaction(tx);
   return (result as any).hash;
 }
+
+// ── Position event timeline (A25) ─────────────────────────────────────────────
+
+export type PositionEventKind = "open" | "rebalance" | "harvest" | "close";
+
+export interface PositionEvent {
+  kind:      PositionEventKind;
+  hash:      string;
+  timestamp: number; // ms since epoch
+  hf:        number | null;
+}
+
+/**
+ * Fetch on-chain events for a user's position in a pool by scanning Horizon
+ * payment/invoke operations on the pool contract account.
+ *
+ * Horizon's /accounts/{pool}/operations endpoint returns all operations that
+ * touched the pool contract. We filter by the user's source account and map
+ * the operation type / function name to a PositionEventKind.
+ */
+export async function fetchPositionEvents(
+  pool: PoolDef,
+  userAddress: string,
+  assetId: string,
+): Promise<PositionEvent[]> {
+  const events: PositionEvent[] = [];
+  // Horizon returns up to 200 records per page; one page is enough for a timeline.
+  const url = `${_cfg.horizonUrl}/accounts/${pool.id}/operations?limit=200&order=desc&include_failed=false`;
+  let resp: any;
+  try {
+    resp = await (await fetch(url)).json();
+  } catch {
+    return events;
+  }
+  const records: any[] = resp?._embedded?.records ?? [];
+  for (const op of records) {
+    // Only care about invoke_host_function ops from this user
+    if (op.type !== "invoke_host_function") continue;
+    if (op.source_account !== userAddress) continue;
+
+    const fn: string = op.function ?? "";
+    let kind: PositionEventKind | null = null;
+    if (fn === "submit") {
+      // Distinguish open vs close vs rebalance by checking asset involvement.
+      // We use the presence of the assetId in the parameters as a heuristic.
+      const params: string = JSON.stringify(op.parameters ?? []);
+      if (params.includes(assetId)) {
+        // Heuristic: if the ledger_key_hash list is short it's likely an open/close;
+        // we fall back to "rebalance" for all submit calls on existing positions.
+        kind = "rebalance";
+      }
+    } else if (fn === "claim") {
+      kind = "harvest";
+    }
+    if (!kind) continue;
+
+    events.push({
+      kind,
+      hash:      op.transaction_hash,
+      timestamp: new Date(op.created_at).getTime(),
+      hf:        null, // HF snapshot injected by main.ts at record time
+    });
+  }
+  return events;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,6 +51,9 @@ import {
   type AssetPosition,
   type UserPositions,
   projectRates,
+  fetchPositionEvents,
+  type PositionEvent,
+  type PositionEventKind,
 } from "./blend.ts";
 
 import {
@@ -445,6 +448,94 @@ function renderTxHistory() {
       <a class="tx-history-link" href="https://stellar.expert/explorer/public/tx/${tx.hash}" target="_blank" rel="noopener">View</a>
     </div>`;
   }).join("");
+}
+
+// ── Position event timeline (A25) ─────────────────────────────────────────────
+
+const POS_EVENTS_MAX = 50;
+
+function posEventsKey(assetId: string, poolId: string) {
+  return `pos_events_${poolId}_${assetId}`;
+}
+
+function getPositionEvents(assetId: string, poolId: string): PositionEvent[] {
+  const raw = localStorage.getItem(posEventsKey(assetId, poolId));
+  return raw ? JSON.parse(raw) : [];
+}
+
+function savePositionEvents(assetId: string, poolId: string, events: PositionEvent[]) {
+  localStorage.setItem(posEventsKey(assetId, poolId), JSON.stringify(events.slice(0, POS_EVENTS_MAX)));
+}
+
+function recordPositionEvent(kind: PositionEventKind, hash: string, hf: number | null) {
+  const events = getPositionEvents(selectedAsset.id, selectedPool.id);
+  // Deduplicate by hash
+  if (events.some(e => e.hash === hash)) return;
+  events.unshift({ kind, hash, timestamp: Date.now(), hf });
+  savePositionEvents(selectedAsset.id, selectedPool.id, events);
+}
+
+function explorerTxUrl(hash: string): string {
+  const net = getActiveNetwork() === "testnet" ? "testnet" : "public";
+  return `https://stellar.expert/explorer/${net}/tx/${hash}`;
+}
+
+const EVENT_LABELS: Record<PositionEventKind, string> = {
+  open:      "Open",
+  rebalance: "Rebalance",
+  harvest:   "Harvest",
+  close:     "Close",
+};
+const EVENT_ICONS: Record<PositionEventKind, string> = {
+  open:      "⊕",
+  rebalance: "⇄",
+  harvest:   "✦",
+  close:     "⊗",
+};
+
+function renderPositionTimeline() {
+  const wrap = document.getElementById("position-timeline");
+  if (!wrap) return;
+  const events = getPositionEvents(selectedAsset.id, selectedPool.id);
+  if (events.length === 0) {
+    wrap.style.display = "none";
+    return;
+  }
+  wrap.style.display = "";
+  const list = document.getElementById("position-timeline-list")!;
+  list.innerHTML = events.map(ev => {
+    const d = new Date(ev.timestamp);
+    const localStr = d.toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" });
+    const utcStr   = d.toUTCString();
+    const hfStr    = ev.hf !== null ? ` · HF ${fmt(ev.hf, 3)}` : "";
+    const shortHash = ev.hash.slice(0, 8) + "…" + ev.hash.slice(-4);
+    return `<div class="pos-event-item pos-event-${ev.kind}">
+      <span class="pos-event-icon" aria-hidden="true">${EVENT_ICONS[ev.kind]}</span>
+      <span class="pos-event-label">${EVENT_LABELS[ev.kind]}</span>
+      <time class="pos-event-time" title="${utcStr}" datetime="${d.toISOString()}">${localStr}</time>
+      <span class="pos-event-hf">${hfStr}</span>
+      <a class="pos-event-link" href="${explorerTxUrl(ev.hash)}" target="_blank" rel="noopener">${shortHash}</a>
+    </div>`;
+  }).join("");
+}
+
+async function refreshTimelineFromChain() {
+  const events = await fetchPositionEvents(selectedPool, userAddress!, selectedAsset.id);
+  if (events.length === 0) return;
+  const stored = getPositionEvents(selectedAsset.id, selectedPool.id);
+  const storedHashes = new Set(stored.map(e => e.hash));
+  let changed = false;
+  for (const ev of events) {
+    if (!storedHashes.has(ev.hash)) {
+      stored.push(ev);
+      changed = true;
+    }
+  }
+  if (changed) {
+    stored.sort((a, b) => b.timestamp - a.timestamp);
+    savePositionEvents(selectedAsset.id, selectedPool.id, stored);
+    renderPositionTimeline();
+  }
 }
 
 // ── TX Stepper (#10) ─────────────────────────────────────────────────────────
@@ -1040,6 +1131,8 @@ function renderPosition() {
 
   // Compound row: show swap estimate if there's pending BLND
   updateCompoundEstimate();
+  // Position event timeline (A25)
+  renderPositionTimeline();
 }
 
 async function updateCompoundEstimate() {
@@ -1335,6 +1428,10 @@ async function loadAll() {
 
     renderSelectedAsset();
     startFreshnessTimer();
+    // Refresh timeline from chain in background (A25)
+    if (positions.byAsset.has(selectedAsset.id)) {
+      refreshTimelineFromChain().catch(() => {});
+    }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error("Failed to load pool data:", e);
@@ -1375,9 +1472,10 @@ async function openPosition() {
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
-    await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
+    const openHash = await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
+    recordPositionEvent("open", openHash, hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1));
     await loadAll();
   } catch (e: any) {
     markStepperError(2);
@@ -1403,8 +1501,9 @@ async function closePosition() {
   showTxStepper(["Close Position"]);
   try {
     const submitXdr = await buildCloseSubmitXdr(selectedPool, userAddress, pos);
-    await signAndSubmit(submitXdr, `Close ${selectedAsset.symbol} position`, 0);
+    const closeHash = await signAndSubmit(submitXdr, `Close ${selectedAsset.symbol} position`, 0);
     hideTxStepper();
+    recordPositionEvent("close", closeHash, null);
     removePnlEntry(selectedAsset.id, selectedPool.id);
     await loadAll();
   } catch (e: any) {
@@ -1494,8 +1593,9 @@ async function claimBlnd() {
   showTxStepper(["Claim BLND"]);
   try {
     const claimXdr = await buildClaimXdr(selectedPool, userAddress, tokenIds);
-    await signAndSubmit(claimXdr, "Claim BLND", 0);
+    const claimHash = await signAndSubmit(claimXdr, "Claim BLND", 0);
     hideTxStepper();
+    recordPositionEvent("harvest", claimHash, null);
     await loadAll();
   } catch (e: any) {
     markStepperError(1);
@@ -1530,10 +1630,12 @@ async function adjustLeverage() {
   try {
     if (targetLev > curLev) {
       const xdr = await buildIncreaseLeverageXdr(selectedPool, userAddress, liveAsset, pos, targetLev);
-      await signAndSubmit(xdr, `Increase leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      const h = await signAndSubmit(xdr, `Increase leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      recordPositionEvent("rebalance", h, hfForLeverage(targetLev, liveAsset.cFactor, rs?.lFactor ?? 1));
     } else {
       const xdr = await buildDecreaseLeverageXdr(selectedPool, userAddress, liveAsset, pos, targetLev);
-      await signAndSubmit(xdr, `Decrease leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      const h = await signAndSubmit(xdr, `Decrease leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      recordPositionEvent("rebalance", h, hfForLeverage(targetLev, liveAsset.cFactor, rs?.lFactor ?? 1));
     }
     hideTxStepper();
     await loadAll();
@@ -1650,7 +1752,8 @@ async function claimAndConvert() {
   try {
     // Claim
     const claimXdr = await buildClaimXdr(selectedPool, userAddress, tokenIds);
-    await signAndSubmit(claimXdr, "Claim BLND", 0);
+    const claimHash = await signAndSubmit(claimXdr, "Claim BLND", 0);
+    recordPositionEvent("harvest", claimHash, null);
 
     // Check actual BLND balance after claim
     const blndBalance = await fetchAssetBalance(userAddress, getBlndId());

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -554,6 +554,27 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .tx-history-status-ok { color: var(--success); }
 .tx-history-status-err { color: var(--danger); }
 
+/* ── Position event timeline (A25) ──────────────────────────────────────── */
+
+.pos-timeline { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 10px; }
+.pos-timeline-list { max-height: 240px; overflow-y: auto; margin-top: 8px; }
+.pos-event-item {
+  display: grid;
+  grid-template-columns: 18px 70px 1fr auto auto;
+  align-items: center; gap: 6px;
+  padding: 6px 0; font-size: 12px; border-bottom: 1px solid var(--border);
+}
+.pos-event-item:last-child { border-bottom: none; }
+.pos-event-icon { font-size: 13px; text-align: center; }
+.pos-event-open    .pos-event-icon { color: var(--success); }
+.pos-event-close   .pos-event-icon { color: var(--danger); }
+.pos-event-rebalance .pos-event-icon { color: var(--primary); }
+.pos-event-harvest .pos-event-icon { color: var(--warning); }
+.pos-event-label { font-weight: 600; color: var(--text-2); }
+.pos-event-time { color: var(--text-3); font-family: var(--mono); font-size: 11px; cursor: help; }
+.pos-event-hf { color: var(--text-3); font-size: 11px; font-family: var(--mono); }
+.pos-event-link { color: var(--primary); font-size: 11px; font-family: var(--mono); white-space: nowrap; }
+
 /* ── Open form ───────────────────────────────────────────────────────────── */
 
 .form-group { margin-bottom: 16px; }


### PR DESCRIPTION

Per-position scrollable timeline showing each event (open, rebalance, harvest,
close) with timestamp, tx hash, and HF snapshot.

## Changes

- **blend.ts** — `fetchPositionEvents()`: queries Horizon `/accounts/{pool}/operations`,
  maps `invoke_host_function` ops to typed `PositionEvent` records
  (`submit` → rebalance, `claim` → harvest)
- **main.ts** — `recordPositionEvent()` writes events to localStorage at tx time
  with HF snapshot; `renderPositionTimeline()` renders the timeline;
  `refreshTimelineFromChain()` merges on-chain history on each `loadAll`
- **index.html** — `<details id="position-timeline">` added to position card
- **style.css** — timeline styles with colour-coded icons per event kind

## Acceptance criteria

- [x] Events pulled from on-chain logs via RPC (Horizon operations endpoint)
- [x] Timestamps in local time with UTC on hover
- [x] Each event links to Stellar Expert (network-aware, testnet/mainnet)

## Tested

`vite build` — 0 errors, 0 type errors

Closes #27