### PR TITLE
feat(ci): enforce Clippy + rustfmt on every Rust PR

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -1,0 +1,44 @@
+name: Rust Lint
+
+on:
+  push:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust-lint.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust-lint.yml"
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rust-lint.yml` with two CI jobs:
  - `clippy`: runs `cargo clippy -- -D warnings` (fails on any warning)
  - `rustfmt`: runs `cargo fmt --all -- --check` (fails on any formatting diff)
- Triggers on push/PR touching `src/**`, `Cargo.toml`, or `Cargo.lock`
- Uses `Swatinem/rust-cache` to keep CI fast

## Test plan

- [ ] Push a Rust file with a Clippy warning → `rust-lint.yml` / clippy job fails
- [ ] Push a Rust file with a formatting diff → rustfmt job fails
- [ ] Clean Rust push → both jobs pass

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)