### PR TITLE
feat: remove hardcoded testnet secret key and add dollar return calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@ scripts/node_modules/
 scripts/package-lock.json
 .DS_Store
 src/.DS_Store
-# Never commit private keys
+# Never commit private keys or local env files
 *.key
 *.secret
+.env.local
+.env*.local
 
 frontend/node_modules/
 frontend/dist/

--- a/SECURITY-TODO.md
+++ b/SECURITY-TODO.md
@@ -1,0 +1,16 @@
+# Security TODO
+
+## Rotated Credentials
+
+### Testnet deployer key — leaked in source (closed by #43)
+
+- **File affected**: `scripts/deploy_strategy.ts`
+- **Issue**: Testnet deployer secret key was hardcoded in plain text.
+- **Fix applied**: Key removed; script now reads `DEPLOY_SECRET_KEY` from the environment.
+  Store the key in `.env.local` (git-ignored) and inject before running:
+  ```
+  DEPLOY_SECRET_KEY=S... npx tsx scripts/deploy_strategy.ts
+  ```
+- **Rotation required**: The key ending in `...E527` was exposed in git history and must be
+  considered compromised. Generate a new testnet keypair and fund it via Friendbot before the
+  next deploy. Do **not** reuse the leaked key even on testnet.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -429,6 +429,23 @@
                     <span>Days to liquidation</span><strong id="prev-liq-days">—</strong>
                   </div>
                 </div>
+                <!-- Return calculator (#36) -->
+                <div class="return-calc">
+                  <div class="form-group" style="margin-bottom:6px">
+                    <label>Return calculator <span class="tooltip" data-tip="Enter a USD deposit amount to see estimated returns at the current leverage and net APY. No wallet needed.">?</span></label>
+                    <div style="position:relative">
+                      <span class="input-suffix" style="right:auto;left:12px">$</span>
+                      <input type="number" id="calc-deposit-usd" class="input mono" placeholder="1000" min="0" step="any" style="padding-left:26px" />
+                    </div>
+                  </div>
+                  <div class="preview-row">
+                    <span>Weekly return</span><strong id="calc-weekly">—</strong>
+                  </div>
+                  <div class="preview-row">
+                    <span>Monthly return</span><strong id="calc-monthly">—</strong>
+                  </div>
+                  <p class="disclaimer">Simple APY &divide; 52 per week, &divide; 12 per month &mdash; not compounded.</p>
+                </div>
                 <p class="hf-warning hidden" id="hf-warning">&#9888; HF too low — liquidation risk. Reduce leverage.</p>
                 <p class="hf-warning hidden" id="liquidity-warning"></p>
               </div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1236,6 +1236,25 @@ function updatePreview() {
 
     // APY chart (#14)
     renderApyChart(rs, lev, equity, oldSupply, oldBorrow);
+
+    // Return calculator (#36)
+    const depositUsd = parseFloat(($("calc-deposit-usd") as HTMLInputElement).value);
+    const weeklyEl  = $("calc-weekly");
+    const monthlyEl = $("calc-monthly");
+    if (!isNaN(depositUsd) && depositUsd > 0) {
+      const weekly  = depositUsd * netApy / 100 / 52;
+      const monthly = depositUsd * netApy / 100 / 12;
+      const cls = netApy > 0 ? "apr-great" : netApy < 0 ? "apr-bad" : "";
+      weeklyEl.textContent  = `$${fmt(weekly, 2)}`;
+      monthlyEl.textContent = `$${fmt(monthly, 2)}`;
+      weeklyEl.className  = cls;
+      monthlyEl.className = cls;
+    } else {
+      weeklyEl.textContent  = "\u2014";
+      monthlyEl.textContent = "\u2014";
+      weeklyEl.className  = "";
+      monthlyEl.className = "";
+    }
   }
 
   // Risk zone labels (#9)
@@ -2224,6 +2243,7 @@ async function refreshAddFundsBalance() {
 });
 ($("initial-input")   as HTMLInputElement).addEventListener("input",  () => { refreshTabData(); updatePreview(); });
 ($("initial-input")   as HTMLInputElement).addEventListener("change", () => { refreshTabData(); updatePreview(); });
+($("calc-deposit-usd") as HTMLInputElement).addEventListener("input", updatePreview);
 
 // ── Demo mode (#17) ──────────────────────────────────────────────────────────
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -640,6 +640,9 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .preview-net-apr { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
 .prev-net-apr { font-size: 16px !important; font-weight: 700 !important; }
 
+.return-calc { margin-top: 12px; padding: 10px 14px; background: var(--metric-bg); border: 1px solid var(--border); border-radius: var(--r); }
+.return-calc .form-group { margin-bottom: 6px; }
+
 .hf-ok   { color: var(--success) !important; }
 .hf-warn { color: var(--warning) !important; }
 .hf-bad  { color: var(--danger)  !important; }

--- a/scripts/deploy_strategy.ts
+++ b/scripts/deploy_strategy.ts
@@ -21,7 +21,17 @@ import * as crypto from "crypto";
 
 const RPC_URL = "https://soroban-testnet.stellar.org";
 const PASSPHRASE = Networks.TESTNET;
-const SECRET = "SCX6RZDDWLKWLSUEKDROH3PCXDPAVVJ355YA4FEHQB3MJMA6K762E527";
+
+const SECRET = process.env.DEPLOY_SECRET_KEY;
+if (!SECRET) {
+  console.error(
+    "Error: DEPLOY_SECRET_KEY is not set.\n" +
+    "Create a .env.local file with:\n" +
+    "  DEPLOY_SECRET_KEY=S...\n" +
+    "Then run: DEPLOY_SECRET_KEY=$(grep DEPLOY_SECRET_KEY .env.local | cut -d= -f2) npx tsx scripts/deploy_strategy.ts"
+  );
+  process.exit(1);
+}
 
 const keypair = Keypair.fromSecret(SECRET);
 const account = keypair.publicKey();


### PR DESCRIPTION
## Summary

- **#43 (D2)** — Removes the hardcoded testnet deployer secret key from `scripts/deploy_strategy.ts`. The script now reads `DEPLOY_SECRET_KEY` from the environment and exits with a clear, actionable message if the variable is missing. `.env.local` is added to `.gitignore`, and `SECURITY-TODO.md` documents the leaked key and rotation instructions.
- **#36 (B9)** — Adds a dollar return calculator to the action card in the frontend. Users enter a USD deposit amount and see `$X / week` and `$Y / month` estimates at the current net APY, pool, asset, and leverage. Updates live on every input change. Works without a wallet connection. Uses simple `APY / 52` and `APY / 12` (not compounded) with a visible disclosure.

## Changes

- `scripts/deploy_strategy.ts` — replace hardcoded secret with `process.env.DEPLOY_SECRET_KEY`; fail-fast with helpful error if unset
- `.gitignore` — add `.env.local` and `.env*.local`
- `SECURITY-TODO.md` — new file logging the leak, fix, and rotation requirement
- `frontend/index.html` — return calculator section with USD input, weekly/monthly output rows, and non-compounding disclaimer
- `frontend/src/main.ts` — live calculation logic in `updatePreview()`; event listener on the new input
- `frontend/src/style.css` — `.return-calc` styles

## Test plan

- [ ] Run `npx tsx scripts/deploy_strategy.ts` with no env var set — confirm clean error message and non-zero exit
- [ ] Set `DEPLOY_SECRET_KEY=<key>` and verify script proceeds past the guard
- [ ] Confirm `.env.local` is ignored by git (`git status` shows no tracking)
- [ ] Open the frontend, select a pool/asset/leverage — return calculator section is visible without wallet
- [ ] Enter a USD amount — weekly and monthly outputs update immediately
- [ ] Change pool, asset, or leverage — outputs update live
- [ ] Verify negative APY scenario shows red values; positive shows green

Closes #43
Closes #36