### PR TITLE
feat: real-time HF preview while dragging leverage slider

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2200,7 +2200,12 @@ async function refreshAddFundsBalance() {
   } catch { /* ignore */ }
 }
 
-($("leverage-slider") as HTMLInputElement).addEventListener("input",  updatePreview);
+let _leverageDebounce: ReturnType<typeof setTimeout> | null = null;
+function debouncedPreview() {
+  if (_leverageDebounce) clearTimeout(_leverageDebounce);
+  _leverageDebounce = setTimeout(updatePreview, 50);
+}
+($("leverage-slider") as HTMLInputElement).addEventListener("input", debouncedPreview);
 // Live preview while typing (no clamping so user can type multi-digit numbers like "10")
 ($("leverage-input")  as HTMLInputElement).addEventListener("input", () => {
   const numIn  = $("leverage-input")  as HTMLInputElement;


### PR DESCRIPTION
## Summary
Binds the leverage slider `input` event to `updatePreview()` via a 50ms debounce so the health factor value and color zone update live as the user drags.

## Changes
- Added `debouncedPreview()` wrapper (50ms `setTimeout`) in `frontend/src/main.ts`
- Slider `input` listener now calls `debouncedPreview()` instead of `updatePreview()` directly

## Acceptance criteria
- ✅ HF updates within 100ms of slider movement (50ms debounce)
- ✅ No additional RPC calls during drag — `updatePreview()` is pure client-side, using cached `reserves` state via `hfForLeverage()` and `projectRates()`
- ✅ Preview matches post-submit HF within rounding error — same `hfForLeverage()` formula used in both preview and submit validation

Closes #3