### PR TITLE
Feat/b2 fee adjusted apy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -535,6 +535,11 @@
                   <summary class="tx-history-toggle">Recent Transactions</summary>
                   <div id="tx-history-list" class="tx-history-list"></div>
                 </details>
+
+                <details class="pos-timeline" id="position-timeline" style="display:none">
+                  <summary class="tx-history-toggle">Position History</summary>
+                  <div id="position-timeline-list" class="pos-timeline-list"></div>
+                </details>
               </div>
             </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,10 @@
         <div id="settings-dropdown" class="settings-dropdown hidden">
           <button id="expert-toggle" class="settings-dropdown-item">Expert Mode <span class="settings-badge">Off</span></button>
           <button id="theme-toggle" class="settings-dropdown-item">Theme <span class="settings-badge">&#9790;</span></button>
+          <label class="settings-dropdown-item settings-fee-row">
+            Rebalances/yr
+            <input type="number" id="rebalances-input" class="input mono settings-rebalances-input" min="0" max="365" step="1" value="12" title="Assumed rebalances per year for fee-adjusted APY. Each rebalance = 2 txs × 0.00001 XLM." />
+          </label>
         </div>
         <button id="network-toggle" class="btn btn-ghost btn-sm network-toggle" data-tip="Switch between Mainnet and Testnet">Mainnet</button>
         <button id="connect-btn" class="btn btn-primary btn-connect">Connect Wallet</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -428,6 +428,10 @@
                   <div class="preview-row">
                     <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
                   </div>
+                  <details class="worst-case-panel" id="worst-case-panel">
+                    <summary class="worst-case-summary">Worst-case scenario ▸</summary>
+                    <div id="worst-case-body" class="worst-case-body"></div>
+                  </details>
                 </div>
                 <p class="hf-warning hidden" id="hf-warning">&#9888; HF too low — liquidation risk. Reduce leverage.</p>
                 <p class="hf-warning hidden" id="liquidity-warning"></p>

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -1340,3 +1340,68 @@ export async function submitClassicXdr(signedXdr: string): Promise<string> {
   const result = await horizon.submitTransaction(tx);
   return (result as any).hash;
 }
+
+// ── Position event timeline (A25) ─────────────────────────────────────────────
+
+export type PositionEventKind = "open" | "rebalance" | "harvest" | "close";
+
+export interface PositionEvent {
+  kind:      PositionEventKind;
+  hash:      string;
+  timestamp: number; // ms since epoch
+  hf:        number | null;
+}
+
+/**
+ * Fetch on-chain events for a user's position in a pool by scanning Horizon
+ * payment/invoke operations on the pool contract account.
+ *
+ * Horizon's /accounts/{pool}/operations endpoint returns all operations that
+ * touched the pool contract. We filter by the user's source account and map
+ * the operation type / function name to a PositionEventKind.
+ */
+export async function fetchPositionEvents(
+  pool: PoolDef,
+  userAddress: string,
+  assetId: string,
+): Promise<PositionEvent[]> {
+  const events: PositionEvent[] = [];
+  // Horizon returns up to 200 records per page; one page is enough for a timeline.
+  const url = `${_cfg.horizonUrl}/accounts/${pool.id}/operations?limit=200&order=desc&include_failed=false`;
+  let resp: any;
+  try {
+    resp = await (await fetch(url)).json();
+  } catch {
+    return events;
+  }
+  const records: any[] = resp?._embedded?.records ?? [];
+  for (const op of records) {
+    // Only care about invoke_host_function ops from this user
+    if (op.type !== "invoke_host_function") continue;
+    if (op.source_account !== userAddress) continue;
+
+    const fn: string = op.function ?? "";
+    let kind: PositionEventKind | null = null;
+    if (fn === "submit") {
+      // Distinguish open vs close vs rebalance by checking asset involvement.
+      // We use the presence of the assetId in the parameters as a heuristic.
+      const params: string = JSON.stringify(op.parameters ?? []);
+      if (params.includes(assetId)) {
+        // Heuristic: if the ledger_key_hash list is short it's likely an open/close;
+        // we fall back to "rebalance" for all submit calls on existing positions.
+        kind = "rebalance";
+      }
+    } else if (fn === "claim") {
+      kind = "harvest";
+    }
+    if (!kind) continue;
+
+    events.push({
+      kind,
+      hash:      op.transaction_hash,
+      timestamp: new Date(op.created_at).getTime(),
+      hf:        null, // HF snapshot injected by main.ts at record time
+    });
+  }
+  return events;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1258,6 +1258,73 @@ function switchAdjustSubTab(sub: "leverage" | "add-funds") {
   updatePreview();
 }
 
+// ── Worst-case scenario panel (B14) ──────────────────────────────────────────
+
+/**
+ * Compute borrow APR at a given utilization using the real IR curve parameters.
+ * Mirrors the exact formula in blend.ts / fetchAllReserves.
+ */
+function irAtUtil(util: number, rc: { rBase: number; rOne: number; rTwo: number; rThree: number; utilOpt: number; irMod: number }): number {
+  const SCALAR_F  = 10_000_000;
+  const FIXED_95  = 9_500_000;
+  const utilFp    = Math.round(util * SCALAR_F);
+  const { rBase, rOne, rTwo, rThree, utilOpt, irMod } = rc;
+  let base: number;
+  if (utilFp <= utilOpt) {
+    base = rBase + Math.ceil(rOne * utilFp / utilOpt);
+  } else if (utilFp <= FIXED_95) {
+    const slope = Math.ceil((utilFp - utilOpt) * SCALAR_F / (FIXED_95 - utilOpt));
+    base = rBase + rOne + Math.ceil(rTwo * slope / SCALAR_F);
+  } else {
+    const slope = Math.ceil((utilFp - FIXED_95) * SCALAR_F / (SCALAR_F - FIXED_95));
+    base = rBase + rOne + rTwo + Math.ceil(rThree * slope / SCALAR_F);
+  }
+  return (Math.ceil(base * irMod / SCALAR_F) / SCALAR_F) * 100; // → APR %
+}
+
+function renderWorstCase(lev: number, hf: number, rs: ReserveStats | null) {
+  const body = document.getElementById("worst-case-body");
+  if (!body) return;
+
+  if (!rs || !isFinite(hf) || hf <= 1 || lev <= 1) {
+    body.innerHTML = `<span class="wc-na">Open a position to see worst-case projection.</span>`;
+    return;
+  }
+
+  const rc = rs.rateConfig;
+  const BACKSTOP = rc.backstopFP / 10_000_000;
+
+  // Worst-case: r_three kicks in at 99% util
+  const UTIL_WORST = 0.99;
+  const borrowApr  = irAtUtil(UTIL_WORST, rc);
+  const supplyApr  = borrowApr * UTIL_WORST * (1 - BACKSTOP);
+  const spread     = borrowApr - supplyApr; // %/yr
+
+  // HF(t) = HF(0) × e^(−spread/100 × t/365)  where t is days
+  const scenarios = [30, 90, 180];
+  const rows = scenarios.map(days => {
+    const hfFuture = hf * Math.exp(-(spread / 100) * (days / 365));
+    const cls = hfFuture > 1.1 ? "hf-ok" : hfFuture > 1.03 ? "hf-warn" : "hf-bad";
+    return `<div class="wc-row">
+      <span class="wc-days">${days}d</span>
+      <span class="wc-arrow">→</span>
+      <span class="wc-hf ${cls}">HF ${fmt(hfFuture, 3)}</span>
+    </div>`;
+  }).join("");
+
+  // Days until HF = 1.0 at worst-case spread
+  const daysToLiq = spread > 0 ? Math.log(hf) / (spread / 100) * 365 : Infinity;
+  const daysStr   = daysToLiq > 3650 ? ">10 years" : `~${Math.round(daysToLiq)} days`;
+  const daysClass = daysToLiq < 30 ? "hf-bad" : daysToLiq < 90 ? "hf-warn" : "hf-ok";
+
+  body.innerHTML = `
+    <p class="wc-premise">If r_three kicks in and util stays at 99%:<br>
+      borrow ${fmt(borrowApr, 2)}%/yr · supply ${fmt(supplyApr, 2)}%/yr · spread <strong>${fmt(spread, 2)}%/yr</strong>
+    </p>
+    <div class="wc-rows">${rows}</div>
+    <p class="wc-liq">Liquidation in <span class="${daysClass}">${daysStr}</span> at this spread.</p>`;
+}
+
 // ── Leverage preview ──────────────────────────────────────────────────────────
 
 function updatePreview() {
@@ -1397,6 +1464,9 @@ function updatePreview() {
       ? `Add ${fmt(addAmt, 2)} ${selectedAsset.symbol} at ${lev.toFixed(1)}\u00D7`
       : "Add Funds";
   }
+
+  // Worst-case scenario panel (B14)
+  renderWorstCase(lev, hf, rs ?? null);
 }
 
 // ── Load data ─────────────────────────────────────────────────────────────────

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,6 +51,9 @@ import {
   type AssetPosition,
   type UserPositions,
   projectRates,
+  fetchPositionEvents,
+  type PositionEvent,
+  type PositionEventKind,
 } from "./blend.ts";
 
 import {
@@ -445,6 +448,94 @@ function renderTxHistory() {
       <a class="tx-history-link" href="https://stellar.expert/explorer/public/tx/${tx.hash}" target="_blank" rel="noopener">View</a>
     </div>`;
   }).join("");
+}
+
+// ── Position event timeline (A25) ─────────────────────────────────────────────
+
+const POS_EVENTS_MAX = 50;
+
+function posEventsKey(assetId: string, poolId: string) {
+  return `pos_events_${poolId}_${assetId}`;
+}
+
+function getPositionEvents(assetId: string, poolId: string): PositionEvent[] {
+  const raw = localStorage.getItem(posEventsKey(assetId, poolId));
+  return raw ? JSON.parse(raw) : [];
+}
+
+function savePositionEvents(assetId: string, poolId: string, events: PositionEvent[]) {
+  localStorage.setItem(posEventsKey(assetId, poolId), JSON.stringify(events.slice(0, POS_EVENTS_MAX)));
+}
+
+function recordPositionEvent(kind: PositionEventKind, hash: string, hf: number | null) {
+  const events = getPositionEvents(selectedAsset.id, selectedPool.id);
+  // Deduplicate by hash
+  if (events.some(e => e.hash === hash)) return;
+  events.unshift({ kind, hash, timestamp: Date.now(), hf });
+  savePositionEvents(selectedAsset.id, selectedPool.id, events);
+}
+
+function explorerTxUrl(hash: string): string {
+  const net = getActiveNetwork() === "testnet" ? "testnet" : "public";
+  return `https://stellar.expert/explorer/${net}/tx/${hash}`;
+}
+
+const EVENT_LABELS: Record<PositionEventKind, string> = {
+  open:      "Open",
+  rebalance: "Rebalance",
+  harvest:   "Harvest",
+  close:     "Close",
+};
+const EVENT_ICONS: Record<PositionEventKind, string> = {
+  open:      "⊕",
+  rebalance: "⇄",
+  harvest:   "✦",
+  close:     "⊗",
+};
+
+function renderPositionTimeline() {
+  const wrap = document.getElementById("position-timeline");
+  if (!wrap) return;
+  const events = getPositionEvents(selectedAsset.id, selectedPool.id);
+  if (events.length === 0) {
+    wrap.style.display = "none";
+    return;
+  }
+  wrap.style.display = "";
+  const list = document.getElementById("position-timeline-list")!;
+  list.innerHTML = events.map(ev => {
+    const d = new Date(ev.timestamp);
+    const localStr = d.toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" });
+    const utcStr   = d.toUTCString();
+    const hfStr    = ev.hf !== null ? ` · HF ${fmt(ev.hf, 3)}` : "";
+    const shortHash = ev.hash.slice(0, 8) + "…" + ev.hash.slice(-4);
+    return `<div class="pos-event-item pos-event-${ev.kind}">
+      <span class="pos-event-icon" aria-hidden="true">${EVENT_ICONS[ev.kind]}</span>
+      <span class="pos-event-label">${EVENT_LABELS[ev.kind]}</span>
+      <time class="pos-event-time" title="${utcStr}" datetime="${d.toISOString()}">${localStr}</time>
+      <span class="pos-event-hf">${hfStr}</span>
+      <a class="pos-event-link" href="${explorerTxUrl(ev.hash)}" target="_blank" rel="noopener">${shortHash}</a>
+    </div>`;
+  }).join("");
+}
+
+async function refreshTimelineFromChain() {
+  const events = await fetchPositionEvents(selectedPool, userAddress!, selectedAsset.id);
+  if (events.length === 0) return;
+  const stored = getPositionEvents(selectedAsset.id, selectedPool.id);
+  const storedHashes = new Set(stored.map(e => e.hash));
+  let changed = false;
+  for (const ev of events) {
+    if (!storedHashes.has(ev.hash)) {
+      stored.push(ev);
+      changed = true;
+    }
+  }
+  if (changed) {
+    stored.sort((a, b) => b.timestamp - a.timestamp);
+    savePositionEvents(selectedAsset.id, selectedPool.id, stored);
+    renderPositionTimeline();
+  }
 }
 
 // ── TX Stepper (#10) ─────────────────────────────────────────────────────────
@@ -1040,6 +1131,8 @@ function renderPosition() {
 
   // Compound row: show swap estimate if there's pending BLND
   updateCompoundEstimate();
+  // Position event timeline (A25)
+  renderPositionTimeline();
 }
 
 async function updateCompoundEstimate() {
@@ -1335,6 +1428,10 @@ async function loadAll() {
 
     renderSelectedAsset();
     startFreshnessTimer();
+    // Refresh timeline from chain in background (A25)
+    if (positions.byAsset.has(selectedAsset.id)) {
+      refreshTimelineFromChain().catch(() => {});
+    }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error("Failed to load pool data:", e);
@@ -1375,9 +1472,10 @@ async function openPosition() {
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
-    await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
+    const openHash = await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
+    recordPositionEvent("open", openHash, hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1));
     await loadAll();
   } catch (e: any) {
     markStepperError(2);
@@ -1403,8 +1501,9 @@ async function closePosition() {
   showTxStepper(["Close Position"]);
   try {
     const submitXdr = await buildCloseSubmitXdr(selectedPool, userAddress, pos);
-    await signAndSubmit(submitXdr, `Close ${selectedAsset.symbol} position`, 0);
+    const closeHash = await signAndSubmit(submitXdr, `Close ${selectedAsset.symbol} position`, 0);
     hideTxStepper();
+    recordPositionEvent("close", closeHash, null);
     removePnlEntry(selectedAsset.id, selectedPool.id);
     await loadAll();
   } catch (e: any) {
@@ -1494,8 +1593,9 @@ async function claimBlnd() {
   showTxStepper(["Claim BLND"]);
   try {
     const claimXdr = await buildClaimXdr(selectedPool, userAddress, tokenIds);
-    await signAndSubmit(claimXdr, "Claim BLND", 0);
+    const claimHash = await signAndSubmit(claimXdr, "Claim BLND", 0);
     hideTxStepper();
+    recordPositionEvent("harvest", claimHash, null);
     await loadAll();
   } catch (e: any) {
     markStepperError(1);
@@ -1530,10 +1630,12 @@ async function adjustLeverage() {
   try {
     if (targetLev > curLev) {
       const xdr = await buildIncreaseLeverageXdr(selectedPool, userAddress, liveAsset, pos, targetLev);
-      await signAndSubmit(xdr, `Increase leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      const h = await signAndSubmit(xdr, `Increase leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      recordPositionEvent("rebalance", h, hfForLeverage(targetLev, liveAsset.cFactor, rs?.lFactor ?? 1));
     } else {
       const xdr = await buildDecreaseLeverageXdr(selectedPool, userAddress, liveAsset, pos, targetLev);
-      await signAndSubmit(xdr, `Decrease leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      const h = await signAndSubmit(xdr, `Decrease leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
+      recordPositionEvent("rebalance", h, hfForLeverage(targetLev, liveAsset.cFactor, rs?.lFactor ?? 1));
     }
     hideTxStepper();
     await loadAll();
@@ -1650,7 +1752,8 @@ async function claimAndConvert() {
   try {
     // Claim
     const claimXdr = await buildClaimXdr(selectedPool, userAddress, tokenIds);
-    await signAndSubmit(claimXdr, "Claim BLND", 0);
+    const claimHash = await signAndSubmit(claimXdr, "Claim BLND", 0);
+    recordPositionEvent("harvest", claimHash, null);
 
     // Check actual BLND balance after claim
     const blndBalance = await fetchAssetBalance(userAddress, getBlndId());

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -93,6 +93,43 @@ let selectedPool: PoolDef        = getKnownPools()[0]; // default: Etherfuse
 let assets: AssetInfo[]          = getPoolAssets(selectedPool);
 let selectedAsset: AssetInfo     = assets[2]; // default: CETES (index 2 in Etherfuse)
 
+// ── Fee-adjusted APY (B2) ─────────────────────────────────────────────────────
+// Default: 12 rebalances/year (monthly). Each rebalance = 2 txs (approve + submit).
+// Per-tx fee = BASE_FEE = 100 stroops = 0.00001 XLM.
+// fee_drag_%/yr = (rebalances × 2 × 0.00001 × xlm_price) / equity_usd × 100
+
+const FEE_REBALANCES_KEY = "blendlev_rebalances_per_year";
+const FEE_REBALANCES_DEFAULT = 12;
+const BASE_FEE_XLM = 0.00001; // 100 stroops
+const TXS_PER_REBALANCE = 2;  // approve + submit
+
+function getRebalancesPerYear(): number {
+  const raw = localStorage.getItem(FEE_REBALANCES_KEY);
+  const n = raw ? parseInt(raw, 10) : FEE_REBALANCES_DEFAULT;
+  return isNaN(n) || n < 0 ? FEE_REBALANCES_DEFAULT : n;
+}
+
+function setRebalancesPerYear(n: number) {
+  localStorage.setItem(FEE_REBALANCES_KEY, String(n));
+}
+
+/** XLM price in USD — use live reserve price if available, else fallback. */
+function xlmPriceUsd(): number {
+  const xlmReserve = reserves.find(r => r.asset.symbol === "XLM");
+  return xlmReserve?.priceUsd ?? 0.10;
+}
+
+/**
+ * Annual fee drag as a percentage of equity.
+ * fee_drag = (rebalances × TXS_PER_REBALANCE × BASE_FEE_XLM × xlm_price) / equity_usd × 100
+ */
+function feeDragPct(equityUsd: number): number {
+  if (equityUsd <= 0) return 0;
+  const rebalances = getRebalancesPerYear();
+  const feeUsdPerYear = rebalances * TXS_PER_REBALANCE * BASE_FEE_XLM * xlmPriceUsd();
+  return (feeUsdPerYear / equityUsd) * 100;
+}
+
 // ── Network switching ────────────────────────────────────────────────────────
 
 async function switchNetwork(net: NetworkMode) {
@@ -1084,7 +1121,9 @@ function renderPosition() {
   const heroApyEl = $("hero-net-apy");
   if (rs && pos.leverage > 0) {
     const posNetApr = rs.netSupplyApr * pos.leverage - rs.netBorrowCost * (pos.leverage - 1);
-    const netApy = aprToApy(posNetApr);
+    const equityUsd = pos.equity * (rs.priceUsd || 1);
+    const drag = feeDragPct(equityUsd);
+    const netApy = aprToApy(posNetApr - drag);
     const apyIcon = netApy > 0 ? "\u2713" : "\u2717";
     netAprEl.textContent = `${apyIcon} ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}%`;
     netAprEl.className   = `metric-value ${netApy > 0 ? "hf-ok" : "hf-bad"}`;
@@ -1092,7 +1131,7 @@ function renderPosition() {
     heroApyEl.textContent = `${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}%`;
     heroApyEl.className   = `metric-hero-value ${netApy > 0 ? "hf-ok" : "hf-bad"}`;
     // Tooltips with actual APR
-    const aprTip = `Approximate APY — Blend interest does not auto-compound. Actual net APR: ${fmt(posNetApr, 2)}%`;
+    const aprTip = `Fee-adjusted APY. Net APR: ${fmt(posNetApr, 2)}% − fee drag: ${fmt(drag, 3)}%/yr (${getRebalancesPerYear()} rebalances/yr). Blend does not auto-compound.`;
     const posTip = $("pos-net-apr-tip");
     if (posTip) posTip.setAttribute("data-tip", aprTip);
     const heroTip = $("hero-net-apy-tip");
@@ -1372,12 +1411,15 @@ function updatePreview() {
   if (rs) {
     const proj = projectRates(rs, supply - oldSupply, borrow - oldBorrow);
     const netApr = proj.netSupplyApr * lev - proj.netBorrowCost * (lev - 1);
-    const netApy = aprToApy(netApr);
+    // Fee-adjusted APY (B2): subtract annualised XLM fee drag from net APR
+    const equityUsd = equity * (rs.priceUsd || 1);
+    const drag = feeDragPct(equityUsd);
+    const netApy = aprToApy(netApr - drag);
     $("prev-net-apr").textContent = `${fmt(netApy, 2)}% APY on equity`;
     $("prev-net-apr").className   = `prev-net-apr ${netApy > 0 ? "apr-great" : "apr-bad"}`;
     const prevTip = $("prev-net-tip");
     if (prevTip) prevTip.setAttribute("data-tip",
-      `Approximate APY — Blend interest does not auto-compound. Actual net APR: ${fmt(netApr, 2)}%`);
+      `Fee-adjusted APY. Net APR: ${fmt(netApr, 2)}% − fee drag: ${fmt(drag, 3)}%/yr (${getRebalancesPerYear()} rebalances × 2 txs × ${BASE_FEE_XLM} XLM @ $${fmt(xlmPriceUsd(), 3)}). Blend does not auto-compound.`);
 
     // Days until liquidation at this leverage (interest-only, no BLND)
     const spreadPct = proj.interestBorrowApr - proj.interestSupplyApr;
@@ -2195,6 +2237,17 @@ function toggleTheme() {
 }
 $("theme-toggle").addEventListener("click", toggleTheme);
 document.getElementById("mobile-theme-toggle")?.addEventListener("click", toggleTheme);
+
+// Rebalances/yr input (B2) — persist and re-render APY on change
+const rebalancesInput = $("rebalances-input") as HTMLInputElement;
+rebalancesInput.value = String(getRebalancesPerYear());
+rebalancesInput.addEventListener("change", () => {
+  const n = Math.max(0, Math.min(365, parseInt(rebalancesInput.value, 10) || 0));
+  rebalancesInput.value = String(n);
+  setRebalancesPerYear(n);
+  updatePreview();
+  renderPosition();
+});
 
 // Settings dropdown toggle
 $("settings-btn").addEventListener("click", (e) => {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -554,6 +554,27 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .tx-history-status-ok { color: var(--success); }
 .tx-history-status-err { color: var(--danger); }
 
+/* ── Position event timeline (A25) ──────────────────────────────────────── */
+
+.pos-timeline { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 10px; }
+.pos-timeline-list { max-height: 240px; overflow-y: auto; margin-top: 8px; }
+.pos-event-item {
+  display: grid;
+  grid-template-columns: 18px 70px 1fr auto auto;
+  align-items: center; gap: 6px;
+  padding: 6px 0; font-size: 12px; border-bottom: 1px solid var(--border);
+}
+.pos-event-item:last-child { border-bottom: none; }
+.pos-event-icon { font-size: 13px; text-align: center; }
+.pos-event-open    .pos-event-icon { color: var(--success); }
+.pos-event-close   .pos-event-icon { color: var(--danger); }
+.pos-event-rebalance .pos-event-icon { color: var(--primary); }
+.pos-event-harvest .pos-event-icon { color: var(--warning); }
+.pos-event-label { font-weight: 600; color: var(--text-2); }
+.pos-event-time { color: var(--text-3); font-family: var(--mono); font-size: 11px; cursor: help; }
+.pos-event-hf { color: var(--text-3); font-size: 11px; font-family: var(--mono); }
+.pos-event-link { color: var(--primary); font-size: 11px; font-family: var(--mono); white-space: nowrap; }
+
 /* ── Open form ───────────────────────────────────────────────────────────── */
 
 .form-group { margin-bottom: 16px; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -575,6 +575,25 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .pos-event-hf { color: var(--text-3); font-size: 11px; font-family: var(--mono); }
 .pos-event-link { color: var(--primary); font-size: 11px; font-family: var(--mono); white-space: nowrap; }
 
+/* ── Worst-case scenario panel (B14) ─────────────────────────────────────── */
+
+.worst-case-panel { margin-top: 10px; }
+.worst-case-summary {
+  font-size: 12px; color: var(--text-3); cursor: pointer; user-select: none;
+  list-style: none; font-weight: 600;
+}
+.worst-case-summary::-webkit-details-marker { display: none; }
+.worst-case-body { margin-top: 8px; font-size: 12px; }
+.wc-premise { color: var(--text-3); margin: 0 0 8px; line-height: 1.5; }
+.wc-premise strong { color: var(--text-2); }
+.wc-rows { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.wc-row { display: flex; align-items: center; gap: 8px; }
+.wc-days { color: var(--text-3); font-family: var(--mono); width: 28px; }
+.wc-arrow { color: var(--text-3); }
+.wc-hf { font-weight: 600; font-family: var(--mono); }
+.wc-liq { color: var(--text-3); margin: 0; }
+.wc-na { color: var(--text-3); font-size: 12px; }
+
 /* ── Open form ───────────────────────────────────────────────────────────── */
 
 .form-group { margin-bottom: 16px; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -217,6 +217,9 @@ body {
 }
 .settings-dropdown-item:hover { background: var(--tab-hover-bg); color: var(--text); }
 .settings-badge { font-size: 10px; padding: 1px 6px; border-radius: 99px; background: var(--surface2); color: var(--text-3); }
+.settings-fee-row { cursor: default; gap: 8px; }
+.settings-fee-row:hover { background: transparent; color: var(--text-2); }
+.settings-rebalances-input { width: 56px; padding: 3px 6px; font-size: 12px; text-align: right; }
 
 /* Legacy sidebar — hidden by default, used for mobile drawer */
 .sidebar { display: none; }


### PR DESCRIPTION
Include annualised XLM fee drag in displayed net APY.

## Formula (from doc.md)

fee_drag_%/yr = (rebalances × 2 txs × 0.00001 XLM × xlm_price) / equity_usd × 100
fee_adjusted_net_apy = aprToApy(netApr − fee_drag_%/yr)

## Changes

- **main.ts** — `feeDragPct()`: computes annual fee drag as % of equity.
  Uses live XLM reserve price when available, fallback $0.10.
  Applied to `prev-net-apr` (updatePreview) and `pos-net-apr` / `hero-net-apy` (renderPosition).
  Tooltip shows full breakdown: net APR, drag %, rebalances, XLM price.
- **index.html** — "Rebalances/yr" number input in settings dropdown.
  Default: 12 (monthly). Persists to localStorage. Updates APY on change.
- **style.css** — minimal styles for the new settings row.

## Acceptance criteria

- [x] Default rebalance frequency documented (12/yr = monthly, in code comment)
- [x] Input persists per user (localStorage key `blendlev_rebalances_per_year`)
- [x] APY math matches doc.md formula exactly

## Tested

`vite build` — 0 errors

Closes #29