### PR TITLE
feat: Safe Max button with configurable HF floor (#6)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,10 @@
         <div id="settings-dropdown" class="settings-dropdown hidden">
           <button id="expert-toggle" class="settings-dropdown-item">Expert Mode <span class="settings-badge">Off</span></button>
           <button id="theme-toggle" class="settings-dropdown-item">Theme <span class="settings-badge">&#9790;</span></button>
+          <div class="settings-dropdown-item settings-hf-floor">
+            <label for="hf-floor-input">Safe Max HF floor</label>
+            <input type="number" id="hf-floor-input" class="input mono" min="1.01" max="3" step="0.01" value="1.2" style="width:5rem" />
+          </div>
         </div>
         <button id="network-toggle" class="btn btn-ghost btn-sm network-toggle" data-tip="Switch between Mainnet and Testnet">Mainnet</button>
         <button id="connect-btn" class="btn btn-primary btn-connect">Connect Wallet</button>
@@ -396,6 +400,7 @@
                   <input type="range" id="leverage-slider" min="1.1" max="12.9" step="0.1" value="2.0" class="slider" />
                   <input type="number" id="leverage-input" class="input mono leverage-num-input" min="1.1" max="12.9" step="0.1" value="2.0" />
                   <span class="slider-value-x mono">&times;</span>
+                  <button id="safe-max-btn" class="btn btn-ghost btn-sm" data-tip="Set leverage to the highest value where projected HF ≥ your configured floor">Safe Max</button>
                 </div>
                 <div class="slider-zones" id="slider-zones">
                   <span class="slider-zone zone-conservative" data-zone="conservative">Conservative</span>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -324,6 +324,21 @@ const MIN_HF_NORMAL = 1.01;
 const MIN_HF_EXPERT = 1.00001;
 function minHF() { return expertMode ? MIN_HF_EXPERT : MIN_HF_NORMAL; }
 
+// ── Safe Max HF floor ────────────────────────────────────────────────────────
+
+const HF_FLOOR_KEY = "safeMaxHfFloor";
+const HF_FLOOR_DEFAULT = 1.2;
+
+function getHfFloor(): number {
+  const raw = localStorage.getItem(HF_FLOOR_KEY);
+  const v = raw ? parseFloat(raw) : HF_FLOOR_DEFAULT;
+  return isFinite(v) && v >= 1.01 ? v : HF_FLOOR_DEFAULT;
+}
+
+function setHfFloor(v: number) {
+  localStorage.setItem(HF_FLOOR_KEY, String(v));
+}
+
 // ── Demo mode ────────────────────────────────────────────────────────────────
 
 let demoMode = false;
@@ -2707,6 +2722,39 @@ $("vault-rebalance-btn").addEventListener("click", async () => {
     ($("vault-rebalance-btn") as HTMLButtonElement).disabled = false;
     ($("vault-rebalance-btn") as HTMLButtonElement).textContent = "Rebalance";
   }
+});
+
+// ── Safe Max button ───────────────────────────────────────────────────────────
+
+function applySafeMax() {
+  const slider = $("leverage-slider") as HTMLInputElement;
+  const numIn  = $("leverage-input")  as HTMLInputElement;
+  const rs     = reserves.find(r => r.asset.id === selectedAsset.id);
+  const c      = rs ? rs.cFactor : selectedAsset.cFactor;
+  const l      = rs?.lFactor ?? 1;
+  const floor  = getHfFloor();
+  const maxSlider = parseFloat(slider.max);
+
+  // Walk down from slider max in 0.1 steps to find highest leverage with HF >= floor
+  let best = 1.0;
+  for (let lev = maxSlider; lev >= 1.0; lev = Math.round((lev - 0.1) * 10) / 10) {
+    if (hfForLeverage(lev, c, l) >= floor) { best = lev; break; }
+  }
+
+  slider.value = String(best);
+  numIn.value  = best.toFixed(1);
+  updatePreview();
+}
+
+$("safe-max-btn").addEventListener("click", applySafeMax);
+
+// HF floor input (settings dropdown)
+const hfFloorInput = $("hf-floor-input") as HTMLInputElement;
+hfFloorInput.value = String(getHfFloor());
+hfFloorInput.addEventListener("change", () => {
+  const v = parseFloat(hfFloorInput.value);
+  if (isFinite(v) && v >= 1.01) setHfFloor(v);
+  else hfFloorInput.value = String(getHfFloor()); // revert invalid
 });
 
 // ── Auto-reconnect saved wallet ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
One-click Safe Max button that snaps the leverage slider to the highest
value where projected HF ≥ a user-configured floor.

## Changes
- Safe Max button added inline next to the leverage slider; walks down
  from slider max in 0.1× steps and picks the highest leverage where
  hfForLeverage >= floor
- HF floor input added to settings dropdown (default 1.2, min 1.01)
- Floor persisted in localStorage under key `safeMaxHfFloor`

## Acceptance criteria
- [x] Clicking Safe Max snaps slider to max leverage where projected HF >= floor
- [x] Floor is editable in settings menu and persists across reloads

Closes #6