### PR TITLE
feat: E3 rate-spike alerts

### DIFF
--- a/alerts/src/email.ts
+++ b/alerts/src/email.ts
@@ -100,3 +100,53 @@ export async function sendApyAlert(
     html,
   );
 }
+
+export async function sendRateSpikeAlert(
+  env: Env,
+  to: string,
+  opts: {
+    poolName: string;
+    assetSymbol: string;
+    borrowAprBefore: number;
+    borrowAprAfter: number;
+    deltapp: number;
+    thresholdPp: number;
+    unsubscribeUrl: string;
+    appUrl: string;
+  },
+): Promise<SendResult> {
+  const { poolName, assetSymbol, borrowAprBefore, borrowAprAfter, deltapp, thresholdPp, unsubscribeUrl, appUrl } = opts;
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 16px; color: #1a1a2e;">
+  <h2 style="margin: 0 0 8px; color: #FF4D6A;">&#9889; Borrow Rate Spike</h2>
+  <p style="font-size: 14px; color: #555; margin: 0 0 20px;">${assetSymbol} on ${poolName} — borrow rate jumped <strong>+${deltapp.toFixed(2)}pp</strong> in the last 15 minutes (threshold: ${thresholdPp.toFixed(1)}pp).</p>
+
+  <div style="background: #f8f8fc; border-radius: 8px; padding: 16px; margin-bottom: 20px;">
+    <table style="width: 100%; font-size: 14px; border-collapse: collapse;">
+      <tr><td style="padding: 4px 0; color: #555;">Borrow APR before</td><td style="padding: 4px 0; text-align: right; font-weight: 600;">${borrowAprBefore.toFixed(2)}%</td></tr>
+      <tr><td style="padding: 4px 0; color: #555;">Borrow APR now</td><td style="padding: 4px 0; text-align: right; font-weight: 600; color: #FF4D6A;">${borrowAprAfter.toFixed(2)}%</td></tr>
+      <tr style="border-top: 1px solid #e0e0e8;"><td style="padding: 8px 0 4px; font-weight: 600;">Change</td><td style="padding: 8px 0 4px; text-align: right; font-weight: 700; color: #FF4D6A;">+${deltapp.toFixed(2)}pp</td></tr>
+    </table>
+  </div>
+
+  <p style="line-height: 1.6; color: #555;">A sudden rate spike may indicate high pool utilization or unusual activity. Review your position.</p>
+
+  <a href="${appUrl}" style="display: inline-block; margin: 16px 0; padding: 12px 28px; background: #2DE8A3; color: #0B0E14; text-decoration: none; border-radius: 8px; font-weight: 600;">Open Turbolong</a>
+
+  <p style="font-size: 12px; color: #aaa; margin-top: 32px;">
+    <a href="${unsubscribeUrl}" style="color: #aaa;">Unsubscribe</a> from rate-spike alerts.
+  </p>
+</body>
+</html>`.trim();
+
+  return sendEmail(
+    env,
+    to,
+    `\u26A1 Rate spike: ${assetSymbol} borrow +${deltapp.toFixed(2)}pp on ${poolName}`,
+    html,
+  );
+}

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -11,7 +11,7 @@
  */
 
 import { POOLS, LEVERAGE_BRACKETS, POOL_NAMES, fetchReserveRates, computeNetApy, type ReserveRates } from "./stellar.ts";
-import { sendVerificationEmail, sendApyAlert } from "./email.ts";
+import { sendVerificationEmail, sendApyAlert, sendRateSpikeAlert } from "./email.ts";
 
 interface Env {
   DB: D1Database;
@@ -180,6 +180,47 @@ async function handleUnsubscribe(request: Request, env: Env): Promise<Response> 
 </html>`);
 }
 
+// ── Rate-spike subscription handler (E3) ─────────────────────────────────────
+
+async function handleSubscribeSpike(request: Request, env: Env): Promise<Response> {
+  let body: any;
+  try { body = await request.json(); } catch {
+    return jsonResponse({ ok: false, error: "Invalid JSON" }, 400, env);
+  }
+
+  const { email, pool_id, asset_symbol, threshold_pp = 2.0 } = body;
+
+  if (!email || !EMAIL_RE.test(email))       return jsonResponse({ ok: false, error: "Invalid email" }, 400, env);
+  if (!KNOWN_POOL_IDS.has(pool_id))          return jsonResponse({ ok: false, error: "Unknown pool" }, 400, env);
+  if (!KNOWN_SYMBOLS.has(asset_symbol))      return jsonResponse({ ok: false, error: "Unknown asset" }, 400, env);
+  const thr = Number(threshold_pp);
+  if (isNaN(thr) || thr <= 0 || thr > 100)  return jsonResponse({ ok: false, error: "threshold_pp must be 0–100" }, 400, env);
+
+  const verifyToken = generateToken();
+  const unsubToken  = generateToken();
+
+  try {
+    await env.DB.prepare(`
+      INSERT INTO rate_spike_subscriptions (email, pool_id, asset_symbol, threshold_pp, verify_token, unsub_token)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+      ON CONFLICT(email, pool_id, asset_symbol) DO UPDATE
+        SET threshold_pp = ?4, verify_token = ?5, unsub_token = ?6, verified = 0
+    `).bind(email, pool_id, asset_symbol, thr, verifyToken, unsubToken).run();
+  } catch (e: any) {
+    console.error("DB insert failed:", e);
+    return jsonResponse({ ok: false, error: "Database error" }, 500, env);
+  }
+
+  const verifyUrl = `${workerUrl(request)}/verify?token=${verifyToken}`;
+  const result = await sendVerificationEmail(
+    { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
+    email, verifyUrl,
+  );
+  if (!result.ok) return jsonResponse({ ok: false, error: "Failed to send verification email" }, 500, env);
+
+  return jsonResponse({ ok: true, message: "Check your email to verify your rate-spike subscription." }, 200, env);
+}
+
 // ── Cron handler ─────────────────────────────────────────────────────────────
 
 async function handleCron(env: Env): Promise<void> {
@@ -200,6 +241,68 @@ async function handleCron(env: Env): Promise<void> {
         continue;
       }
 
+      // ── E3: record snapshot and check for rate spikes ─────────────────────
+      const currentBorrowApr = rates.interestBorrowApr;
+
+      // Store snapshot
+      await env.DB.prepare(
+        "INSERT INTO rate_snapshots (pool_id, asset_symbol, borrow_apr) VALUES (?1, ?2, ?3)"
+      ).bind(pool.id, asset.symbol, currentBorrowApr).run();
+
+      // Prune snapshots older than 24h
+      await env.DB.prepare(
+        "DELETE FROM rate_snapshots WHERE pool_id = ?1 AND asset_symbol = ?2 AND recorded_at < datetime('now', '-24 hours')"
+      ).bind(pool.id, asset.symbol).run();
+
+      // Get the snapshot from ~15 min ago (the previous cron tick)
+      const prevSnap = await env.DB.prepare(`
+        SELECT borrow_apr FROM rate_snapshots
+        WHERE pool_id = ?1 AND asset_symbol = ?2
+          AND recorded_at <= datetime('now', '-14 minutes')
+        ORDER BY recorded_at DESC LIMIT 1
+      `).bind(pool.id, asset.symbol).first<{ borrow_apr: number }>();
+
+      if (prevSnap) {
+        const deltapp = currentBorrowApr - prevSnap.borrow_apr;
+
+        if (deltapp > 0) {
+          // Find verified spike subscribers whose threshold is exceeded and haven't been alerted in 1h
+          const spikeSubs = await env.DB.prepare(`
+            SELECT id, email, unsub_token, threshold_pp
+            FROM rate_spike_subscriptions
+            WHERE pool_id = ?1 AND asset_symbol = ?2 AND verified = 1
+              AND threshold_pp <= ?3
+              AND (last_alerted_at IS NULL OR last_alerted_at < datetime('now', '-1 hour'))
+          `).bind(pool.id, asset.symbol, deltapp).all();
+
+          for (const sub of spikeSubs.results ?? []) {
+            const unsubUrl = `https://turbolong-alerts.workers.dev/unsubscribe?token=${sub.unsub_token}`;
+            const result = await sendRateSpikeAlert(
+              { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
+              sub.email as string,
+              {
+                poolName: pool.name,
+                assetSymbol: asset.symbol,
+                borrowAprBefore: prevSnap.borrow_apr,
+                borrowAprAfter: currentBorrowApr,
+                deltapp,
+                thresholdPp: sub.threshold_pp as number,
+                unsubscribeUrl: unsubUrl,
+                appUrl: env.FRONTEND_ORIGIN,
+              },
+            );
+            if (result.ok) {
+              await env.DB.prepare(
+                "UPDATE rate_spike_subscriptions SET last_alerted_at = datetime('now') WHERE id = ?1"
+              ).bind(sub.id).run();
+            } else {
+              console.error(`[cron] Failed to send spike alert to ${sub.email}:`, result.error);
+            }
+          }
+        }
+      }
+
+      // ── Existing APY alert logic ───────────────────────────────────────────
       for (const bracket of LEVERAGE_BRACKETS) {
         const netApy = computeNetApy(rates, bracket);
 
@@ -271,6 +374,12 @@ export default {
           return jsonResponse({ error: "Method not allowed" }, 405, env);
         }
         return handleSubscribe(request, env);
+
+      case "/subscribe-spike":
+        if (request.method !== "POST") {
+          return jsonResponse({ error: "Method not allowed" }, 405, env);
+        }
+        return handleSubscribeSpike(request, env);
 
       case "/verify":
         return handleVerify(request, env);

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -14,3 +14,33 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 
 CREATE INDEX IF NOT EXISTS idx_subs_pool_asset_lev
   ON subscriptions(pool_id, asset_symbol, leverage_bracket);
+
+-- E3: rate-spike subscriptions
+CREATE TABLE IF NOT EXISTS rate_spike_subscriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  pool_id TEXT NOT NULL,
+  asset_symbol TEXT NOT NULL,
+  threshold_pp REAL NOT NULL DEFAULT 2.0,  -- percentage-point jump to trigger alert
+  verified INTEGER DEFAULT 0,
+  verify_token TEXT,
+  unsub_token TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  last_alerted_at TEXT,
+  UNIQUE(email, pool_id, asset_symbol)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spike_subs_pool_asset
+  ON rate_spike_subscriptions(pool_id, asset_symbol);
+
+-- E3: borrow rate snapshots (one row per pool/asset per cron tick, kept 24h)
+CREATE TABLE IF NOT EXISTS rate_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pool_id TEXT NOT NULL,
+  asset_symbol TEXT NOT NULL,
+  borrow_apr REAL NOT NULL,
+  recorded_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_pool_asset_time
+  ON rate_snapshots(pool_id, asset_symbol, recorded_at);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -435,7 +435,10 @@
                     <span>Borrow headroom</span><strong id="prev-headroom" class="mono">—</strong>
                   </div>
                   <div class="preview-row preview-net-apr">
-                    <span>Est. net APY <span class="tooltip" id="prev-net-tip" data-tip="">?</span></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
+                    <span>Current pool APY</span><strong id="prev-pool-apy" class="prev-net-apr">—</strong>
+                  </div>
+                  <div class="preview-row preview-net-apr">
+                    <span>Projected APY after deposit <span class="tooltip" id="prev-net-tip" data-tip="">?</span></span><strong id="prev-net-apr" class="prev-net-apr">—</strong>
                   </div>
                   <div class="preview-row">
                     <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -339,6 +339,18 @@
                   </div>
                 </div>
               </div>
+              <!-- APY history chart (B4) -->
+              <div class="hist-chart-wrap">
+                <div class="hist-chart-header">
+                  <span class="hist-chart-title">Net Supply APY history</span>
+                  <div class="hist-win-btns" id="hist-win-btns">
+                    <button class="hist-win-btn" data-win="7d">7d</button>
+                    <button class="hist-win-btn active" data-win="30d">30d</button>
+                    <button class="hist-win-btn" data-win="1y">1y</button>
+                  </div>
+                </div>
+                <div id="hist-chart" class="hist-chart"></div>
+              </div>
             </div><!-- stats-body -->
           </div><!-- stats-collapsible -->
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1407,6 +1407,15 @@ function updatePreview() {
   }
 
   if (rs) {
+    // Current pool APY (zero delta = pre-loop snapshot)
+    const cur = projectRates(rs, 0, 0);
+    const curNetApr = cur.netSupplyApr * lev - cur.netBorrowCost * (lev - 1);
+    const curNetApy = aprToApy(curNetApr);
+    const poolApyEl = $("prev-pool-apy");
+    poolApyEl.textContent = `${fmt(curNetApy, 2)}% APY on equity`;
+    poolApyEl.className   = `prev-net-apr ${curNetApy > 0 ? "apr-ok" : "apr-bad"}`;
+
+    // Projected APY after deposit (accounts for utilization shift)
     const proj = projectRates(rs, supply - oldSupply, borrow - oldBorrow);
     const netApr = proj.netSupplyApr * lev - proj.netBorrowCost * (lev - 1);
     const netApy = aprToApy(netApr);
@@ -1414,7 +1423,7 @@ function updatePreview() {
     $("prev-net-apr").className   = `prev-net-apr ${netApy > 0 ? "apr-great" : "apr-bad"}`;
     const prevTip = $("prev-net-tip");
     if (prevTip) prevTip.setAttribute("data-tip",
-      `Approximate APY — Blend interest does not auto-compound. Actual net APR: ${fmt(netApr, 2)}%`);
+      `Projected APY after your deposit — accounts for how your supply/borrow shifts pool utilization and rates. Current pool APY: ${fmt(curNetApy, 2)}%. Actual projected net APR: ${fmt(netApr, 2)}%`);
 
     // Days until liquidation at this leverage (interest-only, no BLND)
     const spreadPct = proj.interestBorrowApr - proj.interestSupplyApr;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -502,6 +502,82 @@ function removePnlEntry(assetId: string, poolId: string) {
   localStorage.removeItem(`pnl_${poolId}_${assetId}`);
 }
 
+// ── Rate history (B3) ────────────────────────────────────────────────────────
+
+const RATE_HISTORY_KEY = "blendlev_rate_history";
+const RATE_HISTORY_MAX = 200; // keep up to 200 snapshots per key
+
+interface RateSnapshot { ts: number; val: number; }
+
+function _rateKey(poolId: string, assetId: string, field: string) {
+  return `${RATE_HISTORY_KEY}:${poolId}:${assetId}:${field}`;
+}
+
+function recordRateSnapshot(poolId: string, assetId: string, field: string, val: number) {
+  const key = _rateKey(poolId, assetId, field);
+  const raw = localStorage.getItem(key);
+  const snaps: RateSnapshot[] = raw ? JSON.parse(raw) : [];
+  const now = Date.now();
+  // Deduplicate: skip if last snapshot is < 5 min old
+  if (snaps.length > 0 && now - snaps[snaps.length - 1].ts < 5 * 60_000) {
+    snaps[snaps.length - 1] = { ts: now, val }; // update in place
+  } else {
+    snaps.push({ ts: now, val });
+    if (snaps.length > RATE_HISTORY_MAX) snaps.splice(0, snaps.length - RATE_HISTORY_MAX);
+  }
+  localStorage.setItem(key, JSON.stringify(snaps));
+}
+
+function getRateAtWindow(poolId: string, assetId: string, field: string, windowMs: number): number | null {
+  const key = _rateKey(poolId, assetId, field);
+  const raw = localStorage.getItem(key);
+  if (!raw) return null;
+  const snaps: RateSnapshot[] = JSON.parse(raw);
+  const cutoff = Date.now() - windowMs;
+  // Find the oldest snapshot within the window (closest to windowMs ago)
+  const candidates = snaps.filter(s => s.ts <= cutoff);
+  if (candidates.length === 0) return null;
+  return candidates[candidates.length - 1].val;
+}
+
+/** Render a trend arrow element next to an APY value element. */
+function renderTrendArrow(
+  targetEl: HTMLElement,
+  current: number,
+  past24h: number | null,
+  past7d: number | null
+) {
+  // Remove any existing arrow
+  const existing = targetEl.parentElement?.querySelector(".rate-trend");
+  if (existing) existing.remove();
+
+  if (past24h === null && past7d === null) return;
+
+  const arrow = document.createElement("span");
+  arrow.className = "rate-trend";
+
+  const parts: string[] = [];
+  const tipParts: string[] = [];
+
+  for (const [label, past, ms] of [
+    ["24h", past24h, 24 * 3600_000],
+    ["7d",  past7d,  7 * 24 * 3600_000],
+  ] as [string, number | null, number][]) {
+    if (past === null) continue;
+    const delta = past !== 0 ? (current - past) / Math.abs(past) * 100 : 0;
+    const up = delta >= 0;
+    const sym = up ? "▲" : "▼";
+    const cls = up ? "rate-trend-up" : "rate-trend-down";
+    parts.push(`<span class="${cls}">${sym}${fmt(Math.abs(delta), 1)}%</span><span class="rate-trend-label">${label}</span>`);
+    tipParts.push(`${label}: ${fmt(past, 2)}% → ${fmt(current, 2)}% (${delta >= 0 ? "+" : ""}${fmt(delta, 1)}%)`);
+  }
+
+  if (parts.length === 0) return;
+  arrow.innerHTML = parts.join(" ");
+  arrow.setAttribute("title", tipParts.join(" | "));
+  targetEl.insertAdjacentElement("afterend", arrow);
+}
+
 // ── Sign + submit ─────────────────────────────────────────────────────────────
 
 async function signAndSubmit(xdrStr: string, label: string, stepIndex?: number): Promise<string> {
@@ -796,6 +872,30 @@ function renderSelectedAsset() {
     `Approximate APY: interest compounds but BLND emissions don't. Actual net APR: ${fmt(rs.netBorrowCost, 2)}%`);
 
   // Don't auto-collapse — user controls visibility via the toggle
+
+  // Rate-trend arrows (A10 / B3) ─────────────────────────────────────────────
+  const supplyNetVal  = aprToApy(rs.interestSupplyApr) + rs.blndSupplyApr;
+  const borrowNetVal  = aprToApy(rs.interestBorrowApr) - rs.blndBorrowApr;
+  const W24 = 24 * 3600_000;
+  const W7D = 7 * 24 * 3600_000;
+
+  // Record current values
+  recordRateSnapshot(selectedPool.id, selectedAsset.id, "supply-net", supplyNetVal);
+  recordRateSnapshot(selectedPool.id, selectedAsset.id, "borrow-net", borrowNetVal);
+
+  // Render arrows on net rows
+  renderTrendArrow(
+    $("supply-net-apr"),
+    supplyNetVal,
+    getRateAtWindow(selectedPool.id, selectedAsset.id, "supply-net", W24),
+    getRateAtWindow(selectedPool.id, selectedAsset.id, "supply-net", W7D),
+  );
+  renderTrendArrow(
+    $("borrow-net-cost"),
+    borrowNetVal,
+    getRateAtWindow(selectedPool.id, selectedAsset.id, "borrow-net", W24),
+    getRateAtWindow(selectedPool.id, selectedAsset.id, "borrow-net", W7D),
+  );
 
   updatePreview();
   renderPosition();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -825,6 +825,101 @@ function renderApyChart(rs: ReserveStats | undefined, currentLev: number, equity
   </svg>`;
 }
 
+// ── APY history chart (B4) ────────────────────────────────────────────────────
+
+let _histWin: "7d" | "30d" | "1y" = "30d";
+
+const HIST_WIN_MS: Record<string, number> = {
+  "7d":  7  * 24 * 3600_000,
+  "30d": 30 * 24 * 3600_000,
+  "1y":  365 * 24 * 3600_000,
+};
+
+function renderHistoryChart() {
+  const container = $("hist-chart");
+  const raw = localStorage.getItem(`blendlev_rate_history:${selectedPool.id}:${selectedAsset.id}:supply-net`);
+  const all: { ts: number; val: number }[] = raw ? JSON.parse(raw) : [];
+  const cutoff = Date.now() - HIST_WIN_MS[_histWin];
+  const snaps = all.filter(s => s.ts >= cutoff);
+
+  if (snaps.length < 2) {
+    container.innerHTML = `<div class="hist-chart-empty">Not enough history yet — check back after data accumulates.</div>`;
+    return;
+  }
+
+  const W = 400, H = 80, padL = 32, padR = 8, padT = 10, padB = 18;
+  const vals = snaps.map(s => s.val);
+  const minV = Math.min(...vals), maxV = Math.max(...vals);
+  const rangeV = maxV - minV || 0.01;
+  const minTs = snaps[0].ts, maxTs = snaps[snaps.length - 1].ts;
+  const rangeTs = maxTs - minTs || 1;
+
+  const px = (ts: number) => padL + (ts - minTs) / rangeTs * (W - padL - padR);
+  const py = (v: number)  => padT + (1 - (v - minV) / rangeV) * (H - padT - padB);
+
+  const pts = snaps.map(s => `${px(s.ts).toFixed(1)},${py(s.val).toFixed(1)}`).join(" ");
+
+  // X-axis tick labels (3 ticks: start, mid, end)
+  const fmtDate = (ts: number) => {
+    const d = new Date(ts);
+    return _histWin === "1y"
+      ? d.toLocaleDateString("en-US", { month: "short", year: "2-digit" })
+      : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+  const ticks = [minTs, (minTs + maxTs) / 2, maxTs];
+  const tickSvg = ticks.map(ts =>
+    `<text x="${px(ts).toFixed(1)}" y="${H - 2}" text-anchor="middle" class="hist-chart-label">${fmtDate(ts)}</text>`
+  ).join("");
+
+  // Y-axis labels
+  const yLabelSvg =
+    `<text x="${padL - 3}" y="${padT + 6}" text-anchor="end" class="hist-chart-label">${fmt(maxV, 1)}%</text>` +
+    `<text x="${padL - 3}" y="${H - padB + 4}" text-anchor="end" class="hist-chart-label">${fmt(minV, 1)}%</text>`;
+
+  // Invisible hit-area rects for tooltip
+  const segW = (W - padL - padR) / snaps.length;
+  const hitRects = snaps.map((s, i) => {
+    const cx = px(s.ts);
+    const cy = py(s.val);
+    const tip = `${fmtDate(s.ts)}: ${fmt(s.val, 2)}%`;
+    return `<rect x="${(cx - segW / 2).toFixed(1)}" y="${padT}" width="${segW.toFixed(1)}" height="${H - padT - padB}"
+      fill="transparent" class="hist-hit"
+      data-tip="${tip}" data-cx="${cx.toFixed(1)}" data-cy="${cy.toFixed(1)}"/>`;
+  }).join("");
+
+  container.innerHTML = `
+    <svg viewBox="0 0 ${W} ${H}" class="hist-chart-svg" id="hist-chart-svg">
+      <polyline points="${pts}" class="hist-chart-line"/>
+      ${yLabelSvg}${tickSvg}${hitRects}
+      <circle id="hist-cursor" r="3.5" class="hist-cursor" style="display:none"/>
+      <text id="hist-tip-text" class="hist-tip-text" style="display:none"/>
+    </svg>`;
+
+  // Pointer tooltip
+  const svg = document.getElementById("hist-chart-svg")!;
+  svg.addEventListener("mouseleave", () => {
+    (document.getElementById("hist-cursor") as SVGCircleElement | null)?.setAttribute("style", "display:none");
+    (document.getElementById("hist-tip-text") as SVGTextElement | null)?.setAttribute("style", "display:none");
+  });
+  svg.querySelectorAll<SVGRectElement>(".hist-hit").forEach(rect => {
+    rect.addEventListener("mouseenter", () => {
+      const cx = rect.dataset.cx!, cy = rect.dataset.cy!, tip = rect.dataset.tip!;
+      const cursor = document.getElementById("hist-cursor") as SVGCircleElement | null;
+      const tipEl  = document.getElementById("hist-tip-text") as SVGTextElement | null;
+      if (!cursor || !tipEl) return;
+      cursor.setAttribute("cx", cx);
+      cursor.setAttribute("cy", cy);
+      cursor.setAttribute("style", "");
+      const tx = Math.min(Number(cx), W - padR - 60);
+      const ty = Number(cy) > padT + 20 ? Number(cy) - 8 : Number(cy) + 14;
+      tipEl.setAttribute("x", String(tx));
+      tipEl.setAttribute("y", String(ty));
+      tipEl.textContent = tip;
+      tipEl.setAttribute("style", "");
+    });
+  });
+}
+
 // ── Render reserve stats for selected asset ───────────────────────────────────
 
 function renderSelectedAsset() {
@@ -896,6 +991,8 @@ function renderSelectedAsset() {
     getRateAtWindow(selectedPool.id, selectedAsset.id, "borrow-net", W24),
     getRateAtWindow(selectedPool.id, selectedAsset.id, "borrow-net", W7D),
   );
+
+  renderHistoryChart();
 
   updatePreview();
   renderPosition();
@@ -2190,6 +2287,16 @@ document.querySelectorAll<HTMLButtonElement>(".mobile-card-tab").forEach(btn => 
 // Collapsible stats (#23)
 $("stats-toggle").addEventListener("click", () => {
   $("stats-collapsible").classList.toggle("collapsed");
+});
+
+// History chart window selector (B4)
+$("hist-win-btns").addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".hist-win-btn");
+  if (!btn) return;
+  _histWin = btn.dataset.win as "7d" | "30d" | "1y";
+  $("hist-win-btns").querySelectorAll(".hist-win-btn").forEach(b => b.classList.remove("active"));
+  btn.classList.add("active");
+  renderHistoryChart();
 });
 
 // Vault deposit/withdraw tabs

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -427,6 +427,12 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .apr-warn   { color: var(--warning); }
 .apr-bad    { color: var(--danger); }
 
+/* ── Rate-trend arrows (A10) ─────────────────────────────────────────────── */
+.rate-trend { display: inline-flex; align-items: center; gap: 2px; font-size: 10px; font-family: var(--mono); margin-left: 5px; opacity: .85; }
+.rate-trend-label { color: var(--text-3); font-family: var(--sans); font-size: 10px; margin-right: 3px; }
+.rate-trend-up   { color: var(--success); }
+.rate-trend-down { color: var(--danger); }
+
 /* ── Frozen banner ───────────────────────────────────────────────────────── */
 
 .pool-frozen-banner {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -433,6 +433,23 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .rate-trend-up   { color: var(--success); }
 .rate-trend-down { color: var(--danger); }
 
+/* ── APY history chart (B4) ──────────────────────────────────────────────── */
+.hist-chart-wrap { margin-top: 10px; }
+.hist-chart-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+.hist-chart-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .7px; color: var(--text-3); }
+.hist-win-btns { display: flex; gap: 3px; }
+.hist-win-btn { background: none; border: 1px solid var(--border); border-radius: 4px; color: var(--text-2); font-size: 11px; padding: 2px 7px; cursor: pointer; transition: background .15s, color .15s; }
+.hist-win-btn:hover { border-color: var(--primary); color: var(--primary); }
+.hist-win-btn.active { background: var(--primary); border-color: var(--primary); color: #fff; }
+.hist-chart { min-height: 80px; }
+.hist-chart-svg { width: 100%; height: 80px; display: block; overflow: visible; }
+.hist-chart-line { fill: none; stroke: var(--primary); stroke-width: 1.5; stroke-linejoin: round; }
+.hist-chart-label { font-size: 9px; fill: var(--text-3); font-family: var(--mono); }
+.hist-cursor { fill: var(--primary); }
+.hist-tip-text { font-size: 10px; fill: var(--text); font-family: var(--mono); font-weight: 600; }
+.hist-hit { cursor: crosshair; }
+.hist-chart-empty { font-size: 12px; color: var(--text-3); padding: 16px 0; text-align: center; }
+
 /* ── Frozen banner ───────────────────────────────────────────────────────── */
 
 .pool-frozen-banner {


### PR DESCRIPTION
## Summary

Closes #60 (E3). Subscribers can opt in to be emailed when the borrow rate for a chosen pool/asset jumps more than a configurable threshold (default 2pp) within a 15-minute window. Uses the B3 rate-snapshot infrastructure stored in D1.

## Changes

**`alerts/src/schema.sql`**
- `rate_spike_subscriptions` — stores email, pool, asset, `threshold_pp`, verified flag, tokens, `last_alerted_at`
- `rate_snapshots` — one row per cron tick per pool/asset; pruned to 24h rolling window

**`alerts/src/email.ts`**
- `sendRateSpikeAlert` — email template showing before/after borrow APR, delta pp, threshold, and unsubscribe link

**`alerts/src/index.ts`**
- `POST /subscribe-spike` — accepts `{ email, pool_id, asset_symbol, threshold_pp? }`, validates, inserts into `rate_spike_subscriptions`, sends verification email
- Cron extended: each tick records a `rate_snapshots` row, queries the snapshot from ~15 min ago, computes `delta = current - prev`, and fires `sendRateSpikeAlert` to all verified subscribers whose `threshold_pp ≤ delta` (1h cooldown per subscriber)

## Acceptance criteria

- ✅ New subscription type (`rate_spike_subscriptions`) with configurable `threshold_pp`
- ✅ Email template for rate-spike events (`sendRateSpikeAlert`)
- ✅ Depends on B3 (`rate_snapshots` table mirrors B3 server-side)