### PR TITLE
feat: architecture diagram + RPC rate-limiting with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# TurboLong
+
+Leveraged long positions on [Blend Protocol](https://blend.capital) — Stellar / Soroban.
+
+## Architecture
+
+![Architecture diagram](docs/diagrams/architecture.svg)
+
+| Layer | Description |
+|---|---|
+| **User** | Interacts via browser |
+| **Wallet** | Freighter, xBull, Albedo, Lobstr, Hana — signs XDR |
+| **Frontend** | `blend.ts` + `main.ts` — builds transactions, rate-limits RPC calls with exponential backoff |
+| **Soroban RPC** | Simulates and submits Soroban transactions |
+| **Blend Pool** | `submit_with_allowance` — atomic supply / borrow / repay / withdraw |
+| **b / d Tokens** | bToken = collateral receipt, dToken = debt receipt |
+
+## Quickstart
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Docs
+
+- [`doc.md`](doc.md) — strategy overview
+- [`profitability_analysis.md`](profitability_analysis.md) — rate and profit modelling
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution guide

--- a/docs/diagrams/architecture.svg
+++ b/docs/diagrams/architecture.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 340" width="860" height="340" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="13">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#6b7280"/>
+    </marker>
+    <style>
+      .box       { rx:8; ry:8; stroke-width:1.5 }
+      .user      { fill:#dbeafe; stroke:#3b82f6 }
+      .wallet    { fill:#ede9fe; stroke:#7c3aed }
+      .frontend  { fill:#dcfce7; stroke:#16a34a }
+      .rpc       { fill:#fef9c3; stroke:#ca8a04 }
+      .pool      { fill:#fee2e2; stroke:#dc2626 }
+      .token     { fill:#f3f4f6; stroke:#6b7280 }
+      .label     { fill:#111827; font-weight:600 }
+      .sub       { fill:#6b7280; font-size:11px }
+      .edge      { stroke:#6b7280; stroke-width:1.5; fill:none; marker-end:url(#arrow) }
+      .edgelabel { fill:#6b7280; font-size:11px }
+    </style>
+  </defs>
+
+  <!-- User -->
+  <rect class="box user" x="20" y="130" width="100" height="60"/>
+  <text class="label" x="70" y="156" text-anchor="middle">User</text>
+  <text class="sub"   x="70" y="174" text-anchor="middle">browser</text>
+
+  <!-- Wallet -->
+  <rect class="box wallet" x="170" y="130" width="110" height="60"/>
+  <text class="label" x="225" y="156" text-anchor="middle">Wallet</text>
+  <text class="sub"   x="225" y="174" text-anchor="middle">Freighter / xBull</text>
+
+  <!-- Frontend -->
+  <rect class="box frontend" x="335" y="100" width="130" height="120"/>
+  <text class="label" x="400" y="130" text-anchor="middle">Frontend</text>
+  <text class="sub"   x="400" y="148" text-anchor="middle">blend.ts</text>
+  <text class="sub"   x="400" y="164" text-anchor="middle">main.ts</text>
+  <text class="sub"   x="400" y="180" text-anchor="middle">rate-limit + retry</text>
+  <text class="sub"   x="400" y="196" text-anchor="middle">exp. backoff + jitter</text>
+
+  <!-- Soroban RPC -->
+  <rect class="box rpc" x="530" y="60" width="130" height="60"/>
+  <text class="label" x="595" y="86" text-anchor="middle">Soroban RPC</text>
+  <text class="sub"   x="595" y="104" text-anchor="middle">simulate / send</text>
+
+  <!-- Blend Pool -->
+  <rect class="box pool" x="530" y="180" width="130" height="60"/>
+  <text class="label" x="595" y="206" text-anchor="middle">Blend Pool</text>
+  <text class="sub"   x="595" y="224" text-anchor="middle">submit_with_allowance</text>
+
+  <!-- b/d tokens -->
+  <rect class="box token" x="720" y="130" width="120" height="80"/>
+  <text class="label" x="780" y="162" text-anchor="middle">b / d Tokens</text>
+  <text class="sub"   x="780" y="180" text-anchor="middle">bToken = collateral</text>
+  <text class="sub"   x="780" y="196" text-anchor="middle">dToken = debt</text>
+
+  <!-- Edges -->
+  <!-- User → Wallet -->
+  <line class="edge" x1="120" y1="160" x2="168" y2="160"/>
+  <text class="edgelabel" x="144" y="153" text-anchor="middle">sign</text>
+
+  <!-- Wallet → Frontend -->
+  <line class="edge" x1="280" y1="160" x2="333" y2="160"/>
+  <text class="edgelabel" x="306" y="153" text-anchor="middle">XDR</text>
+
+  <!-- Frontend → Soroban RPC -->
+  <path class="edge" d="M465,130 Q500,90 528,90"/>
+  <text class="edgelabel" x="494" y="100" text-anchor="middle">simulate</text>
+
+  <!-- Frontend → Blend Pool -->
+  <path class="edge" d="M465,190 Q500,210 528,210"/>
+  <text class="edgelabel" x="494" y="225" text-anchor="middle">submit</text>
+
+  <!-- Soroban RPC → Blend Pool (on-chain) -->
+  <line class="edge" x1="595" y1="120" x2="595" y2="178"/>
+  <text class="edgelabel" x="600" y="153" text-anchor="start">on-chain</text>
+
+  <!-- Blend Pool → b/d tokens -->
+  <line class="edge" x1="660" y1="210" x2="718" y2="185"/>
+  <text class="edgelabel" x="686" y="193" text-anchor="middle">mint/burn</text>
+</svg>

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -334,14 +334,21 @@ function buildRequestsVec(items: xdr.ScVal[]): xdr.ScVal {
 
 // ── RPC retry helper ──────────────────────────────────────────────────────────
 
-async function withRetry<T>(fn: () => Promise<T>, retries = 2, delayMs = 1000): Promise<T> {
+async function withRetry<T>(fn: () => Promise<T>, retries = 4, baseDelayMs = 500): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
       return await fn();
-    } catch (e) {
+    } catch (e: any) {
       if (attempt >= retries) throw e;
-      console.warn(`RPC call failed (attempt ${attempt + 1}/${retries + 1}), retrying in ${delayMs}ms...`);
-      await new Promise(r => setTimeout(r, delayMs));
+      const is429 = e?.status === 429 || e?.response?.status === 429 ||
+                    String(e?.message ?? e).includes("429");
+      const delay = baseDelayMs * Math.pow(2, attempt) + Math.random() * 300;
+      if (is429) {
+        console.warn(`[rpc] 429 rate-limited — backing off ${Math.round(delay)}ms (attempt ${attempt + 1}/${retries + 1})`);
+      } else {
+        console.warn(`[rpc] call failed (attempt ${attempt + 1}/${retries + 1}), retrying in ${Math.round(delay)}ms...`);
+      }
+      await new Promise(r => setTimeout(r, delay));
     }
   }
 }
@@ -873,10 +880,10 @@ export async function buildApproveXdr(
   const token     = new Contract(assetId);
   const addrScVal = new Address(userAddress).toScVal();
   const poolScVal = new Address(pool.id).toScVal();
-  const ledger    = await server.getLatestLedger();
+  const ledger    = await withRetry(() => server.getLatestLedger());
   const expiry    = ledger.sequence + 120;
 
-  const acc = await server.getAccount(userAddress);
+  const acc = await withRetry(() => server.getAccount(userAddress));
   const tx  = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -890,7 +897,7 @@ export async function buildApproveXdr(
     ))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Approve simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -908,7 +915,7 @@ export async function buildOpenPositionXdr(
   const addrScVal    = new Address(userAddress).toScVal();
   const requests     = buildRequestsVec(buildOpenRequests(asset.id, initialStroops, cFactorBn, leverage));
 
-  const acc = await server.getAccount(userAddress);
+  const acc = await withRetry(() => server.getAccount(userAddress));
   const tx  = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -916,7 +923,7 @@ export async function buildOpenPositionXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Open position simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -955,7 +962,7 @@ export async function buildCloseSubmitXdr(
 
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx           = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -963,7 +970,7 @@ export async function buildCloseSubmitXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Close simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -992,7 +999,7 @@ export async function buildRepayXdr(
 
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx           = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1000,7 +1007,7 @@ export async function buildRepayXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Repay simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -1023,7 +1030,7 @@ export async function buildWithdrawXdr(
 
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx           = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1031,7 +1038,7 @@ export async function buildWithdrawXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Withdraw simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -1079,7 +1086,7 @@ export async function buildClaimXdr(
     tokenIds.map(id => nativeToScVal(id, { type: "u32" }))
   );
 
-  const acc = await server.getAccount(userAddress);
+  const acc = await withRetry(() => server.getAccount(userAddress));
   const tx  = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1087,7 +1094,7 @@ export async function buildClaimXdr(
     .addOperation(poolContract.call("claim", addrScVal, tokenIds_scv, addrScVal))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Claim simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -1143,7 +1150,7 @@ export async function buildIncreaseLeverageXdr(
   const requests = buildRequestsVec(items);
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1151,7 +1158,7 @@ export async function buildIncreaseLeverageXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Increase leverage simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -1185,7 +1192,7 @@ export async function buildDecreaseLeverageXdr(
 
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1193,7 +1200,7 @@ export async function buildDecreaseLeverageXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Decrease leverage simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();
@@ -1218,7 +1225,7 @@ export async function buildResupplyXdr(
 
   const poolContract = new Contract(pool.id);
   const addrScVal    = new Address(userAddress).toScVal();
-  const acc          = await server.getAccount(userAddress);
+  const acc          = await withRetry(() => server.getAccount(userAddress));
   const tx           = new TransactionBuilder(acc, {
     fee: (BigInt(BASE_FEE) * 10n).toString(),
     networkPassphrase: _cfg.passphrase,
@@ -1226,7 +1233,7 @@ export async function buildResupplyXdr(
     .addOperation(poolContract.call("submit_with_allowance", addrScVal, addrScVal, addrScVal, requests))
     .setTimeout(60).build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withRetry(() => server.simulateTransaction(tx));
   if (!SorobanRpc.Api.isSimulationSuccess(sim))
     throw new Error(`Resupply simulation failed: ${(sim as SorobanRpc.Api.SimulateTransactionErrorResponse).error}`);
   return SorobanRpc.assembleTransaction(tx, sim).build().toXDR();


### PR DESCRIPTION
## Summary

Closes #79
Closes #89

---

### #79 — Architecture diagram in root README

- Added `docs/diagrams/architecture.svg`: a flow diagram showing the full request path — **User → Wallet → Frontend → Soroban RPC → Blend Pool → b/d Tokens**
- Created `README.md` at the repo root, embedding the SVG with a layer description table, quickstart instructions, and links to existing docs
- SVG uses inline CSS `fill`/`stroke` classes so it renders correctly on both GitHub dark and light themes

### #89 — Rate-limit RPC calls from frontend

**`withRetry()` upgrade** (`frontend/src/blend.ts`):
- Retries increased from 2 → 4
- Fixed delay replaced with **exponential backoff**: `baseDelay × 2^attempt`
- Up to **300 ms random jitter** added per attempt to prevent retry storms
- **429 detection**: checks `error.status`, `error.response.status`, and the error message string; emits `console.warn` with the back-off duration when throttling triggers

**All bare `server.*` calls wrapped** in `withRetry()`:
- `buildApproveXdr` — `getLatestLedger`, `getAccount`, `simulateTransaction`
- `buildOpenPositionXdr` — `getAccount`, `simulateTransaction`
- `buildCloseSubmitXdr` — `getAccount`, `simulateTransaction`
- `buildRepayXdr` — `getAccount`, `simulateTransaction`
- `buildWithdrawXdr` — `getAccount`, `simulateTransaction`
- `buildClaimXdr` — `getAccount`, `simulateTransaction`
- `buildIncreaseLeverageXdr` — `getAccount`, `simulateTransaction`
- `buildDecreaseLeverageXdr` — `getAccount`, `simulateTransaction`
- `buildResupplyXdr` — `getAccount`, `simulateTransaction`

## Files changed

| File | Change |
|---|---|
| `README.md` | Created — root readme with embedded diagram |
| `docs/diagrams/architecture.svg` | Created — architecture flow SVG |
| `frontend/src/blend.ts` | `withRetry` upgraded; all bare RPC calls wrapped |