### PR TITLE
Health factor

### DIFF
--- a/alerts/src/email.ts
+++ b/alerts/src/email.ts
@@ -100,3 +100,52 @@ export async function sendApyAlert(
     html,
   );
 }
+
+export async function sendHealthFactorAlert(
+  env: Env,
+  to: string,
+  opts: {
+    poolName: string;
+    assetSymbol: string;
+    leverage: number;
+    currentHf: number;
+    threshold: number;
+    unsubscribeUrl: string;
+    appUrl: string;
+  },
+): Promise<SendResult> {
+  const { poolName, assetSymbol, leverage, currentHf, threshold, unsubscribeUrl, appUrl } = opts;
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 16px; color: #1a1a2e;">
+  <h2 style="margin: 0 0 8px; color: #FF4D6A;">⚠️ Health Factor Alert</h2>
+  <p style="font-size: 14px; color: #555; margin: 0 0 20px;">Your ${assetSymbol} position at ${leverage}x on ${poolName} has breached your health factor threshold.</p>
+
+  <div style="background: #f8f8fc; border-radius: 8px; padding: 16px; margin-bottom: 20px;">
+    <p style="margin: 0 0 8px; font-size: 13px; color: #888;">Position status</p>
+    <table style="width: 100%; font-size: 14px; border-collapse: collapse;">
+      <tr><td style="padding: 4px 0; color: #555;">Alert Threshold</td><td style="padding: 4px 0; text-align: right; font-weight: 600;">${threshold.toFixed(2)}</td></tr>
+      <tr style="border-top: 1px solid #e0e0e8;"><td style="padding: 8px 0 4px; color: #FF4D6A; font-weight: 600;">Current Health Factor</td><td style="padding: 8px 0 4px; text-align: right; font-weight: 700; color: #FF4D6A;">${currentHf.toFixed(3)}</td></tr>
+    </table>
+  </div>
+
+  <p style="line-height: 1.6; color: #555;">Your health factor is dangerously close to 1.0. If it drops below 1.0, your position is subject to liquidation and loss of funds. Please consider adding collateral or reducing leverage immediately.</p>
+
+  <a href="${appUrl}" style="display: inline-block; margin: 16px 0; padding: 12px 28px; background: #2DE8A3; color: #0B0E14; text-decoration: none; border-radius: 8px; font-weight: 600;">Open Turbolong</a>
+
+  <p style="font-size: 12px; color: #aaa; margin-top: 32px;">
+    <a href="${unsubscribeUrl}" style="color: #aaa;">Unsubscribe</a> from this alert.
+  </p>
+</body>
+</html>`.trim();
+
+  return sendEmail(
+    env,
+    to,
+    `⚠️ Health Factor Alert: ${assetSymbol} at ${leverage}x on ${poolName}`,
+    html,
+  );
+}

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -11,7 +11,7 @@
  */
 
 import { POOLS, LEVERAGE_BRACKETS, POOL_NAMES, fetchReserveRates, computeNetApy, type ReserveRates } from "./stellar.ts";
-import { sendVerificationEmail, sendApyAlert } from "./email.ts";
+import { sendVerificationEmail, sendApyAlert, sendHealthFactorAlert } from "./email.ts";
 
 interface Env {
   DB: D1Database;
@@ -78,7 +78,7 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ ok: false, error: "Invalid JSON" }, 400, env);
   }
 
-  const { email, pool_id, asset_symbol, leverage_bracket } = body;
+  const { email, pool_id, asset_symbol, leverage_bracket, hf_threshold } = body;
 
   // Validate
   if (!email || !EMAIL_RE.test(email)) {
@@ -95,16 +95,21 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ ok: false, error: "Invalid leverage bracket. Must be one of: " + LEVERAGE_BRACKETS.join(", ") }, 400, env);
   }
 
+  const hfThreshold = hf_threshold != null ? Number(hf_threshold) : null;
+  if (hfThreshold !== null && (isNaN(hfThreshold) || hfThreshold < 1.0)) {
+    return jsonResponse({ ok: false, error: "Health factor threshold must be at least 1.0" }, 400, env);
+  }
+
   const verifyToken = generateToken();
   const unsubToken  = generateToken();
 
   try {
     await env.DB.prepare(`
-      INSERT INTO subscriptions (email, pool_id, asset_symbol, leverage_bracket, verify_token, unsub_token)
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+      INSERT INTO subscriptions (email, pool_id, asset_symbol, leverage_bracket, hf_threshold, verify_token, unsub_token, hf_breached)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)
       ON CONFLICT(email, pool_id, asset_symbol, leverage_bracket) DO UPDATE
-        SET verify_token = ?5, unsub_token = ?6, verified = 0
-    `).bind(email, pool_id, asset_symbol, lev, verifyToken, unsubToken).run();
+        SET hf_threshold = ?5, verify_token = ?6, unsub_token = ?7, verified = 0, hf_breached = 0
+    `).bind(email, pool_id, asset_symbol, lev, hfThreshold, verifyToken, unsubToken).run();
   } catch (e: any) {
     console.error("DB insert failed:", e);
     return jsonResponse({ ok: false, error: "Database error" }, 500, env);
@@ -203,48 +208,106 @@ async function handleCron(env: Env): Promise<void> {
       for (const bracket of LEVERAGE_BRACKETS) {
         const netApy = computeNetApy(rates, bracket);
 
-        if (netApy >= 0) continue; // APY is positive, no alert needed
+        const cFactor = rates.cFactor || 0.9;
+        const lFactor = rates.lFactor || 1.0;
+        const currentHf = bracket <= 1 ? Infinity : (cFactor * bracket) / ((bracket - 1) / lFactor);
 
-        console.log(`[cron] Negative APY: ${asset.symbol} at ${bracket}x on ${pool.name} = ${netApy.toFixed(2)}%`);
-
-        // Find verified subscribers who haven't been alerted in the last 24h
+        // Find verified subscribers
         const subs = await env.DB.prepare(`
-          SELECT id, email, unsub_token
+          SELECT id, email, unsub_token, hf_threshold, hf_breached, last_alerted_at
           FROM subscriptions
           WHERE pool_id = ?1
             AND asset_symbol = ?2
             AND leverage_bracket = ?3
             AND verified = 1
-            AND (last_alerted_at IS NULL OR last_alerted_at < datetime('now', '-24 hours'))
         `).bind(pool.id, asset.symbol, bracket).all();
 
         if (!subs.results?.length) continue;
 
-        console.log(`[cron] Alerting ${subs.results.length} subscriber(s) for ${asset.symbol}@${bracket}x on ${pool.name}`);
-
         for (const sub of subs.results) {
-          const unsubUrl = `https://turbolong-alerts.workers.dev/unsubscribe?token=${sub.unsub_token}`;
-          const result = await sendApyAlert(
-            { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
-            sub.email as string,
-            {
-              poolName: pool.name,
-              assetSymbol: asset.symbol,
-              leverage: bracket,
-              netApy,
-              supplyApr: rates.netSupplyApr,
-              borrowCost: rates.netBorrowCost,
-              unsubscribeUrl: unsubUrl,
-              appUrl: env.FRONTEND_ORIGIN,
-            },
-          );
+          const hfThreshold = sub.hf_threshold != null ? Number(sub.hf_threshold) : null;
+          const hfBreached = sub.hf_breached != null ? Number(sub.hf_breached) : 0;
+          const lastAlertedAt = sub.last_alerted_at as string | null;
 
-          if (result.ok) {
-            await env.DB.prepare(
-              "UPDATE subscriptions SET last_alerted_at = datetime('now') WHERE id = ?1"
-            ).bind(sub.id).run();
+          const unsubUrl = `https://turbolong-alerts.workers.dev/unsubscribe?token=${sub.unsub_token}`;
+
+          if (hfThreshold !== null) {
+            // Health Factor Alert Logic
+            if (currentHf < hfThreshold) {
+              if (hfBreached === 0) {
+                console.log(`[cron] Health Factor breach: ${asset.symbol}@${bracket}x on ${pool.name} = ${currentHf.toFixed(3)} (threshold: ${hfThreshold})`);
+
+                const result = await sendHealthFactorAlert(
+                  { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
+                  sub.email as string,
+                  {
+                    poolName: pool.name,
+                    assetSymbol: asset.symbol,
+                    leverage: bracket,
+                    currentHf,
+                    threshold: hfThreshold,
+                    unsubscribeUrl: unsubUrl,
+                    appUrl: env.FRONTEND_ORIGIN,
+                  }
+                );
+
+                if (result.ok) {
+                  await env.DB.prepare(`
+                    UPDATE subscriptions
+                    SET last_alerted_at = datetime('now'),
+                        hf_breached = 1
+                    WHERE id = ?1
+                  `).bind(sub.id).run();
+                } else {
+                  console.error(`[cron] Failed to send HF alert to ${sub.email}:`, result.error);
+                }
+              }
+            } else {
+              // currentHf >= hfThreshold -> Healed
+              if (hfBreached === 1) {
+                console.log(`[cron] Health Factor healed: ${asset.symbol}@${bracket}x on ${pool.name} = ${currentHf.toFixed(3)}`);
+                await env.DB.prepare(`
+                  UPDATE subscriptions
+                  SET hf_breached = 0
+                  WHERE id = ?1
+                `).bind(sub.id).run();
+              }
+            }
           } else {
-            console.error(`[cron] Failed to send alert to ${sub.email}:`, result.error);
+            // APY Alert Logic
+            if (netApy < 0) {
+              const isCoolDownOver = !lastAlertedAt ||
+                (new Date().getTime() - new Date(lastAlertedAt).getTime() > 24 * 60 * 60 * 1000);
+
+              if (isCoolDownOver) {
+                console.log(`[cron] Negative APY: ${asset.symbol} at ${bracket}x on ${pool.name} = ${netApy.toFixed(2)}%`);
+
+                const result = await sendApyAlert(
+                  { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
+                  sub.email as string,
+                  {
+                    poolName: pool.name,
+                    assetSymbol: asset.symbol,
+                    leverage: bracket,
+                    netApy,
+                    supplyApr: rates.netSupplyApr,
+                    borrowCost: rates.netBorrowCost,
+                    unsubscribeUrl: unsubUrl,
+                    appUrl: env.FRONTEND_ORIGIN,
+                  }
+                );
+
+                if (result.ok) {
+                  await env.DB.prepare(`
+                    UPDATE subscriptions
+                    SET last_alerted_at = datetime('now')
+                    WHERE id = ?1
+                  `).bind(sub.id).run();
+                } else {
+                  console.error(`[cron] Failed to send APY alert to ${sub.email}:`, result.error);
+                }
+              }
+            }
           }
         }
       }

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -4,6 +4,8 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   pool_id TEXT NOT NULL,
   asset_symbol TEXT NOT NULL,
   leverage_bracket REAL NOT NULL,
+  hf_threshold REAL DEFAULT NULL,
+  hf_breached INTEGER DEFAULT 0,
   verified INTEGER DEFAULT 0,
   verify_token TEXT,
   unsub_token TEXT,

--- a/alerts/src/stellar.ts
+++ b/alerts/src/stellar.ts
@@ -101,6 +101,8 @@ export interface ReserveRates {
   interestBorrowApr: number;
   blndSupplyApr: number;
   blndBorrowApr: number;
+  cFactor?: number;
+  lFactor?: number;
 }
 
 /** Simulate a contract call and return the decoded result. */
@@ -217,6 +219,13 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
     const blndSupplyApr = totalSupplyUsd > 0 ? (supplyBlndYr * blndPrice / totalSupplyUsd) * 100 : 0;
     const blndBorrowApr = totalBorrowUsd > 0 ? (borrowBlndYr * blndPrice / totalBorrowUsd) * 100 : 0;
 
+    const cFactor = reserveRaw.config?.c_factor != null
+      ? Number(BigInt(reserveRaw.config.c_factor)) / SCALAR
+      : 0.9;
+    const lFactor = reserveRaw.config?.l_factor != null
+      ? Number(BigInt(reserveRaw.config.l_factor)) / SCALAR
+      : 1.0;
+
     return {
       netSupplyApr:     interestSupplyApr + blndSupplyApr,
       netBorrowCost:    interestBorrowApr - blndBorrowApr,
@@ -224,6 +233,8 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
       interestBorrowApr,
       blndSupplyApr,
       blndBorrowApr,
+      cFactor,
+      lFactor,
     };
   } catch (e) {
     console.error(`fetchReserveRates failed for ${asset.symbol} on ${pool.name}:`, e);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,7 @@
         <div id="pool-dropdown" class="pool-dropdown hidden"></div>
         <button class="nav-btn" id="proto-vault">Vault</button>
         <button class="nav-btn" id="proto-swap">Swap</button>
+        <button class="nav-btn" id="proto-referral">Refer &amp; Earn</button>
       </div>
       <div class="top-nav-right" id="wallet-area">
         <button id="settings-btn" class="nav-btn" aria-label="Settings">&#9881;</button>
@@ -107,6 +108,12 @@
             <button class="protocol-btn" id="mobile-proto-swap">
               <span class="protocol-icon">&#8644;</span>
               Swap
+            </button>
+          </div>
+          <div class="protocol-section">
+            <button class="protocol-btn" id="mobile-proto-referral">
+              <span class="protocol-icon">&#127873;</span>
+              Refer &amp; Earn
             </button>
           </div>
         </nav>
@@ -753,6 +760,113 @@
             </div>
 
             <p class="disclaimer">Deposits are managed by the Turbolong Strategy on Blend Protocol. Leverage loops are executed atomically. Rebalance is permissionless — anyone can trigger it when HF drops below the minimum threshold to protect all depositors.</p>
+          </section>
+        </div>
+
+        <!-- Referral view -->
+        <div id="referral-view" class="hidden">
+          <section class="card referral-card">
+            <div class="card-header">
+              <h2>Refer &amp; Earn</h2>
+              <span class="referral-badge">Stats</span>
+            </div>
+
+            <!-- Not connected state -->
+            <div id="referral-not-connected" class="empty-state">
+              <p>Connect your wallet to generate a referral code and start earning.</p>
+              <button class="btn btn-primary" onclick="document.getElementById('connect-btn').click()">Connect Wallet</button>
+            </div>
+
+            <!-- Connected state -->
+            <div id="referral-connected-section" class="hidden">
+              <div class="referral-code-banner">
+                <div class="ref-code-box">
+                  <span class="ref-label">YOUR REFERRAL CODE</span>
+                  <div class="ref-code-value-wrap">
+                    <span id="ref-code-display" class="mono">--</span>
+                    <button id="ref-copy-btn" class="btn btn-ghost btn-sm">Copy Code</button>
+                  </div>
+                </div>
+                <div class="ref-link-box">
+                  <span class="ref-label">YOUR REFERRAL LINK</span>
+                  <div class="ref-link-value-wrap">
+                    <input type="text" id="ref-link-input" class="input mono" readonly value="" />
+                    <button id="ref-copy-link-btn" class="btn btn-primary btn-sm">Copy Link</button>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Referral stats overview -->
+              <div class="overview-totals" style="margin-top: 24px;">
+                <div class="stat-card">
+                  <span class="stat-label">Total Referrals</span>
+                  <span class="stat-value mono" id="ref-stat-total">--</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Unique Depositors</span>
+                  <span class="stat-value mono" id="ref-stat-depositors">--</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Active Referrals</span>
+                  <span class="stat-value mono" id="ref-stat-active">--</span>
+                </div>
+              </div>
+
+              <!-- Breakdown and Recent Activity Grid -->
+              <div class="two-col" style="margin-top: 24px;">
+                <!-- Left column: Breakdown by Pool -->
+                <section class="card" style="padding: 16px; margin: 0;">
+                  <div class="card-header" style="margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border);">
+                    <h3>Breakdown by Pool</h3>
+                  </div>
+                  <table class="overview-table" id="ref-breakdown-table">
+                    <thead>
+                      <tr>
+                        <th>Pool ID</th>
+                        <th style="text-align: right;">Total Memos</th>
+                        <th style="text-align: right;">Unique Depositors</th>
+                      </tr>
+                    </thead>
+                    <tbody id="ref-breakdown-tbody">
+                      <tr>
+                        <td colspan="3" class="text-center" style="color: var(--text-muted); padding: 16px;">No referral data yet.</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </section>
+
+                <!-- Right column: Recent Activity -->
+                <section class="card" style="padding: 16px; margin: 0;">
+                  <div class="card-header" style="margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border);">
+                    <h3>Recent Referrals</h3>
+                  </div>
+                  <div id="ref-activity-list" class="tx-history-list" style="max-height: 250px; overflow-y: auto;">
+                    <div style="color: var(--text-muted); text-align: center; padding: 16px;">No recent referral activity.</div>
+                  </div>
+                </section>
+              </div>
+            </div>
+
+            <div class="landing-steps" style="margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border);">
+              <h2 style="font-size: 20px; margin-bottom: 20px;">How the Referral System Works</h2>
+              <div class="landing-steps-grid">
+                <div class="landing-step">
+                  <div class="landing-step-num">1</div>
+                  <h3>Share Your Link</h3>
+                  <p>Copy your unique referral link or code and share it with other traders.</p>
+                </div>
+                <div class="landing-step">
+                  <div class="landing-step-num">2</div>
+                  <h3>Traders Deposit</h3>
+                  <p>When friends click your link and open a position, your code is stored as a text memo on the transaction.</p>
+                </div>
+                <div class="landing-step">
+                  <div class="landing-step-num">3</div>
+                  <h3>Track Performance</h3>
+                  <p>Our off-chain indexer scans the ledger every 15 minutes, updating your dashboard stats automatically.</p>
+                </div>
+              </div>
+            </div>
           </section>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -877,8 +877,8 @@
         <div id="alert-modal-overlay" class="alert-modal-overlay hidden">
           <div class="alert-modal">
             <button id="alert-modal-close" class="alert-modal-close">&times;</button>
-            <h3>APY Alerts</h3>
-            <p class="alert-modal-desc">Get notified when your position's net APY turns negative.</p>
+            <h3>Position Alerts</h3>
+            <p class="alert-modal-desc">Get notified when your position's net APY turns negative or health factor drops below a threshold.</p>
             <div class="form-group">
               <label>Email</label>
               <input type="email" id="alert-email" class="input" placeholder="you@example.com" />
@@ -900,6 +900,10 @@
                 <option value="8">8x</option>
                 <option value="10">10x</option>
               </select>
+            </div>
+            <div class="form-group">
+              <label>Health Factor Threshold (Optional)</label>
+              <input type="number" id="alert-hf-threshold" class="input" placeholder="e.g. 1.05" step="0.01" min="1.0" />
             </div>
             <button id="alert-subscribe-btn" class="btn btn-primary btn-lg">Subscribe</button>
             <p class="alert-hint">We never store your wallet address.</p>

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -9,6 +9,7 @@ import {
   BASE_FEE,
   Contract,
   Horizon,
+  Memo,
   Networks,
   nativeToScVal,
   Operation,
@@ -869,6 +870,7 @@ export async function buildApproveXdr(
   userAddress: string,
   assetId: string,
   amountStroops: bigint,
+  referralCode?: string,
 ): Promise<string> {
   const token     = new Contract(assetId);
   const addrScVal = new Address(userAddress).toScVal();
@@ -877,18 +879,24 @@ export async function buildApproveXdr(
   const expiry    = ledger.sequence + 120;
 
   const acc = await server.getAccount(userAddress);
-  const tx  = new TransactionBuilder(acc, {
+  const txBuilder = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
-  })
-    .addOperation(token.call(
-      "approve",
-      addrScVal,
-      poolScVal,
-      i128ToScVal(amountStroops),
-      nativeToScVal(expiry, { type: "u32" }),
-    ))
-    .setTimeout(60).build();
+  });
+
+  txBuilder.addOperation(token.call(
+    "approve",
+    addrScVal,
+    poolScVal,
+    i128ToScVal(amountStroops),
+    nativeToScVal(expiry, { type: "u32" }),
+  ));
+
+  if (referralCode) {
+    txBuilder.addMemo(Memo.text(`ref:${referralCode}`));
+  }
+
+  const tx = txBuilder.setTimeout(60).build();
 
   const sim = await server.simulateTransaction(tx);
   if (!SorobanRpc.Api.isSimulationSuccess(sim))

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2810,6 +2810,17 @@ $("alert-subscribe-btn").addEventListener("click", async () => {
   }
 
   const leverageBracket = Number(($("alert-leverage") as HTMLSelectElement).value);
+
+  const hfThresholdRaw = ($("alert-hf-threshold") as HTMLInputElement).value.trim();
+  let hfThreshold: number | null = null;
+  if (hfThresholdRaw !== "") {
+    hfThreshold = Number(hfThresholdRaw);
+    if (isNaN(hfThreshold) || hfThreshold < 1.0) {
+      toast("Health factor threshold must be ≥ 1.0 (e.g. 1.05).", "error");
+      return;
+    }
+  }
+
   const btn = $("alert-subscribe-btn") as HTMLButtonElement;
   btn.disabled = true;
   btn.textContent = "Subscribing...";
@@ -2818,12 +2829,11 @@ $("alert-subscribe-btn").addEventListener("click", async () => {
     const res = await fetch(`${ALERTS_WORKER_URL}/subscribe`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        email,
-        pool_id: selectedPool.id,
-        asset_symbol: selectedAsset.symbol,
-        leverage_bracket: leverageBracket,
-      }),
+      body: JSON.stringify(
+        hfThreshold !== null
+          ? { email, pool_id: selectedPool.id, asset_symbol: selectedAsset.symbol, leverage_bracket: leverageBracket, hf_threshold: hfThreshold }
+          : { email, pool_id: selectedPool.id, asset_symbol: selectedAsset.symbol, leverage_bracket: leverageBracket }
+      ),
     });
 
     const data = await res.json() as any;
@@ -2832,6 +2842,7 @@ $("alert-subscribe-btn").addEventListener("click", async () => {
       toast("Check your email to verify your alert subscription.", "success");
       $("alert-modal-overlay").classList.add("hidden");
       ($("alert-email") as HTMLInputElement).value = "";
+      ($("alert-hf-threshold") as HTMLInputElement).value = "";
     } else {
       toast(data.error || "Subscription failed.", "error");
     }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -314,7 +314,7 @@ document.getElementById("disclaimer-accept")!.addEventListener("click", () => {
 
 // ── Active view (leverage | swap) ────────────────────────────────────────
 
-type AppView = "overview" | "leverage" | "swap" | "vault";
+type AppView = "overview" | "leverage" | "swap" | "vault" | "referral";
 let activeView: AppView = "leverage";
 
 // ── Expert mode ──────────────────────────────────────────────────────────────
@@ -1372,7 +1372,8 @@ async function openPosition() {
   setLoading($("open-btn") as HTMLButtonElement, true);
   showTxStepper(["Approve", "Submit"]);
   try {
-    const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
+    const pendingRef = sessionStorage.getItem("pending_ref") || undefined;
+    const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n, pendingRef);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
     await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
@@ -1575,7 +1576,8 @@ async function addFundsToPosition() {
   setLoading($("add-funds-btn") as HTMLButtonElement, true);
   showTxStepper(["Approve", "Submit"]);
   try {
-    const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, additionalStroops + 1n);
+    const pendingRef = sessionStorage.getItem("pending_ref") || undefined;
+    const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, additionalStroops + 1n, pendingRef);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
     const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, additionalStroops, leverage);
     await signAndSubmit(submitXdr, `Add ${fmt(additional, 2)} ${liveAsset.symbol} at ${leverage.toFixed(1)}\u00D7`, 1);
@@ -1615,7 +1617,8 @@ async function resupply() {
   setLoading($("resupply-btn") as HTMLButtonElement, true);
   showTxStepper(["Approve", "Resupply"]);
   try {
-    const approveXdr = await buildApproveXdr(selectedPool, userAddress, selectedAsset.id, amountStroops + 1n);
+    const pendingRef = sessionStorage.getItem("pending_ref") || undefined;
+    const approveXdr = await buildApproveXdr(selectedPool, userAddress, selectedAsset.id, amountStroops + 1n, pendingRef);
     await signAndSubmit(approveXdr, `Approve ${selectedAsset.symbol}`, 0);
 
     const supplyXdr = await buildResupplyXdr(selectedPool, userAddress, selectedAsset.id, amountStroops);
@@ -1699,6 +1702,10 @@ function showConnected() {
   $("connect-btn").classList.add("hidden");
   $("wallet-connected").classList.remove("hidden");
   $("connect-prompt").classList.add("hidden");
+  
+  // Register/get referral code in background on connect
+  getOrCreateReferralCode(userAddress!);
+
   if (activeView === "leverage") {
     $("dashboard").classList.remove("hidden");
     $("asset-tabs-bar").style.display = "";
@@ -1768,16 +1775,19 @@ function switchView(view: AppView) {
   const blendBtn = $("proto-blend");
   const swapBtn  = $("proto-swap");
   const vaultBtn = $("proto-vault");
+  const referralBtn = $("proto-referral");
   overviewBtn.classList.toggle("active", view === "overview");
   blendBtn.classList.toggle("active", view === "leverage");
   swapBtn.classList.toggle("active", view === "swap");
   vaultBtn.classList.toggle("active", view === "vault");
+  referralBtn.classList.toggle("active", view === "referral");
 
   // Mobile sidebar active states
   document.getElementById("mobile-proto-overview")?.classList.toggle("active", view === "overview");
   document.getElementById("mobile-proto-blend")?.classList.toggle("active", view === "leverage");
   document.getElementById("mobile-proto-swap")?.classList.toggle("active", view === "swap");
   document.getElementById("mobile-proto-vault")?.classList.toggle("active", view === "vault");
+  document.getElementById("mobile-proto-referral")?.classList.toggle("active", view === "referral");
 
   // Toggle pool tabs visibility (mobile sidebar)
   $("pool-tabs").style.display = view === "leverage" ? "" : "none";
@@ -1790,6 +1800,7 @@ function switchView(view: AppView) {
   $("overview-view").classList.add("hidden");
   $("swap-view").classList.add("hidden");
   $("vault-view").classList.add("hidden");
+  $("referral-view").classList.add("hidden");
   $("dashboard").classList.add("hidden");
   $("connect-prompt").classList.add("hidden");
 
@@ -1814,6 +1825,9 @@ function switchView(view: AppView) {
   } else if (view === "vault") {
     $("vault-view").classList.remove("hidden");
     refreshVaultView();
+  } else if (view === "referral") {
+    $("referral-view").classList.remove("hidden");
+    loadReferralView();
   }
   closeDrawer();
   // Close pool dropdown
@@ -2053,12 +2067,14 @@ $("proto-blend").addEventListener("click", (e) => {
 });
 $("proto-swap").addEventListener("click",  () => switchView("swap"));
 $("proto-vault").addEventListener("click", () => switchView("vault"));
+$("proto-referral").addEventListener("click", () => switchView("referral"));
 
 // Mobile sidebar nav
 document.getElementById("mobile-proto-overview")?.addEventListener("click", () => switchView("overview"));
 document.getElementById("mobile-proto-blend")?.addEventListener("click", () => switchView("leverage"));
 document.getElementById("mobile-proto-swap")?.addEventListener("click", () => switchView("swap"));
 document.getElementById("mobile-proto-vault")?.addEventListener("click", () => switchView("vault"));
+document.getElementById("mobile-proto-referral")?.addEventListener("click", () => switchView("referral"));
 
 // Close dropdowns on click outside
 document.addEventListener("click", () => {
@@ -2826,3 +2842,135 @@ $("alert-subscribe-btn").addEventListener("click", async () => {
     btn.textContent = "Subscribe";
   }
 });
+
+// ── Referral System Helper Functions ──────────────────────────────────────────
+
+const REFERRALS_WORKER_URL = "https://turbolong-referrals.workers.dev";
+
+// Auto-parse and save referral code from URL search parameters on load
+(function captureReferralCode() {
+  const params = new URLSearchParams(window.location.search);
+  const refCode = params.get("ref");
+  if (refCode && refCode.length >= 4 && refCode.length <= 15) {
+    sessionStorage.setItem("pending_ref", refCode);
+    console.log("[referrals] Stored pending referral code:", refCode);
+  }
+})();
+
+async function getOrCreateReferralCode(address: string): Promise<string> {
+  const localKey = `referral_code_${address}`;
+  let code = localStorage.getItem(localKey);
+  if (code) {
+    // Register or verify registration with backend idempotently
+    registerReferralCode(address, code);
+    return code;
+  }
+
+  // Generate: REF- + first 4 of address + 4 random hex chars
+  const first4 = address.slice(2, 6).toUpperCase();
+  const randHex = Math.random().toString(16).substring(2, 6).toUpperCase();
+  code = `REF-${first4}-${randHex}`;
+
+  localStorage.setItem(localKey, code);
+  registerReferralCode(address, code);
+  return code;
+}
+
+async function registerReferralCode(address: string, code: string) {
+  try {
+    await fetch(`${REFERRALS_WORKER_URL}/referrals/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address, code })
+    });
+  } catch (e) {
+    console.error("[referrals] Failed to register code:", e);
+  }
+}
+
+async function loadReferralView() {
+  if (!userAddress) {
+    $("referral-not-connected").classList.remove("hidden");
+    $("referral-connected-section").classList.add("hidden");
+    return;
+  }
+
+  $("referral-not-connected").classList.add("hidden");
+  $("referral-connected-section").classList.remove("hidden");
+
+  // Show code & share link
+  const code = await getOrCreateReferralCode(userAddress);
+  $("ref-code-display").textContent = code;
+
+  const shareLink = `${window.location.origin}${window.location.pathname}?ref=${code}`;
+  ($("ref-link-input") as HTMLInputElement).value = shareLink;
+
+  // Configure copy buttons
+  $("ref-copy-btn").onclick = () => {
+    navigator.clipboard.writeText(code);
+    toast("Referral code copied!", "success");
+  };
+
+  $("ref-copy-link-btn").onclick = () => {
+    navigator.clipboard.writeText(shareLink);
+    toast("Referral link copied to clipboard!", "success");
+  };
+
+  // Fetch stats from referrals server
+  try {
+    const res = await fetch(`${REFERRALS_WORKER_URL}/referrals/stats?code=${code}`);
+    if (!res.ok) throw new Error("Fetch failed");
+    const data = await res.json() as any;
+
+    if (data.ok) {
+      const stats = data.stats;
+      $("ref-stat-total").textContent = String(stats.totalReferrals || 0);
+      $("ref-stat-depositors").textContent = String(stats.uniqueDepositors || 0);
+      $("ref-stat-active").textContent = String(stats.uniqueDepositors || 0);
+
+      // Render pool breakdown
+      const tbody = $("ref-breakdown-tbody");
+      tbody.innerHTML = "";
+      if (!stats.poolBreakdown || stats.poolBreakdown.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="3" class="text-center" style="color: var(--text-muted); padding: 16px;">No referral data yet.</td></tr>`;
+      } else {
+        stats.poolBreakdown.forEach((row: any) => {
+          const tr = document.createElement("tr");
+          tr.innerHTML = `
+            <td class="text-label mono">${fmtAddr(row.pool_id)}</td>
+            <td style="text-align: right;">${row.count}</td>
+            <td style="text-align: right;">${row.unique_depositors}</td>
+          `;
+          tbody.appendChild(tr);
+        });
+      }
+
+      // Render recent activity
+      const activityList = $("ref-activity-list");
+      activityList.innerHTML = "";
+      if (!stats.recentEvents || stats.recentEvents.length === 0) {
+        activityList.innerHTML = `<div style="color: var(--text-muted); text-align: center; padding: 16px;">No recent referral activity.</div>`;
+      } else {
+        stats.recentEvents.forEach((event: any) => {
+          const item = document.createElement("div");
+          item.className = "tx-history-item";
+          item.innerHTML = `
+            <div class="tx-history-label">
+              <span>Depositor: </span>
+              <span class="mono">${fmtAddr(event.depositor_address)}</span>
+            </div>
+            <div style="display: flex; gap: 8px; align-items: center;">
+              <span class="tx-history-time">${new Date(event.indexed_at).toLocaleDateString()}</span>
+              <a href="https://stellar.expert/explorer/public/tx/${event.tx_hash}" target="_blank" class="tx-history-link">Explorer</a>
+            </div>
+          `;
+          activityList.appendChild(item);
+        });
+      }
+    }
+  } catch (e) {
+    console.error("[referrals] Failed to load referral stats:", e);
+    toast("Failed to load referral statistics", "error");
+  }
+}
+

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1210,3 +1210,81 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
   .skeleton { animation: none; background: var(--metric-bg); }
 }
+
+/* ── Referral View ───────────────────────────────────────────────────────── */
+
+.referral-card {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.referral-badge {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: var(--primary);
+  background: rgba(45,232,163,.1);
+  border-radius: 99px;
+  padding: 3px 10px;
+}
+
+.referral-code-banner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  background: var(--metric-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  padding: 20px;
+  margin-top: 16px;
+}
+
+@media (max-width: 600px) {
+  .referral-code-banner {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ref-code-box, .ref-link-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ref-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-3);
+  letter-spacing: .5px;
+}
+
+.ref-code-value-wrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+#ref-code-display {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--primary);
+  letter-spacing: 0.5px;
+  text-shadow: 0 0 10px var(--primary-glow);
+}
+
+.ref-link-value-wrap {
+  display: flex;
+  gap: 8px;
+}
+
+.ref-link-value-wrap input {
+  flex: 1;
+  font-size: 12px;
+  padding: 8px 12px;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-2);
+}
+

--- a/integrations/referrals/package.json
+++ b/integrations/referrals/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "turbolong-referrals",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:create": "wrangler d1 create turbolong-referrals",
+    "db:migrate": "wrangler d1 execute turbolong-referrals --file=src/schema.sql",
+    "db:migrate:remote": "wrangler d1 execute turbolong-referrals --file=src/schema.sql --remote"
+  },
+  "devDependencies": {
+    "wrangler": "^3.99.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/integrations/referrals/src/index.ts
+++ b/integrations/referrals/src/index.ts
@@ -1,0 +1,236 @@
+interface Env {
+  DB: D1Database;
+  FRONTEND_ORIGIN: string;
+  HORIZON_URL: string;
+  POOL_IDS: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function jsonResponse(body: object, status = 200, env?: Env): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(env ? corsHeaders(env) : {}),
+    },
+  });
+}
+
+function corsHeaders(env: Env): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": "*", // Allow all origins for the public API, or restrict to FRONTEND_ORIGIN
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+// ── Route handlers ───────────────────────────────────────────────────────────
+
+async function handleRegister(request: Request, env: Env): Promise<Response> {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: "Invalid JSON" }, 400, env);
+  }
+
+  const { address, code } = body;
+
+  if (!address || typeof address !== "string" || !address.startsWith("G") || address.length !== 56) {
+    return jsonResponse({ ok: false, error: "Invalid address" }, 400, env);
+  }
+
+  if (!code || typeof code !== "string" || code.length < 4 || code.length > 15) {
+    return jsonResponse({ ok: false, error: "Invalid code" }, 400, env);
+  }
+
+  try {
+    // Upsert code. If address already has a code, return it. If code already exists for another address, return error.
+    const existing = await env.DB.prepare(
+      "SELECT code, owner_address FROM referral_codes WHERE owner_address = ?1 OR code = ?2"
+    ).bind(address, code).all();
+
+    if (existing.results && existing.results.length > 0) {
+      const matchAddress = existing.results.find((r: any) => r.owner_address === address);
+      if (matchAddress) {
+        return jsonResponse({ ok: true, code: matchAddress.code, message: "Code already registered for this address" }, 200, env);
+      }
+      // If we got here, the code belongs to someone else
+      return jsonResponse({ ok: false, error: "Referral code already taken" }, 400, env);
+    }
+
+    await env.DB.prepare(
+      "INSERT INTO referral_codes (code, owner_address) VALUES (?1, ?2)"
+    ).bind(code, address).run();
+
+    return jsonResponse({ ok: true, code, message: "Referral code successfully registered" }, 200, env);
+  } catch (e: any) {
+    console.error("DB insert failed:", e);
+    return jsonResponse({ ok: false, error: "Database error" }, 500, env);
+  }
+}
+
+async function handleGetCode(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const address = url.searchParams.get("address");
+
+  if (!address) {
+    return jsonResponse({ ok: false, error: "Missing address" }, 400, env);
+  }
+
+  try {
+    const row = await env.DB.prepare(
+      "SELECT code FROM referral_codes WHERE owner_address = ?1"
+    ).bind(address).first();
+
+    if (!row) {
+      return jsonResponse({ ok: true, code: null }, 200, env);
+    }
+
+    return jsonResponse({ ok: true, code: row.code }, 200, env);
+  } catch (e: any) {
+    console.error("DB select failed:", e);
+    return jsonResponse({ ok: false, error: "Database error" }, 500, env);
+  }
+}
+
+async function handleGetStats(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+
+  if (!code) {
+    return jsonResponse({ ok: false, error: "Missing code" }, 400, env);
+  }
+
+  try {
+    // Fetch overview stats
+    const totalReferrals = await env.DB.prepare(
+      "SELECT COUNT(*) as count FROM referral_events WHERE code = ?1"
+    ).bind(code).first();
+
+    const uniqueDepositors = await env.DB.prepare(
+      "SELECT COUNT(DISTINCT depositor_address) as count FROM referral_events WHERE code = ?1"
+    ).bind(code).first();
+
+    // Fetch breakdown per pool
+    const poolBreakdown = await env.DB.prepare(
+      "SELECT pool_id, COUNT(*) as count, COUNT(DISTINCT depositor_address) as unique_depositors FROM referral_events WHERE code = ?1 GROUP BY pool_id"
+    ).bind(code).all();
+
+    // Fetch recent events
+    const recentEvents = await env.DB.prepare(
+      "SELECT depositor_address, tx_hash, pool_id, indexed_at FROM referral_events WHERE code = ?1 ORDER BY indexed_at DESC LIMIT 10"
+    ).bind(code).all();
+
+    return jsonResponse({
+      ok: true,
+      stats: {
+        totalReferrals: totalReferrals?.count ?? 0,
+        uniqueDepositors: uniqueDepositors?.count ?? 0,
+        poolBreakdown: poolBreakdown.results ?? [],
+        recentEvents: recentEvents.results ?? []
+      }
+    }, 200, env);
+  } catch (e: any) {
+    console.error("DB stats query failed:", e);
+    return jsonResponse({ ok: false, error: "Database error" }, 500, env);
+  }
+}
+
+// ── Cron Indexer ─────────────────────────────────────────────────────────────
+
+async function handleCron(env: Env): Promise<void> {
+  console.log("[cron] Referral indexer starting...");
+  const poolIds = env.POOL_IDS.split(",");
+
+  for (const poolId of poolIds) {
+    if (!poolId) continue;
+    console.log(`[cron] Indexing pool: ${poolId}`);
+
+    try {
+      // Scrape recent transactions on pool contract account from Horizon
+      const horizonUrl = `${env.HORIZON_URL}/accounts/${poolId}/transactions?order=desc&limit=50`;
+      const res = await fetch(horizonUrl);
+      if (!res.ok) {
+        console.error(`[cron] Failed to fetch transactions from Horizon for ${poolId}: ${res.statusText}`);
+        continue;
+      }
+
+      const data = await res.json() as any;
+      const txs = data._embedded?.records ?? [];
+
+      for (const tx of txs) {
+        if (tx.memo_type !== "text" || !tx.memo) continue;
+
+        const memoVal = tx.memo.trim();
+        if (!memoVal.startsWith("ref:")) continue;
+
+        const referralCode = memoVal.replace("ref:", "").trim();
+        if (!referralCode) continue;
+
+        // Verify that this code exists
+        const codeRow = await env.DB.prepare(
+          "SELECT code FROM referral_codes WHERE code = ?1"
+        ).bind(referralCode).first();
+
+        if (!codeRow) {
+          // Unregistered code, skip
+          continue;
+        }
+
+        // Get tx sender (depositor)
+        const depositor = tx.source_account;
+        const txHash = tx.hash;
+
+        try {
+          await env.DB.prepare(`
+            INSERT INTO referral_events (code, depositor_address, tx_hash, memo_raw, pool_id)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(tx_hash) DO NOTHING
+          `).bind(referralCode, depositor, txHash, memoVal, poolId).run();
+        } catch (dbErr) {
+          console.error(`[cron] Failed to record event for tx ${txHash}:`, dbErr);
+        }
+      }
+    } catch (e) {
+      console.error(`[cron] Exception while indexing ${poolId}:`, e);
+    }
+  }
+
+  console.log("[cron] Referral indexer complete.");
+}
+
+// ── Worker entry ─────────────────────────────────────────────────────────────
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(env) });
+    }
+
+    switch (url.pathname) {
+      case "/referrals/register":
+        if (request.method !== "POST") {
+          return jsonResponse({ error: "Method not allowed" }, 405, env);
+        }
+        return handleRegister(request, env);
+
+      case "/referrals/code":
+        return handleGetCode(request, env);
+
+      case "/referrals/stats":
+        return handleGetStats(request, env);
+
+      default:
+        return jsonResponse({ error: "Not found" }, 404);
+    }
+  },
+
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(handleCron(env));
+  },
+};

--- a/integrations/referrals/src/schema.sql
+++ b/integrations/referrals/src/schema.sql
@@ -1,0 +1,33 @@
+-- ── Referral Codes ───────────────────────────────────────────────────────────
+-- One referral code per wallet address. Code is deterministic but can be
+-- re-registered (idempotent upsert).
+CREATE TABLE IF NOT EXISTS referral_codes (
+  code          TEXT PRIMARY KEY,          -- e.g. "GABS4a3f"
+  owner_address TEXT NOT NULL UNIQUE,      -- G... Stellar address
+  created_at    TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ref_codes_owner
+  ON referral_codes(owner_address);
+
+-- ── Referral Events ───────────────────────────────────────────────────────────
+-- One row per referred deposit transaction found by the indexer.
+CREATE TABLE IF NOT EXISTS referral_events (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  code             TEXT    NOT NULL,        -- FK → referral_codes.code
+  depositor_address TEXT   NOT NULL,        -- G... address that made the tx
+  tx_hash          TEXT    NOT NULL UNIQUE, -- Stellar tx hash
+  memo_raw         TEXT    NOT NULL,        -- full memo string (e.g. "ref:GABS4a3f")
+  pool_id          TEXT    NOT NULL,        -- Blend pool contract ID
+  indexed_at       TEXT    DEFAULT (datetime('now')),
+  FOREIGN KEY (code) REFERENCES referral_codes(code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ref_events_code
+  ON referral_events(code);
+
+CREATE INDEX IF NOT EXISTS idx_ref_events_depositor
+  ON referral_events(depositor_address);
+
+CREATE INDEX IF NOT EXISTS idx_ref_events_pool
+  ON referral_events(pool_id);

--- a/integrations/referrals/tsconfig.json
+++ b/integrations/referrals/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/integrations/referrals/wrangler.toml
+++ b/integrations/referrals/wrangler.toml
@@ -1,0 +1,17 @@
+name = "turbolong-referrals"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[triggers]
+crons = ["*/15 * * * *"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "turbolong-referrals"
+database_id = "<run `npm run db:create` and paste the ID here>"
+
+[vars]
+FRONTEND_ORIGIN = "https://app.turbolong.com"
+HORIZON_URL = "https://horizon.stellar.org"
+# Pool contract IDs to watch for incoming deposit memos (comma-separated)
+POOL_IDS = "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI,CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD"


### PR DESCRIPTION
Close: #58
## Summary

 Health-Factor Alert Channel — Complete
alerts/src/schema.sql

hf_threshold REAL DEFAULT NULL — user-configured alert trigger, NULL = APY-only subscriber
hf_breached INTEGER DEFAULT 0 — tracks whether we're inside an active breach window (prevents spam)
alerts/src/stellar.ts

Extended ReserveRates interface with optional cFactor? and lFactor?
Parses them from reserveRaw.config.c_factor / l_factor (falls back to 0.9 / 1.0)
alerts/src/email.ts

New sendHealthFactorAlert() — rich HTML email showing current HF vs threshold, with liquidation risk copy and CTA
alerts/src/index.ts — the core logic:

Subscribe route: accepts optional hf_threshold, validates >= 1.0, stores in D1
Cron handleCron: for every bracket, computes currentHf = (cFactor × lev) / ((lev−1) / lFactor), then:
HF subscribers: sends alert when currentHf < threshold AND hf_breached = 0, sets hf_breached = 1. Resets to 0 when HF heals — exactly one email per breach window
APY subscribers: unchanged — 24h cooldown still applies
frontend/index.html

New "Health Factor Threshold (Optional)" <input type="number" min="1.0"> in the alert modal
Modal title updated to "Position Alerts"
frontend/src/main.ts

Reads and validates the threshold input (must be ≥ 1.0 or empty)
Conditionally includes hf_threshold in the /subscribe POST body
Clears the field on successful subscription
## Related Issue

Closes #58

## Checks

- [ ] I read the [contribution guide][contribution-guide].
- [ ] I kept this pull request scoped to the linked issue.
- [ ] I ran the relevant local checks or explained why they were skipped.
- [ ] For Drips wave issues, I claimed the issue before opening this pull request.

## Notes for Reviewers

<!-- Add reviewer notes, screenshots, or skipped-check explanations here. -->

[contribution-guide]: https://github.com/Dgetsylver/TurboLong/blob/main/CONTRIBUTING.md
