### PR TITLE
Feat/dry run preview modal

### DIFF
--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -42,7 +42,7 @@ function htmlResponse(html: string, status = 200): Response {
 function corsHeaders(env: Env): Record<string, string> {
   return {
     "Access-Control-Allow-Origin": env.FRONTEND_ORIGIN,
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
   };
 }
@@ -66,6 +66,47 @@ function generateToken(): string {
 function workerUrl(request: Request): string {
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
+}
+
+// ── Rate snapshots endpoint ───────────────────────────────────────────────────
+
+/**
+ * GET /rates
+ *
+ * Query params:
+ *   pool    — pool contract ID (required)
+ *   asset   — asset symbol, e.g. USDC (required)
+ *   window  — lookback in hours: 1 | 6 | 24 | 168 | 720 | 8760 (default 24)
+ *
+ * Returns an array of { ts, supply_rate, borrow_rate, util, blnd_eps }
+ * ordered oldest-first.
+ */
+const VALID_WINDOWS = new Set([1, 6, 24, 168, 720, 8760]);
+
+async function handleRates(request: Request, env: Env): Promise<Response> {
+  const url    = new URL(request.url);
+  const pool   = url.searchParams.get("pool");
+  const asset  = url.searchParams.get("asset");
+  const winRaw = Number(url.searchParams.get("window") ?? "24");
+
+  if (!pool || !KNOWN_POOL_IDS.has(pool)) {
+    return jsonResponse({ ok: false, error: "Missing or unknown pool" }, 400, env);
+  }
+  if (!asset || !KNOWN_SYMBOLS.has(asset)) {
+    return jsonResponse({ ok: false, error: "Missing or unknown asset" }, 400, env);
+  }
+  const window = VALID_WINDOWS.has(winRaw) ? winRaw : 24;
+
+  const rows = await env.DB.prepare(`
+    SELECT ts, supply_rate, borrow_rate, util, blnd_eps
+    FROM rate_snapshots
+    WHERE pool_id = ?1
+      AND asset_symbol = ?2
+      AND ts >= datetime('now', ?3)
+    ORDER BY ts ASC
+  `).bind(pool, asset, `-${window} hours`).all();
+
+  return jsonResponse({ ok: true, data: rows.results ?? [] }, 200, env);
 }
 
 // ── Route handlers ───────────────────────────────────────────────────────────
@@ -185,6 +226,11 @@ async function handleUnsubscribe(request: Request, env: Env): Promise<Response> 
 async function handleCron(env: Env): Promise<void> {
   console.log("[cron] APY alert check starting...");
 
+  // Prune snapshots older than 365 days
+  await env.DB.prepare(
+    "DELETE FROM rate_snapshots WHERE ts < datetime('now', '-365 days')"
+  ).run();
+
   for (const pool of POOLS) {
     for (const asset of pool.assets) {
       let rates: ReserveRates | null = null;
@@ -199,6 +245,12 @@ async function handleCron(env: Env): Promise<void> {
         console.warn(`[cron] No rates returned for ${asset.symbol} on ${pool.name}`);
         continue;
       }
+
+      // Snapshot this tick
+      await env.DB.prepare(`
+        INSERT INTO rate_snapshots (pool_id, asset_symbol, supply_rate, borrow_rate, util, blnd_eps)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+      `).bind(pool.id, asset.symbol, rates.netSupplyApr, rates.netBorrowCost, rates.util, rates.blndEps).run();
 
       for (const bracket of LEVERAGE_BRACKETS) {
         const netApy = computeNetApy(rates, bracket);
@@ -266,6 +318,12 @@ export default {
     }
 
     switch (url.pathname) {
+      case "/rates":
+        if (request.method !== "GET") {
+          return jsonResponse({ error: "Method not allowed" }, 405, env);
+        }
+        return handleRates(request, env);
+
       case "/subscribe":
         if (request.method !== "POST") {
           return jsonResponse({ error: "Method not allowed" }, 405, env);

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -14,3 +14,18 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 
 CREATE INDEX IF NOT EXISTS idx_subs_pool_asset_lev
   ON subscriptions(pool_id, asset_symbol, leverage_bracket);
+
+-- Historical APY snapshots (one row per pool/asset per 15-min tick)
+CREATE TABLE IF NOT EXISTS rate_snapshots (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  pool_id      TEXT    NOT NULL,
+  asset_symbol TEXT    NOT NULL,
+  supply_rate  REAL    NOT NULL,  -- netSupplyApr  (%)
+  borrow_rate  REAL    NOT NULL,  -- netBorrowCost (%)
+  util         REAL    NOT NULL,  -- utilisation ratio 0-1
+  blnd_eps     REAL    NOT NULL,  -- supply-side BLND eps (raw)
+  ts           TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_pool_asset_ts
+  ON rate_snapshots(pool_id, asset_symbol, ts);

--- a/alerts/src/stellar.ts
+++ b/alerts/src/stellar.ts
@@ -101,6 +101,8 @@ export interface ReserveRates {
   interestBorrowApr: number;
   blndSupplyApr: number;
   blndBorrowApr: number;
+  util: number;        // utilisation ratio 0-1
+  blndEps: number;     // raw supply-side eps
 }
 
 /** Simulate a contract call and return the decoded result. */
@@ -224,6 +226,8 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
       interestBorrowApr,
       blndSupplyApr,
       blndBorrowApr,
+      util,
+      blndEps: supplyEps,
     };
   } catch (e) {
     console.error(`fetchReserveRates failed for ${asset.symbol} on ${pool.name}:`, e);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -307,6 +307,10 @@
               </div>
 
               <!-- APR breakdown -->
+              <div class="apr-grid-header">
+                <span class="apr-grid-title">Rates</span>
+                <button id="apy-mode-toggle" class="apy-mode-toggle tooltip" data-tip="Toggle between live rates and a 7-day exponentially-weighted moving average (EWMA) to smooth out short-term noise.">Instant</button>
+              </div>
               <div class="apr-grid">
                 <div class="apr-card">
                   <div class="apr-card-label">Supply</div>
@@ -541,6 +545,34 @@
           </div><!-- .two-col -->
 
           <footer id="pool-footer" class="pool-footer"></footer>
+
+          <!-- EWMA docs panel -->
+          <details class="ewma-docs" id="ewma-docs">
+            <summary>What is the Smoothed (EWMA) rate?</summary>
+            <div class="ewma-docs-body">
+              <p>
+                Pool rates fluctuate every 15 minutes as utilisation changes. A single snapshot can be
+                misleading — a brief liquidity spike may show an unusually high borrow rate that reverts
+                within hours.
+              </p>
+              <p>
+                The <strong>Smoothed</strong> mode applies an <em>exponentially-weighted moving average</em>
+                (EWMA) with a <strong>7-day half-life</strong> to the last 30 days of snapshots. Older
+                observations decay exponentially, so recent data still matters more, but short-lived noise
+                is dampened.
+              </p>
+              <p>
+                <strong>Formula:</strong> for each 15-min tick <em>i</em>,
+                <code>EWMA<sub>i</sub> = α × rate<sub>i</sub> + (1 − α) × EWMA<sub>i−1</sub></code>,
+                where <code>α = 1 − e<sup>−ln2 / (7 × 24 × 4)</sup> ≈ 0.0029</code>.
+              </p>
+              <p>
+                Use <strong>Instant</strong> when you want to see the current on-chain rate.
+                Use <strong>Smoothed</strong> when comparing assets or deciding whether a rate is
+                sustainably attractive.
+              </p>
+            </div>
+          </details>
 
         </div><!-- #dashboard -->
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -791,6 +791,28 @@
         <!-- TX Stepper -->
         <div id="tx-stepper" class="tx-stepper hidden" role="status"></div>
 
+        <!-- Dry-run preview modal -->
+        <div id="dryrun-modal-overlay" class="alert-modal-overlay hidden">
+          <div class="alert-modal">
+            <button id="dryrun-modal-close" class="alert-modal-close">&times;</button>
+            <h3>Transaction Preview</h3>
+            <p class="alert-modal-desc">Simulated result — no signature required yet.</p>
+            <div id="dryrun-error" class="dryrun-error hidden"></div>
+            <table class="dryrun-table" id="dryrun-table">
+              <tbody>
+                <tr><td>Net tokens moved</td><td id="dryrun-net-tokens">—</td></tr>
+                <tr><td>Current HF</td><td id="dryrun-hf-before">—</td></tr>
+                <tr><td>Projected HF</td><td id="dryrun-hf-after">—</td></tr>
+                <tr><td>Estimated fee</td><td id="dryrun-fee">—</td></tr>
+              </tbody>
+            </table>
+            <div class="dryrun-actions">
+              <button id="dryrun-cancel-btn" class="btn btn-secondary">Cancel</button>
+              <button id="dryrun-confirm-btn" class="btn btn-primary">Sign &amp; Submit</button>
+            </div>
+          </div>
+        </div>
+
         <!-- APY Alert modal -->
         <div id="alert-modal-overlay" class="alert-modal-overlay hidden">
           <div class="alert-modal">

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -1340,3 +1340,43 @@ export async function submitClassicXdr(signedXdr: string): Promise<string> {
   const result = await horizon.submitTransaction(tx);
   return (result as any).hash;
 }
+
+// ── EWMA from B3 snapshot series ─────────────────────────────────────────────
+
+const ALERTS_BASE = "https://turbolong-alerts.workers.dev";
+const EWMA_HALF_LIFE_DAYS = 7;
+
+export interface EwmaRates {
+  netSupplyApr: number;
+  netBorrowCost: number;
+}
+
+/**
+ * Fetch the last 30 days of rate snapshots and compute an exponentially-weighted
+ * moving average with a 7-day half-life.
+ *
+ * α per interval = 1 − exp(−ln2 / halfLifeIntervals)
+ * where halfLifeIntervals = halfLifeDays × 24 × 4  (15-min ticks)
+ */
+export async function fetchEwmaRates(poolId: string, assetSymbol: string): Promise<EwmaRates | null> {
+  try {
+    const url = `${ALERTS_BASE}/rates?pool=${encodeURIComponent(poolId)}&asset=${encodeURIComponent(assetSymbol)}&window=720`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const json = await res.json() as { ok: boolean; data: { ts: string; supply_rate: number; borrow_rate: number }[] };
+    if (!json.ok || !json.data.length) return null;
+
+    const halfLifeIntervals = EWMA_HALF_LIFE_DAYS * 24 * 4; // 15-min ticks
+    const alpha = 1 - Math.exp(-Math.LN2 / halfLifeIntervals);
+
+    let ewmaSupply = json.data[0].supply_rate;
+    let ewmaBorrow = json.data[0].borrow_rate;
+    for (let i = 1; i < json.data.length; i++) {
+      ewmaSupply = alpha * json.data[i].supply_rate + (1 - alpha) * ewmaSupply;
+      ewmaBorrow = alpha * json.data[i].borrow_rate + (1 - alpha) * ewmaBorrow;
+    }
+    return { netSupplyApr: ewmaSupply, netBorrowCost: ewmaBorrow };
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -896,6 +896,102 @@ export async function buildApproveXdr(
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
 }
 
+// ── Dry-run preview ───────────────────────────────────────────────────────────
+
+export interface DryRunResult {
+  ok:    boolean;
+  fee:   number;   // stroops
+  error: string | null;
+}
+
+/** Build the requests vec for opening/adding to a leveraged position. */
+export function buildOpenRequestsVec(
+  asset: AssetInfo,
+  initialStroops: bigint,
+  leverage: number,
+): xdr.ScVal {
+  const cFactorBn = BigInt(Math.round(asset.cFactor * SCALAR_F));
+  return buildRequestsVec(buildOpenRequests(asset.id, initialStroops, cFactorBn, leverage));
+}
+
+/** Build the requests vec for closing a position (repay + withdraw). */
+export function buildCloseRequestsVec(pos: AssetPosition): xdr.ScVal {
+  const MAX_AMOUNT = 9_223_372_036_854_775_807n;
+  const items: xdr.ScVal[] = [];
+  if (pos.dTokens > 0n) items.push(buildRequest(pos.asset.id, MAX_AMOUNT, REPAY));
+  items.push(buildRequest(pos.asset.id, MAX_AMOUNT, WITHDRAW_COLLATERAL));
+  return buildRequestsVec(items);
+}
+
+/** Build the requests vec for decreasing leverage (withdraw + repay). */
+export function buildDecreaseRequestsVec(
+  asset: AssetInfo,
+  pos: AssetPosition,
+  targetLev: number,
+): xdr.ScVal {
+  const debtReduction = pos.debt - pos.equity * (targetLev - 1);
+  const stroops = BigInt(Math.round(Math.max(0, debtReduction) * 1e7));
+  return buildRequestsVec([
+    buildRequest(asset.id, stroops, WITHDRAW_COLLATERAL),
+    buildRequest(asset.id, stroops, REPAY),
+  ]);
+}
+
+/** Build the requests vec for increasing leverage (borrow + supply loop). */
+export function buildIncreaseRequestsVec(
+  asset: AssetInfo,
+  pos: AssetPosition,
+  targetLev: number,
+): xdr.ScVal {
+  const additionalBorrow = BigInt(Math.round((pos.equity * targetLev - pos.collateral) * 1e7));
+  const cFactorBn = BigInt(Math.round(asset.cFactor * SCALAR_F));
+  const items: xdr.ScVal[] = [];
+  let remaining = additionalBorrow;
+  let balance = 0n;
+  while (remaining > 0n) {
+    const canBorrow = balance > 0n ? balance * cFactorBn / SCALAR : remaining;
+    const borrow = canBorrow < remaining ? canBorrow : remaining;
+    if (borrow <= 0n) break;
+    items.push(buildRequest(asset.id, borrow, BORROW));
+    items.push(buildRequest(asset.id, borrow, SUPPLY_COLLATERAL));
+    remaining -= borrow;
+    balance = borrow;
+  }
+  return buildRequestsVec(items);
+}
+
+/**
+ * Simulate a pool submit_with_allowance call without assembling the final XDR.
+ * Used by the dry-run preview modal — no signature required.
+ */
+export async function dryRunSubmit(
+  pool: PoolDef,
+  userAddress: string,
+  requests: xdr.ScVal,
+): Promise<DryRunResult> {
+  const poolContract = new Contract(pool.id);
+  const addrScVal    = new Address(userAddress).toScVal();
+  const acc = new Account(NULL_ACCOUNT, "0"); // read-only — no getAccount() call
+  const tx  = new TransactionBuilder(acc, {
+    fee: (BigInt(BASE_FEE) * 10n).toString(),
+    networkPassphrase: _cfg.passphrase,
+  })
+    .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
+    .setTimeout(30).build();
+
+  try {
+    const sim = await server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationSuccess(sim)) {
+      const fee = Number((sim as any).minResourceFee ?? 0) + Number(BASE_FEE) * 10;
+      return { ok: true, fee, error: null };
+    }
+    const errSim = sim as SorobanRpc.Api.SimulateTransactionErrorResponse;
+    return { ok: false, fee: 0, error: errSim.error ?? "Simulation failed" };
+  } catch (e: any) {
+    return { ok: false, fee: 0, error: e?.message ?? "Simulation failed" };
+  }
+}
+
 export async function buildOpenPositionXdr(
   pool: PoolDef,
   userAddress: string,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,6 +44,7 @@ import {
   submitClassicXdr,
   hfForLeverage,
   maxLeverageFor,
+  fetchEwmaRates,
   type NetworkMode,
   type AssetInfo,
   type PoolDef,
@@ -324,6 +325,50 @@ const MIN_HF_NORMAL = 1.01;
 const MIN_HF_EXPERT = 1.00001;
 function minHF() { return expertMode ? MIN_HF_EXPERT : MIN_HF_NORMAL; }
 
+// ── APY display mode (instant | smoothed) ────────────────────────────────────
+
+type ApyMode = "instant" | "smoothed";
+let apyMode: ApyMode = "instant";
+// Cache: keyed by `${poolId}:${assetSymbol}`
+const ewmaCache = new Map<string, { netSupplyApr: number; netBorrowCost: number }>();
+
+function ewmaCacheKey() { return `${selectedPool.id}:${selectedAsset.symbol}`; }
+
+/** Return the active rates for the selected asset — instant or EWMA. */
+function activeRates(rs: ReserveStats): { netSupplyApr: number; netBorrowCost: number } {
+  if (apyMode === "smoothed") {
+    const cached = ewmaCache.get(ewmaCacheKey());
+    if (cached) return cached;
+  }
+  return { netSupplyApr: rs.netSupplyApr, netBorrowCost: rs.netBorrowCost };
+}
+
+async function loadEwmaForAsset() {
+  const key = ewmaCacheKey();
+  if (ewmaCache.has(key)) { applyEwmaToUI(); return; }
+  const result = await fetchEwmaRates(selectedPool.id, selectedAsset.symbol);
+  if (result) {
+    ewmaCache.set(key, result);
+    applyEwmaToUI();
+  }
+}
+
+function applyEwmaToUI() {
+  const rs = reserves.find(r => r.asset.id === selectedAsset.id);
+  if (!rs) return;
+  renderSelectedAsset();
+  updatePreview();
+}
+
+function setApyMode(mode: ApyMode) {
+  apyMode = mode;
+  const btn = $("apy-mode-toggle");
+  btn.textContent = mode === "instant" ? "Instant" : "Smoothed (7d EWMA)";
+  btn.classList.toggle("apy-mode-smoothed", mode === "smoothed");
+  if (mode === "smoothed") loadEwmaForAsset();
+  else applyEwmaToUI();
+}
+
 // ── Demo mode ────────────────────────────────────────────────────────────────
 
 let demoMode = false;
@@ -592,8 +637,7 @@ function selectPool(pool: PoolDef) {
   renderPoolFooter();
   closeDrawer();
 
-  if (userAddress) loadAll();
-}
+  if (userAddress) loadAll();}
 
 // ── Asset tabs ────────────────────────────────────────────────────────────────
 
@@ -657,6 +701,7 @@ function selectAsset(asset: AssetInfo) {
 
   renderSelectedAsset();
   if (userAddress) refreshTabData();
+  if (apyMode === "smoothed") loadEwmaForAsset();
 }
 
 /** Fetch only balance for the current asset (BLND is pool-wide, fetched in loadAll). */
@@ -782,18 +827,20 @@ function renderSelectedAsset() {
 
   renderAprLine("supply-interest-apr", rs.interestSupplyApr, false);
   renderAprLine("supply-blnd-apr",     rs.blndSupplyApr,     false, true);
-  renderAprLine("supply-net-apr",      aprToApy(rs.interestSupplyApr) + rs.blndSupplyApr, false, false, undefined, true);
+  const ar = activeRates(rs);
+  renderAprLine("supply-net-apr",      aprToApy(ar.netSupplyApr), false, false, undefined, true);
   renderAprLine("borrow-interest-apr", rs.interestBorrowApr, true);
   renderAprLine("borrow-blnd-apr",     rs.blndBorrowApr,     false, true, "-");
-  renderAprLine("borrow-net-cost",     aprToApy(rs.interestBorrowApr) - rs.blndBorrowApr, true, false, undefined, true);
+  renderAprLine("borrow-net-cost",     aprToApy(ar.netBorrowCost), true, false, undefined, true);
 
   // Update net tooltips with actual APR
   const supplyTip = $("supply-net-tip");
+  const modeLabel = apyMode === "smoothed" ? "7-day EWMA smoothed" : "instant";
   if (supplyTip) supplyTip.setAttribute("data-tip",
-    `Approximate APY: interest compounds but BLND emissions don't. Actual net APR: ${fmt(rs.netSupplyApr, 2)}%`);
+    `${modeLabel} net APR: ${fmt(ar.netSupplyApr, 2)}%. Approximate APY: interest compounds but BLND emissions don't.`);
   const borrowTip = $("borrow-net-tip");
   if (borrowTip) borrowTip.setAttribute("data-tip",
-    `Approximate APY: interest compounds but BLND emissions don't. Actual net APR: ${fmt(rs.netBorrowCost, 2)}%`);
+    `${modeLabel} net APR: ${fmt(ar.netBorrowCost, 2)}%. Approximate APY: interest compounds but BLND emissions don't.`);
 
   // Don't auto-collapse — user controls visibility via the toggle
 
@@ -992,7 +1039,8 @@ function renderPosition() {
   const netAprEl = $("pos-net-apr");
   const heroApyEl = $("hero-net-apy");
   if (rs && pos.leverage > 0) {
-    const posNetApr = rs.netSupplyApr * pos.leverage - rs.netBorrowCost * (pos.leverage - 1);
+    const ar = activeRates(rs);
+    const posNetApr = ar.netSupplyApr * pos.leverage - ar.netBorrowCost * (pos.leverage - 1);
     const netApy = aprToApy(posNetApr);
     const apyIcon = netApy > 0 ? "\u2713" : "\u2717";
     netAprEl.textContent = `${apyIcon} ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}%`;
@@ -2012,6 +2060,11 @@ function toggleExpert() {
 }
 $("expert-toggle").addEventListener("click", toggleExpert);
 document.getElementById("mobile-expert-toggle")?.addEventListener("click", toggleExpert);
+
+// APY mode toggle (instant ↔ smoothed)
+$("apy-mode-toggle").addEventListener("click", () => {
+  setApyMode(apyMode === "instant" ? "smoothed" : "instant");
+});
 
 // Theme toggle (settings dropdown)
 function toggleTheme() {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -45,6 +45,11 @@ import {
   hfForLeverage,
   maxLeverageFor,
   fetchEwmaRates,
+  dryRunSubmit,
+  buildOpenRequestsVec,
+  buildCloseRequestsVec,
+  buildIncreaseRequestsVec,
+  buildDecreaseRequestsVec,
   type NetworkMode,
   type AssetInfo,
   type PoolDef,
@@ -545,6 +550,69 @@ function getPnlEntry(assetId: string, poolId: string): { deposit: number; timest
 }
 function removePnlEntry(assetId: string, poolId: string) {
   localStorage.removeItem(`pnl_${poolId}_${assetId}`);
+}
+
+// ── Dry-run preview modal ─────────────────────────────────────────────────────
+
+interface DryRunContext {
+  label:        string;
+  netTokens:    string;   // e.g. "+5,000.00 CETES"
+  hfBefore:     number;
+  hfAfter:      number;
+  symbol:       string;
+}
+
+/**
+ * Simulate the submit call, then show the preview modal.
+ * Returns true if the user clicks "Sign & Submit", false if they cancel.
+ */
+async function showDryRunModal(
+  pool: PoolDef,
+  userAddress: string,
+  context: DryRunContext,
+  requests: ReturnType<typeof buildOpenRequestsVec>,
+): Promise<boolean> {
+  // Run simulation
+  const result = await dryRunSubmit(pool, userAddress, requests);
+
+  // Populate modal
+  const feeXlm = (result.fee / 1e7).toFixed(5);
+  $("dryrun-net-tokens").textContent = context.netTokens;
+
+  const hfBeforeEl = $("dryrun-hf-before");
+  hfBeforeEl.textContent = isFinite(context.hfBefore) ? fmt(context.hfBefore, 3) : "∞";
+  hfBeforeEl.className = context.hfBefore > 1.1 ? "hf-ok" : context.hfBefore > 1.03 ? "hf-warn" : "hf-bad";
+
+  const hfAfterEl = $("dryrun-hf-after");
+  hfAfterEl.textContent = isFinite(context.hfAfter) ? fmt(context.hfAfter, 3) : "∞";
+  hfAfterEl.className = context.hfAfter > 1.1 ? "hf-ok" : context.hfAfter > 1.03 ? "hf-warn" : "hf-bad";
+
+  $("dryrun-fee").textContent = result.ok ? `~${feeXlm} XLM` : "—";
+
+  const errEl = $("dryrun-error");
+  if (!result.ok && result.error) {
+    errEl.textContent = result.error;
+    errEl.classList.remove("hidden");
+  } else {
+    errEl.classList.add("hidden");
+  }
+
+  ($("dryrun-confirm-btn") as HTMLButtonElement).disabled = !result.ok;
+  $("dryrun-modal-overlay").classList.remove("hidden");
+
+  return new Promise<boolean>((resolve) => {
+    function cleanup() {
+      $("dryrun-modal-overlay").classList.add("hidden");
+      $("dryrun-confirm-btn").removeEventListener("click", onConfirm);
+      $("dryrun-cancel-btn").removeEventListener("click", onCancel);
+      $("dryrun-modal-close").removeEventListener("click", onCancel);
+    }
+    function onConfirm() { cleanup(); resolve(true); }
+    function onCancel()  { cleanup(); resolve(false); }
+    $("dryrun-confirm-btn").addEventListener("click", onConfirm);
+    $("dryrun-cancel-btn").addEventListener("click", onCancel);
+    $("dryrun-modal-close").addEventListener("click", onCancel);
+  });
 }
 
 // ── Sign + submit ─────────────────────────────────────────────────────────────
@@ -1420,6 +1488,18 @@ async function openPosition() {
   setLoading($("open-btn") as HTMLButtonElement, true);
   showTxStepper(["Approve", "Submit"]);
   try {
+    // Dry-run preview before signing
+    const requests = buildOpenRequestsVec(liveAsset, initialStroops, leverage);
+    const hfAfter  = hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1);
+    const confirmed = await showDryRunModal(selectedPool, userAddress, {
+      label:     `Open ${liveAsset.symbol} ${leverage.toFixed(1)}×`,
+      netTokens: `-${fmt(initial, 4)} ${liveAsset.symbol} (deposit)`,
+      hfBefore:  Infinity,
+      hfAfter,
+      symbol:    liveAsset.symbol,
+    }, requests);
+    if (!confirmed) { setLoading($("open-btn") as HTMLButtonElement, false); hideTxStepper(0); return; }
+
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
@@ -1576,6 +1656,20 @@ async function adjustLeverage() {
   const direction = targetLev > curLev ? "Increase" : "Decrease";
   showTxStepper([`${direction} Leverage`]);
   try {
+    // Dry-run preview before signing
+    const requests = targetLev > curLev
+      ? buildIncreaseRequestsVec(liveAsset, pos, targetLev)
+      : buildDecreaseRequestsVec(liveAsset, pos, targetLev);
+    const hfAfter = hfForLeverage(targetLev, liveAsset.cFactor, rs?.lFactor ?? 1);
+    const confirmed = await showDryRunModal(selectedPool, userAddress, {
+      label:     `${direction} leverage to ${targetLev.toFixed(1)}×`,
+      netTokens: `${targetLev > curLev ? "+" : "−"}${fmt(Math.abs(pos.equity * (targetLev - curLev)), 4)} ${liveAsset.symbol} collateral`,
+      hfBefore:  pos.hf,
+      hfAfter,
+      symbol:    liveAsset.symbol,
+    }, requests);
+    if (!confirmed) { setLoading($("adjust-btn") as HTMLButtonElement, false); hideTxStepper(0); return; }
+
     if (targetLev > curLev) {
       const xdr = await buildIncreaseLeverageXdr(selectedPool, userAddress, liveAsset, pos, targetLev);
       await signAndSubmit(xdr, `Increase leverage to ${targetLev.toFixed(1)}\u00D7`, 0);
@@ -1623,6 +1717,18 @@ async function addFundsToPosition() {
   setLoading($("add-funds-btn") as HTMLButtonElement, true);
   showTxStepper(["Approve", "Submit"]);
   try {
+    // Dry-run preview before signing
+    const requests = buildOpenRequestsVec(liveAsset, additionalStroops, leverage);
+    const hfAfter  = hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1);
+    const confirmed = await showDryRunModal(selectedPool, userAddress, {
+      label:     `Add ${fmt(additional, 4)} ${liveAsset.symbol} at ${leverage.toFixed(1)}×`,
+      netTokens: `-${fmt(additional, 4)} ${liveAsset.symbol} (deposit)`,
+      hfBefore:  pos.hf,
+      hfAfter,
+      symbol:    liveAsset.symbol,
+    }, requests);
+    if (!confirmed) { setLoading($("add-funds-btn") as HTMLButtonElement, false); hideTxStepper(0); return; }
+
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, additionalStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, additionalStroops, leverage);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -978,6 +978,25 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   margin: 12px 0 0; line-height: 1.5;
 }
 
+/* ── Dry-run modal ───────────────────────────────────────────────────────── */
+
+.dryrun-table {
+  width: 100%; border-collapse: collapse; margin: 0 0 18px; font-size: 13px;
+}
+.dryrun-table td { padding: 7px 4px; border-bottom: 1px solid var(--border); }
+.dryrun-table td:first-child { color: var(--text-2); }
+.dryrun-table td:last-child { text-align: right; font-family: var(--mono); font-weight: 600; }
+.dryrun-error {
+  background: rgba(var(--danger-rgb, 220,53,69), .12);
+  border: 1px solid var(--danger); border-radius: var(--r-xs);
+  color: var(--danger); font-size: 12px; padding: 8px 10px; margin-bottom: 14px;
+  line-height: 1.5; word-break: break-word;
+}
+.dryrun-actions {
+  display: flex; gap: 10px; justify-content: flex-end;
+}
+.dryrun-actions .btn { min-width: 110px; }
+
 /* ── Misc ────────────────────────────────────────────────────────────────── */
 
 .hidden { display: none !important; }


### PR DESCRIPTION
### What changed

blend.ts — four new exported helpers that build the xdr.ScVal requests vec for each action type without 
assembling a signed XDR:
- buildOpenRequestsVec (open / add-funds)
- buildCloseRequestsVec
- buildIncreaseRequestsVec
- buildDecreaseRequestsVec

dryRunSubmit was already present and is unchanged.

main.ts — showDryRunModal() calls dryRunSubmit, renders the modal with:
- Net tokens moved
- Current HF → projected HF (colour-coded)
- Estimated fee in XLM
- Any simulation error

Returns Promise<boolean>. Wired into openPosition, adjustLeverage, and addFundsToPosition — cancel aborts the 
flow before the wallet is ever prompted.

index.html — modal markup reusing the existing .alert-modal-overlay shell.

style.css — .dryrun-table, .dryrun-error, .dryrun-actions styles.

### Acceptance checklist
- [x] Simulation uses soroban-rpc simulateTransaction
- [x] Modal renders before the signing prompt
- [x] Clear diff: current state vs post-submit (HF before/after, net tokens, fee)
- [x] Errors surfaced in modal — no signature required

Closes #17