### PR TITLE
feat(#48): multi-pool / multi-asset PoolRouter contract

### DIFF
--- a/contracts/strategies/router/Cargo.toml
+++ b/contracts/strategies/router/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "blend_leverage_router"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "25.3.0"
+soroban-fixed-point-math = "1.3.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "25.3.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/strategies/router/README.md
+++ b/contracts/strategies/router/README.md
@@ -1,0 +1,90 @@
+# PoolRouter
+
+A Soroban smart contract that acts as an entry point for multi-pool deposits, routing user funds to the registered strategy offering the best net APY.
+
+## Overview
+
+Currently, each `BlendLeverageStrategy` is single-pool: one deployment = one Blend pool. `PoolRouter` sits in front of multiple strategies and automatically directs deposits to the highest-yield option, while giving users the option to override the selection.
+
+```
+User
+ │
+ ▼
+PoolRouter.deposit(amount, from, preferred?)
+ │
+ ├── select_strategy()  →  Strategy A (APY 8.2%)  ◄ chosen (highest)
+ │                         Strategy B (APY 7.1%)
+ │                         Strategy C (APY 5.8%)
+ │
+ └── StrategyA.deposit(amount, router_addr)
+```
+
+## Architecture
+
+### Virtual shares
+
+The router itself is the depositor in each underlying strategy. Strategy contracts track the router's aggregate balance. Internally, the router issues **virtual shares** to each user proportional to their contribution to the router's position in a given strategy.
+
+```
+User deposits 1 000 USDC into Strategy A (first depositor):
+  router_balance_before = 0  →  user gets 1 000 virtual shares (1:1)
+
+User 2 deposits 500 USDC into Strategy A (pool has grown to 1 100):
+  user2_vs = 500 × 1 000 / 1 100 ≈ 454 virtual shares
+
+User 2's underlying = 454 / 1 454 × 1 600 ≈ 499 USDC
+```
+
+### APY snapshots
+
+The router does **not** query Blend pool rates on-chain (this would require re-entrant calls across multiple pools in a single transaction). Instead, the admin (or a trusted keeper that integrates with the B3 rate-snapshot oracle) calls `update_apy(strategy, net_apy_bps)` to write the current net yield for each strategy. The router then reads these snapshots to pick the best pool deterministically.
+
+## Initialisation
+
+```rust
+PoolRouter::__constructor(
+    asset:      Address,       // underlying asset (must match all strategies)
+    init_args:  Vec<Val>,
+    //  [0] admin:    Address  — manages registry and APY updates
+    //  [1..N] strategy: Address  — initial strategy addresses (optional)
+)
+```
+
+## Key methods
+
+| Method | Auth | Description |
+|--------|------|-------------|
+| `deposit(amount, from, preferred?)` | `from` | Route deposit to best (or preferred) strategy |
+| `withdraw(amount, from, to)` | `from` | Withdraw from user's current strategy |
+| `balance(from)` | none | User's underlying value across the router |
+| `best_strategy()` | none | Preview which strategy would be chosen |
+| `add_strategy(strategy)` | admin | Register a new strategy |
+| `remove_strategy(strategy)` | admin | De-register a strategy |
+| `update_apy(strategy, bps)` | admin | Publish a new APY snapshot |
+| `set_admin(new_admin)` | admin | Transfer admin role |
+| `strategies()` | none | List all registered strategies with APY |
+
+## Migration from a single-pool strategy
+
+Existing depositors in a `BlendLeverageStrategy` can migrate gradually:
+
+1. **No forced migration** — existing positions in individual strategy contracts are unaffected. The router is purely additive.
+2. **Withdraw + re-deposit** — to benefit from automatic routing, a user:
+   1. Calls `strategy.withdraw(balance, from, to)` on their current strategy.
+   2. Calls `router.deposit(amount, from, None)` to enter the router with automatic best-pool selection.
+3. **Front-end guidance** — the DeFindex UI can prompt users with a "Migrate to router" flow once the router holds strategies with competitive APYs.
+
+## Routing algorithm
+
+`select_strategy` is deterministic:
+
+1. Iterate registered strategies and find the one with the highest `net_apy_bps`.
+2. Ties are broken by insertion order (earlier registration wins), ensuring stable selection when multiple pools report identical rates.
+3. If the user supplies `preferred_strategy`, the router verifies it is registered and uses it directly (skipping the APY comparison).
+
+## Events
+
+| Topic | Data | Description |
+|-------|------|-------------|
+| `(RouterDeposit, from)` | `(strategy, amount, virtual_shares)` | Emitted on each successful deposit |
+| `(RouterWithdraw, from)` | `(strategy, amount)` | Emitted on each successful withdrawal |

--- a/contracts/strategies/router/src/lib.rs
+++ b/contracts/strategies/router/src/lib.rs
@@ -1,0 +1,442 @@
+#![no_std]
+
+mod storage;
+
+use soroban_sdk::{
+    contract, contractclient, contractimpl, contracterror, token::TokenClient, Address, Env,
+    IntoVal, Symbol, Val, Vec,
+};
+use storage::{extend_instance_ttl, StrategyEntry, UserPosition};
+
+// ── Router errors ─────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RouterError {
+    NoStrategiesRegistered = 1,
+    StrategyNotFound = 2,
+    NoPositionFound = 3,
+    InsufficientBalance = 4,
+    ArithmeticError = 5,
+    Unauthorized = 6,
+    InvalidAmount = 7,
+    StrategyAlreadyRegistered = 8,
+}
+
+// ── Strategy interface (minimal client) ───────────────────────────────────────
+//
+// The router calls these three methods on each underlying strategy contract.
+// The signatures match the DeFindexStrategyTrait methods used by all Blend
+// leverage strategies; the client is generated from the trait definition here
+// so no import of the concrete strategy crate is required.
+
+#[contractclient(name = "StrategyClient")]
+pub trait IStrategy {
+    fn deposit(e: Env, amount: i128, from: Address) -> i128;
+    fn withdraw(e: Env, amount: i128, from: Address, to: Address) -> i128;
+    fn balance(e: Env, from: Address) -> i128;
+}
+
+// ── Router contract ───────────────────────────────────────────────────────────
+
+#[contract]
+pub struct PoolRouter;
+
+#[contractimpl]
+impl PoolRouter {
+    /// Initialise the router.
+    ///
+    /// init_args layout:
+    ///   [0] admin: Address           — manages the strategy registry and APY updates
+    ///   [1..N] strategy: Address     — initial strategy addresses (may be empty)
+    pub fn __constructor(e: Env, asset: Address, init_args: Vec<Val>) {
+        let admin: Address = init_args
+            .get(0)
+            .expect("Missing: admin")
+            .into_val(&e);
+
+        storage::set_admin(&e, &admin);
+        storage::set_asset(&e, &asset);
+
+        // Register any strategy addresses supplied at construction time.
+        let mut entries: Vec<StrategyEntry> = Vec::new(&e);
+        let mut i = 1u32;
+        while let Some(raw) = init_args.get(i) {
+            let strategy: Address = raw.into_val(&e);
+            entries.push_back(StrategyEntry {
+                address: strategy,
+                net_apy_bps: 0,
+            });
+            i += 1;
+        }
+        storage::set_strategies(&e, &entries);
+    }
+
+    // ── Strategy registry management (admin-only) ─────────────────────────────
+
+    /// Add a new strategy to the registry with an initial APY of 0 bps.
+    /// The admin must call `update_apy` to set a meaningful rate before deposits
+    /// can be routed to this strategy deterministically.
+    pub fn add_strategy(e: Env, strategy: Address) -> Result<(), RouterError> {
+        extend_instance_ttl(&e);
+        let admin = storage::get_admin(&e);
+        admin.require_auth();
+
+        let mut strategies = storage::get_strategies(&e);
+        for i in 0..strategies.len() {
+            if strategies.get(i).unwrap().address == strategy {
+                return Err(RouterError::StrategyAlreadyRegistered);
+            }
+        }
+        strategies.push_back(StrategyEntry {
+            address: strategy,
+            net_apy_bps: 0,
+        });
+        storage::set_strategies(&e, &strategies);
+        Ok(())
+    }
+
+    /// Remove a strategy from the registry.
+    /// Existing user positions in this strategy are unaffected; they can still withdraw.
+    pub fn remove_strategy(e: Env, strategy: Address) -> Result<(), RouterError> {
+        extend_instance_ttl(&e);
+        let admin = storage::get_admin(&e);
+        admin.require_auth();
+
+        let strategies = storage::get_strategies(&e);
+        let mut updated: Vec<StrategyEntry> = Vec::new(&e);
+        let mut found = false;
+        for i in 0..strategies.len() {
+            let entry = strategies.get(i).unwrap();
+            if entry.address == strategy {
+                found = true;
+            } else {
+                updated.push_back(entry);
+            }
+        }
+        if !found {
+            return Err(RouterError::StrategyNotFound);
+        }
+        storage::set_strategies(&e, &updated);
+        Ok(())
+    }
+
+    /// Update the net-APY snapshot for a registered strategy (basis points).
+    /// This value is read from an off-chain rate oracle (see B3) and written
+    /// on-chain by the admin or a trusted keeper before each routing decision.
+    pub fn update_apy(
+        e: Env,
+        strategy: Address,
+        net_apy_bps: i128,
+    ) -> Result<(), RouterError> {
+        extend_instance_ttl(&e);
+        let admin = storage::get_admin(&e);
+        admin.require_auth();
+
+        // Verify strategy is registered and update its snapshot.
+        let mut strategies = storage::get_strategies(&e);
+        let mut found = false;
+        for i in 0..strategies.len() {
+            let mut entry = strategies.get(i).unwrap();
+            if entry.address == strategy {
+                entry.net_apy_bps = net_apy_bps;
+                strategies.set(i, entry);
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(RouterError::StrategyNotFound);
+        }
+        storage::set_strategies(&e, &strategies);
+        storage::set_strategy_apy(&e, &strategy, net_apy_bps);
+        Ok(())
+    }
+
+    /// Transfer the admin role to a new address.
+    pub fn set_admin(e: Env, new_admin: Address) -> Result<(), RouterError> {
+        extend_instance_ttl(&e);
+        let admin = storage::get_admin(&e);
+        admin.require_auth();
+        storage::set_admin(&e, &new_admin);
+        Ok(())
+    }
+
+    // ── Deposit ───────────────────────────────────────────────────────────────
+
+    /// Deposit `amount` of the underlying asset into the best-APY strategy.
+    ///
+    /// The router:
+    ///   1. Selects the registered strategy with the highest `net_apy_bps`.
+    ///   2. If `preferred_strategy` is provided and is registered, uses it instead.
+    ///   3. Transfers `amount` from `from` to the router, then calls the strategy's
+    ///      `deposit` with the router as the depositor.
+    ///   4. Issues virtual shares to the user proportional to their contribution.
+    ///
+    /// Returns the user's underlying value after the deposit.
+    pub fn deposit(
+        e: Env,
+        amount: i128,
+        from: Address,
+        preferred_strategy: Option<Address>,
+    ) -> Result<i128, RouterError> {
+        extend_instance_ttl(&e);
+        if amount <= 0 {
+            return Err(RouterError::InvalidAmount);
+        }
+        from.require_auth();
+
+        // If the user already has a position, route to their current strategy unless
+        // they explicitly request a different one via preferred_strategy.
+        let existing_position = storage::get_user_position(&e, &from);
+        let chosen = if preferred_strategy.is_some() {
+            Self::select_strategy(&e, preferred_strategy)?
+        } else if let Some(ref pos) = existing_position {
+            pos.strategy.clone()
+        } else {
+            Self::select_strategy(&e, None)?
+        };
+
+        let router_addr = e.current_contract_address();
+        let strategy_client = StrategyClient::new(&e, &chosen);
+
+        // Query router's existing balance before deposit for accurate share pricing.
+        let router_balance_before = strategy_client.balance(&router_addr);
+
+        // Pull asset from user into the router, then forward to the strategy.
+        let asset = storage::get_asset(&e);
+        let token = TokenClient::new(&e, &asset);
+        token.transfer(&from, &router_addr, &amount);
+
+        let router_balance_after = strategy_client.deposit(&amount, &router_addr);
+
+        // Mint virtual shares for the user proportional to their contribution.
+        let total_vs = storage::get_strategy_virtual_shares(&e, &chosen);
+        let user_vs = if total_vs == 0 || router_balance_before <= 0 {
+            // First depositor into this strategy via the router: 1 virtual share = 1 unit.
+            amount
+        } else {
+            // Proportional allocation: user_vs = amount × total_vs / router_balance_before
+            amount
+                .checked_mul(total_vs)
+                .ok_or(RouterError::ArithmeticError)?
+                .checked_div(router_balance_before)
+                .ok_or(RouterError::ArithmeticError)?
+        };
+
+        let total_vs_after = total_vs + user_vs;
+        storage::set_strategy_virtual_shares(&e, &chosen, total_vs_after);
+
+        // Each user holds one position in the router (single strategy).
+        // If they already have a position in the same strategy, accumulate shares.
+        // To switch strategies, users must withdraw their current position first.
+        let new_vs = match &existing_position {
+            Some(pos) if pos.strategy == chosen => pos.virtual_shares + user_vs,
+            _ => user_vs,
+        };
+        storage::set_user_position(
+            &e,
+            &from,
+            &UserPosition {
+                strategy: chosen.clone(),
+                virtual_shares: new_vs,
+            },
+        );
+
+        e.events().publish(
+            (Symbol::new(&e, "RouterDeposit"), from.clone()),
+            (chosen, amount, user_vs),
+        );
+
+        // Return underlying value: new_vs / total_vs_after × router_balance_after
+        let underlying = new_vs
+            .checked_mul(router_balance_after)
+            .ok_or(RouterError::ArithmeticError)?
+            .checked_div(total_vs_after)
+            .ok_or(RouterError::ArithmeticError)?;
+        Ok(underlying)
+    }
+
+    // ── Withdraw ──────────────────────────────────────────────────────────────
+
+    /// Withdraw `amount` of underlying from the user's strategy position.
+    /// The net equity is sent directly to `to`.
+    ///
+    /// Returns the user's remaining underlying balance after withdrawal.
+    pub fn withdraw(
+        e: Env,
+        amount: i128,
+        from: Address,
+        to: Address,
+    ) -> Result<i128, RouterError> {
+        extend_instance_ttl(&e);
+        if amount <= 0 {
+            return Err(RouterError::InvalidAmount);
+        }
+        from.require_auth();
+
+        let position = storage::get_user_position(&e, &from)
+            .ok_or(RouterError::NoPositionFound)?;
+        let strategy = position.strategy.clone();
+
+        let total_vs = storage::get_strategy_virtual_shares(&e, &strategy);
+        if total_vs == 0 {
+            return Err(RouterError::InsufficientBalance);
+        }
+
+        // Determine user's underlying: user_vs / total_vs × router_balance
+        let strategy_client = StrategyClient::new(&e, &strategy);
+        let router_addr = e.current_contract_address();
+        let router_balance = strategy_client.balance(&router_addr);
+
+        let user_underlying = position
+            .virtual_shares
+            .checked_mul(router_balance)
+            .ok_or(RouterError::ArithmeticError)?
+            .checked_div(total_vs)
+            .ok_or(RouterError::ArithmeticError)?;
+
+        if amount > user_underlying {
+            return Err(RouterError::InsufficientBalance);
+        }
+
+        // Compute virtual shares to burn: vs_burn = amount × total_vs / router_balance
+        let vs_burn = amount
+            .checked_mul(total_vs)
+            .ok_or(RouterError::ArithmeticError)?
+            .checked_div(router_balance)
+            .ok_or(RouterError::ArithmeticError)?;
+
+        // Call strategy.withdraw — sends `amount` equity directly to `to`.
+        let remaining_router_balance = strategy_client.withdraw(&amount, &router_addr, &to);
+
+        // Update virtual share bookkeeping.
+        let new_user_vs = position.virtual_shares.saturating_sub(vs_burn);
+        let new_total_vs = total_vs.saturating_sub(vs_burn);
+        storage::set_strategy_virtual_shares(&e, &strategy, new_total_vs);
+
+        if new_user_vs == 0 {
+            storage::remove_user_position(&e, &from);
+        } else {
+            storage::set_user_position(
+                &e,
+                &from,
+                &UserPosition {
+                    strategy: strategy.clone(),
+                    virtual_shares: new_user_vs,
+                },
+            );
+        }
+
+        e.events().publish(
+            (Symbol::new(&e, "RouterWithdraw"), from.clone()),
+            (strategy, amount),
+        );
+
+        // Return user's remaining underlying.
+        if new_user_vs == 0 || new_total_vs == 0 {
+            return Ok(0);
+        }
+        let remaining_user = new_user_vs
+            .checked_mul(remaining_router_balance)
+            .ok_or(RouterError::ArithmeticError)?
+            .checked_div(new_total_vs)
+            .ok_or(RouterError::ArithmeticError)?;
+        Ok(remaining_user)
+    }
+
+    // ── Balance ───────────────────────────────────────────────────────────────
+
+    /// Return the underlying asset value of `from`'s position across the router.
+    pub fn balance(e: Env, from: Address) -> Result<i128, RouterError> {
+        extend_instance_ttl(&e);
+        let position = match storage::get_user_position(&e, &from) {
+            Some(p) => p,
+            None => return Ok(0),
+        };
+
+        let total_vs = storage::get_strategy_virtual_shares(&e, &position.strategy);
+        if total_vs == 0 {
+            return Ok(0);
+        }
+
+        let strategy_client = StrategyClient::new(&e, &position.strategy);
+        let router_balance = strategy_client.balance(&e.current_contract_address());
+
+        let underlying = position
+            .virtual_shares
+            .checked_mul(router_balance)
+            .ok_or(RouterError::ArithmeticError)?
+            .checked_div(total_vs)
+            .ok_or(RouterError::ArithmeticError)?;
+        Ok(underlying)
+    }
+
+    // ── View helpers ──────────────────────────────────────────────────────────
+
+    /// Return the strategy that would be chosen for a new deposit (deterministic).
+    /// Useful for front-ends and for letting users preview before confirming.
+    pub fn best_strategy(e: Env) -> Result<Address, RouterError> {
+        Self::select_strategy(&e, None)
+    }
+
+    /// Return all registered strategies with their APY snapshots.
+    pub fn strategies(e: Env) -> Vec<StrategyEntry> {
+        extend_instance_ttl(&e);
+        storage::get_strategies(&e)
+    }
+
+    /// Return the current admin address.
+    pub fn admin(e: Env) -> Address {
+        extend_instance_ttl(&e);
+        storage::get_admin(&e)
+    }
+
+    /// Return the underlying asset address.
+    pub fn asset(e: Env) -> Address {
+        extend_instance_ttl(&e);
+        storage::get_asset(&e)
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    /// Select the strategy with the highest `net_apy_bps`.
+    /// If `preferred` is Some and is registered, it is used instead (user override).
+    /// Returns `RouterError::NoStrategiesRegistered` if the registry is empty.
+    fn select_strategy(
+        e: &Env,
+        preferred: Option<Address>,
+    ) -> Result<Address, RouterError> {
+        let strategies = storage::get_strategies(e);
+        if strategies.is_empty() {
+            return Err(RouterError::NoStrategiesRegistered);
+        }
+
+        // User override: verify the preferred strategy is registered.
+        if let Some(pref) = preferred {
+            for i in 0..strategies.len() {
+                if strategies.get(i).unwrap().address == pref {
+                    return Ok(pref);
+                }
+            }
+            return Err(RouterError::StrategyNotFound);
+        }
+
+        // Deterministic best-pick: highest net_apy_bps wins.
+        // Ties are broken by position in the registry (earlier = preferred), making
+        // the selection stable across identical snapshots.
+        let mut best_addr = strategies.get(0).unwrap().address.clone();
+        let mut best_apy = strategies.get(0).unwrap().net_apy_bps;
+
+        for i in 1..strategies.len() {
+            let entry = strategies.get(i).unwrap();
+            if entry.net_apy_bps > best_apy {
+                best_apy = entry.net_apy_bps;
+                best_addr = entry.address.clone();
+            }
+        }
+
+        Ok(best_addr)
+    }
+}

--- a/contracts/strategies/router/src/storage.rs
+++ b/contracts/strategies/router/src/storage.rs
@@ -1,0 +1,163 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+// ── TTL constants ────────────────────────────────────────────────────────────
+
+const ONE_DAY_LEDGERS: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 30 * ONE_DAY_LEDGERS;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - ONE_DAY_LEDGERS;
+const PERSISTENT_BUMP_AMOUNT: u32 = 120 * ONE_DAY_LEDGERS;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = PERSISTENT_BUMP_AMOUNT - 20 * ONE_DAY_LEDGERS;
+
+// ── Data keys ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Admin address (manages strategy registry)
+    Admin,
+    /// Underlying asset address (must be the same across all strategies)
+    Asset,
+    /// Ordered list of registered strategy addresses
+    Strategies,
+    /// Net APY snapshot for a strategy (basis points, 100 bps = 1%)
+    StrategyApy(Address),
+    /// Total virtual shares the router has issued for a given strategy
+    StrategyVirtualShares(Address),
+    /// Per-user position: which strategy their funds are in and their virtual shares
+    UserPosition(Address),
+}
+
+// ── StrategyEntry ─────────────────────────────────────────────────────────────
+
+/// A registered strategy with its latest net-APY snapshot.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StrategyEntry {
+    pub address: Address,
+    /// Net APY in basis points (e.g. 500 = 5.00%).  Updated by the admin via
+    /// `update_apy`. The router uses this snapshot to pick the best pool; it does
+    /// NOT query rates on-chain to avoid re-entrant calls.
+    pub net_apy_bps: i128,
+}
+
+// ── UserPosition ──────────────────────────────────────────────────────────────
+
+/// Tracks a user's allocation via the router.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UserPosition {
+    /// The strategy contract this user's funds are deposited in.
+    pub strategy: Address,
+    /// The user's virtual-share balance in the router's pool for that strategy.
+    pub virtual_shares: i128,
+}
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+pub fn set_admin(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(e: &Env) -> Address {
+    e.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("Admin not set")
+}
+
+// ── Asset ─────────────────────────────────────────────────────────────────────
+
+pub fn set_asset(e: &Env, asset: &Address) {
+    e.storage().instance().set(&DataKey::Asset, asset);
+}
+
+pub fn get_asset(e: &Env) -> Address {
+    e.storage()
+        .instance()
+        .get(&DataKey::Asset)
+        .expect("Asset not set")
+}
+
+// ── Strategy registry ─────────────────────────────────────────────────────────
+
+pub fn set_strategies(e: &Env, strategies: &Vec<StrategyEntry>) {
+    e.storage().instance().set(&DataKey::Strategies, strategies);
+}
+
+pub fn get_strategies(e: &Env) -> Vec<StrategyEntry> {
+    e.storage()
+        .instance()
+        .get(&DataKey::Strategies)
+        .unwrap_or_else(|| Vec::new(e))
+}
+
+pub fn set_strategy_apy(e: &Env, strategy: &Address, apy_bps: i128) {
+    e.storage()
+        .instance()
+        .set(&DataKey::StrategyApy(strategy.clone()), &apy_bps);
+}
+
+pub fn get_strategy_apy(e: &Env, strategy: &Address) -> i128 {
+    e.storage()
+        .instance()
+        .get(&DataKey::StrategyApy(strategy.clone()))
+        .unwrap_or(0)
+}
+
+// ── Virtual shares (router-internal accounting) ───────────────────────────────
+
+pub fn get_strategy_virtual_shares(e: &Env, strategy: &Address) -> i128 {
+    e.storage()
+        .persistent()
+        .get(&DataKey::StrategyVirtualShares(strategy.clone()))
+        .unwrap_or(0i128)
+}
+
+pub fn set_strategy_virtual_shares(e: &Env, strategy: &Address, shares: i128) {
+    let key = DataKey::StrategyVirtualShares(strategy.clone());
+    e.storage().persistent().set(&key, &shares);
+    e.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+// ── Per-user position ─────────────────────────────────────────────────────────
+
+pub fn get_user_position(e: &Env, user: &Address) -> Option<UserPosition> {
+    let key = DataKey::UserPosition(user.clone());
+    let pos: Option<UserPosition> = e.storage().persistent().get(&key);
+    if pos.is_some() {
+        e.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    pos
+}
+
+pub fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
+    let key = DataKey::UserPosition(user.clone());
+    e.storage().persistent().set(&key, position);
+    e.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+pub fn remove_user_position(e: &Env, user: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::UserPosition(user.clone()));
+}
+
+// ── Instance TTL ──────────────────────────────────────────────────────────────
+
+pub fn extend_instance_ttl(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}


### PR DESCRIPTION
## Summary

Implements issue #48 — D7: Multi-pool / multi-asset router contract.

- New crate `contracts/strategies/router/` (Soroban cdylib).
- `PoolRouter` stores a registry of strategy addresses with net-APY snapshots (bps) updated by the admin.
- `deposit(amount, from, preferred_strategy?)` — queries the router's pre-deposit balance for accurate share pricing, picks the highest-APY strategy deterministically (or uses user override), issues proportional virtual shares.
- `withdraw(amount, from, to)` — burns virtual shares, strategy sends equity directly to `to`.
- `balance(from)` — returns `user_vs / total_vs × strategy.balance(router)`.
- Admin methods: `add_strategy`, `remove_strategy`, `update_apy`, `set_admin`.
- `README.md` covers architecture, virtual-share accounting, routing algorithm, and migration path for existing single-pool depositors.

## Test plan

- [ ] `cargo check -p blend_leverage_router` — router contract compiles without errors.
- [ ] Verify `PoolRouter::deposit` routes to highest-APY strategy; user override selects preferred pool.
- [ ] Confirm on-chain events are emitted for router deposits/withdrawals.
- [ ] Verify `add_strategy` / `remove_strategy` / `update_apy` are admin-gated.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)