### PR TITLE
chore: make cargo clippy -D warnings pass on sim binaries

### DIFF
--- a/src/bin/execute_loop.rs
+++ b/src/bin/execute_loop.rs
@@ -15,20 +15,16 @@
 /// Key file format: one line containing the Stellar secret key (S...).
 /// Never paste a secret key in the terminal or in source code.
 use std::{
-    env,
-    fs,
+    env, fs,
     process::{self, Command},
 };
 
-use reqwest::blocking::Client;
-use serde::Deserialize;
-use serde_json::{json, Value};
 use ed25519_dalek::SigningKey;
+use reqwest::blocking::Client;
 use stellar_strkey::ed25519::{PrivateKey, PublicKey};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const MAINNET_RPC: &str = "https://mainnet.sorobanrpc.com";
 const POOL_ID: &str = "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI";
 const USDC_ID: &str = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
 
@@ -59,9 +55,21 @@ impl Args {
         while let Some(flag) = args.next() {
             match flag.as_str() {
                 "--key-file" => key_file = Some(args.next().expect("--key-file requires a value")),
-                "--loops"    => loops = args.next().expect("--loops requires a value").parse().expect("loops must be an integer"),
-                "--initial"  => initial_usdc = args.next().expect("--initial requires a value").parse().expect("initial must be a number"),
-                "--dry-run"  => dry_run = true,
+                "--loops" => {
+                    loops = args
+                        .next()
+                        .expect("--loops requires a value")
+                        .parse()
+                        .expect("loops must be an integer")
+                }
+                "--initial" => {
+                    initial_usdc = args
+                        .next()
+                        .expect("--initial requires a value")
+                        .parse()
+                        .expect("initial must be a number")
+                }
+                "--dry-run" => dry_run = true,
                 other => eprintln!("Unknown flag: {other}"),
             }
         }
@@ -73,31 +81,6 @@ impl Args {
             dry_run,
         }
     }
-}
-
-// ── RPC helpers ───────────────────────────────────────────────────────────────
-
-#[derive(Deserialize, Debug)]
-struct RpcResponse {
-    result: Option<Value>,
-    error:  Option<Value>,
-}
-
-fn rpc_call(client: &Client, method: &str, params: Value) -> Value {
-    let body = json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params });
-    let resp: RpcResponse = client
-        .post(MAINNET_RPC)
-        .json(&body)
-        .send()
-        .expect("RPC call failed")
-        .json()
-        .expect("RPC response parse failed");
-
-    if let Some(err) = resp.error {
-        eprintln!("RPC error: {err}");
-        process::exit(1);
-    }
-    resp.result.expect("RPC returned no result")
 }
 
 // ── Pool state from RPC ───────────────────────────────────────────────────────
@@ -115,13 +98,12 @@ const MAX_RATE_SPREAD_PCT: f64 = 15.0;
 /// We use the simulation test for detailed pre-flight; here we just need
 /// c_factor and current rates to compute request amounts.
 struct PoolSnapshot {
-    c_factor:     i128, // 1e7-scaled
+    c_factor: i128, // 1e7-scaled
     usdc_decimals: u32,
-    supply_apr:   f64,
-    borrow_apr:   f64,
+    supply_apr: f64,
+    borrow_apr: f64,
     pool_supply_usdc: f64,
     pool_borrow_usdc: f64,
-    supply_cap_usdc:  Option<f64>,
 }
 
 /// Reads a quick pool snapshot via the Soroban RPC `simulateTransaction` trick:
@@ -129,7 +111,7 @@ struct PoolSnapshot {
 /// For the actual amounts computation we rely on c_factor only (fetched via
 /// `stellar contract invoke --dry-run` below), so we hard-code the well-known
 /// USDC decimals here and let stellar-cli do the full pre-flight.
-fn fetch_pool_snapshot(client: &Client) -> PoolSnapshot {
+fn fetch_pool_snapshot(_client: &Client) -> PoolSnapshot {
     // We call the Soroban RPC to get the reserve config via getLedgerEntries.
     // Reserve config key for USDC in this pool is deterministic from the
     // pool ID + USDC address. Rather than computing the XDR key here, we
@@ -142,13 +124,12 @@ fn fetch_pool_snapshot(client: &Client) -> PoolSnapshot {
     //
     // A future improvement would parse the raw XDR ledger entries directly.
     PoolSnapshot {
-        c_factor: 9_500_000,         // 95% — validated in preflight
+        c_factor: 9_500_000, // 95% — validated in preflight
         usdc_decimals: 7,
-        supply_apr: 0.0,             // populated in preflight output
+        supply_apr: 0.0, // populated in preflight output
         borrow_apr: 0.0,
         pool_supply_usdc: 0.0,
         pool_borrow_usdc: 0.0,
-        supply_cap_usdc: None,
     }
 }
 
@@ -216,21 +197,41 @@ fn print_preflight(pairs: &[(i128, i128)], c_factor: i128, initial_usdc: f64, dr
     println!("  USDC:              {USDC_ID}");
     let n_borrows = pairs.iter().filter(|(_, b)| *b > 0).count();
     let n_requests = n_borrows + pairs.len(); // supplies + borrows
-    println!("  Loops:             {}  ({} borrows + {} supplies = {} requests)", n_borrows, n_borrows, pairs.len(), n_requests);
+    println!(
+        "  Loops:             {}  ({} borrows + {} supplies = {} requests)",
+        n_borrows,
+        n_borrows,
+        pairs.len(),
+        n_requests
+    );
     println!("  Initial deposit:   ${initial_usdc:.2}");
     println!("  Collateral factor: {:.0}%", c * 100.0);
     println!();
-    println!("  {:>4}  {:>14}  {:>14}", "Loop", "Supply ($)", "Borrow ($)");
+    println!(
+        "  {:>4}  {:>14}  {:>14}",
+        "Loop", "Supply ($)", "Borrow ($)"
+    );
     println!("  {}", "─".repeat(36));
     for (i, (s, b)) in pairs.iter().enumerate() {
         if *b > 0 {
-            println!("  {:>4}  {:>14.2}  {:>14.2}", i + 1, *s as f64 / scalar_f, *b as f64 / scalar_f);
+            println!(
+                "  {:>4}  {:>14.2}  {:>14.2}",
+                i + 1,
+                *s as f64 / scalar_f,
+                *b as f64 / scalar_f
+            );
         } else {
-            println!("  {:>4}  {:>14.2}  {:>14}  (final supply)", i + 1, *s as f64 / scalar_f, "—");
+            println!(
+                "  {:>4}  {:>14.2}  {:>14}  (final supply)",
+                i + 1,
+                *s as f64 / scalar_f,
+                "—"
+            );
         }
     }
     println!("  {}", "─".repeat(36));
-    println!("  {:>4}  {:>14.2}  {:>14.2}  →  {:.3}× leverage",
+    println!(
+        "  {:>4}  {:>14.2}  {:>14.2}  →  {:.3}× leverage",
         "net",
         total_supply as f64 / scalar_f,
         total_borrow as f64 / scalar_f,
@@ -272,7 +273,8 @@ fn check_safety(snap: &PoolSnapshot, initial_usdc: f64, n_loops: usize) -> Resul
             "Pool utilization is {:.1}% (max {:.0}%). \
              High utilization means collateral d-tokens are illiquid — \
              liquidators won't act, risking bad debt spiral. Wait for utilization to drop.",
-            util * 100.0, MAX_SAFE_UTILIZATION * 100.0
+            util * 100.0,
+            MAX_SAFE_UTILIZATION * 100.0
         ));
     }
 
@@ -282,7 +284,8 @@ fn check_safety(snap: &PoolSnapshot, initial_usdc: f64, n_loops: usize) -> Resul
         return Err(format!(
             "Borrow-supply APR spread is {:.1}% — abnormally high (max {:.0}%). \
              This may indicate rate manipulation. Wait for rates to stabilize.",
-            spread * 100.0, MAX_RATE_SPREAD_PCT
+            spread * 100.0,
+            MAX_RATE_SPREAD_PCT
         ));
     }
 
@@ -292,13 +295,18 @@ fn check_safety(snap: &PoolSnapshot, initial_usdc: f64, n_loops: usize) -> Resul
     let add_borrow = initial_usdc * (lev - 1.0);
     let proj_supply = snap.pool_supply_usdc + add_supply;
     let proj_borrow = snap.pool_borrow_usdc + add_borrow;
-    let proj_util = if proj_supply > 0.0 { proj_borrow / proj_supply } else { 0.0 };
+    let proj_util = if proj_supply > 0.0 {
+        proj_borrow / proj_supply
+    } else {
+        0.0
+    };
 
     if proj_util > MAX_SAFE_UTILIZATION {
         return Err(format!(
             "This position would push pool utilization to {:.1}% (max {:.0}%). \
              Reduce --loops or --initial.",
-            proj_util * 100.0, MAX_SAFE_UTILIZATION * 100.0
+            proj_util * 100.0,
+            MAX_SAFE_UTILIZATION * 100.0
         ));
     }
 
@@ -319,12 +327,16 @@ fn main() {
     let args = Args::parse();
 
     // 1. Load secret key from file — never from env or CLI arg.
-    let secret_raw = fs::read_to_string(&args.key_file)
-        .unwrap_or_else(|e| { eprintln!("Cannot read key file '{}': {e}", args.key_file); process::exit(1); });
+    let secret_raw = fs::read_to_string(&args.key_file).unwrap_or_else(|e| {
+        eprintln!("Cannot read key file '{}': {e}", args.key_file);
+        process::exit(1);
+    });
     let secret_str = secret_raw.trim();
 
-    let secret_key = PrivateKey::from_string(secret_str)
-        .unwrap_or_else(|e| { eprintln!("Invalid secret key: {e}"); process::exit(1); });
+    let secret_key = PrivateKey::from_string(secret_str).unwrap_or_else(|e| {
+        eprintln!("Invalid secret key: {e}");
+        process::exit(1);
+    });
     // Derive the public key via ed25519-dalek (stellar-strkey doesn't expose this).
     let signing_key = SigningKey::from_bytes(&secret_key.0);
     let pub_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
@@ -367,26 +379,41 @@ fn main() {
     //   --network mainnet \
     //   [--send=no if dry-run] \
     //   -- submit --from ADDR --spender ADDR --to ADDR --requests '[...]'
-    let send_flag = if args.dry_run { "--send=no" } else { "--send=yes" };
+    let send_flag = if args.dry_run {
+        "--send=no"
+    } else {
+        "--send=yes"
+    };
 
     let mut cmd = Command::new(&stellar_cli);
     cmd.args([
-        "contract", "invoke",
-        "--id",             POOL_ID,
-        "--source-account", secret_str,
-        "--network",        "mainnet",
+        "contract",
+        "invoke",
+        "--id",
+        POOL_ID,
+        "--source-account",
+        secret_str,
+        "--network",
+        "mainnet",
         send_flag,
         "--",
         "submit",
-        "--from",           &account_id,
-        "--spender",        &account_id,
-        "--to",             &account_id,
-        "--requests",       &requests_json,
+        "--from",
+        &account_id,
+        "--spender",
+        &account_id,
+        "--to",
+        &account_id,
+        "--requests",
+        &requests_json,
     ]);
 
     println!("Invoking stellar-cli…");
     println!("  stellar contract invoke --id {POOL_ID} --network mainnet {send_flag}");
-    println!("  -- submit --from {account_id} ... ({} requests)", pairs.len() * 2);
+    println!(
+        "  -- submit --from {account_id} ... ({} requests)",
+        pairs.len() * 2
+    );
     println!();
 
     let status = cmd.status().unwrap_or_else(|e| {
@@ -417,14 +444,22 @@ fn which_stellar_cli() -> String {
         // Same cargo bin dir as this binary.
         std::env::current_exe()
             .ok()
-            .and_then(|p| p.parent().map(|d| d.join("stellar").to_string_lossy().to_string()))
+            .and_then(|p| {
+                p.parent()
+                    .map(|d| d.join("stellar").to_string_lossy().to_string())
+            })
             .unwrap_or_default(),
-        format!("{}/.cargo/bin/stellar", env::var("HOME").unwrap_or_default()),
+        format!(
+            "{}/.cargo/bin/stellar",
+            env::var("HOME").unwrap_or_default()
+        ),
         "stellar".to_string(), // in PATH
     ];
 
     for candidate in &candidates {
-        if candidate.is_empty() { continue; }
+        if candidate.is_empty() {
+            continue;
+        }
         if std::path::Path::new(candidate).exists()
             || Command::new(candidate).arg("--version").output().is_ok()
         {

--- a/src/bin/rate_calc.rs
+++ b/src/bin/rate_calc.rs
@@ -45,53 +45,64 @@ struct ProjectedRates {
 
 fn compute_rates(fixture: &InputFixture) -> ProjectedRates {
     let cfg = &fixture.rateConfig;
-    
+
     let proj_supply = fixture.totalSupply + fixture.addSupply;
     let proj_borrow = fixture.totalBorrow + fixture.addBorrow;
-    
+
     let proj_util = if proj_supply > 0.0 {
         proj_borrow / proj_supply
     } else {
         0.0
     };
-    
+
     let util_fp = (proj_util * SCALAR_F).round() as i64;
-    
+
     let base_rate: i64;
     if util_fp <= cfg.utilOpt {
-        base_rate = cfg.rBase + (cfg.rOne as f64 * util_fp as f64 / cfg.utilOpt as f64).ceil() as i64;
+        base_rate =
+            cfg.rBase + (cfg.rOne as f64 * util_fp as f64 / cfg.utilOpt as f64).ceil() as i64;
     } else if util_fp <= FIXED_95PCT {
-        let slope = ((util_fp - cfg.utilOpt) as f64 * SCALAR_F / (FIXED_95PCT - cfg.utilOpt) as f64).ceil() as i64;
-        base_rate = cfg.rBase + cfg.rOne + (cfg.rTwo as f64 * slope as f64 / SCALAR_F).ceil() as i64;
+        let slope = ((util_fp - cfg.utilOpt) as f64 * SCALAR_F / (FIXED_95PCT - cfg.utilOpt) as f64)
+            .ceil() as i64;
+        base_rate =
+            cfg.rBase + cfg.rOne + (cfg.rTwo as f64 * slope as f64 / SCALAR_F).ceil() as i64;
     } else {
-        let slope = ((util_fp - FIXED_95PCT) as f64 * SCALAR_F / (SCALAR_F as i64 - FIXED_95PCT) as f64).ceil() as i64;
-        base_rate = cfg.rBase + cfg.rOne + cfg.rTwo + (cfg.rThree as f64 * slope as f64 / SCALAR_F).ceil() as i64;
+        let slope = ((util_fp - FIXED_95PCT) as f64 * SCALAR_F
+            / (SCALAR_F as i64 - FIXED_95PCT) as f64)
+            .ceil() as i64;
+        base_rate = cfg.rBase
+            + cfg.rOne
+            + cfg.rTwo
+            + (cfg.rThree as f64 * slope as f64 / SCALAR_F).ceil() as i64;
     }
-    
+
     let cur_ir = (base_rate as f64 * cfg.irMod as f64 / SCALAR_F).ceil() as i64;
     let interest_borrow_apr = (cur_ir as f64 / SCALAR_F) * 100.0;
-    
-    let supply_capture = ((SCALAR_F as i64 - cfg.backstopFP) as f64 * util_fp as f64 / SCALAR_F).floor() as i64;
-    let interest_supply_apr = (((cur_ir as f64 * supply_capture as f64 / SCALAR_F).floor() as i64) as f64 / SCALAR_F) * 100.0;
-    
+
+    let supply_capture =
+        ((SCALAR_F as i64 - cfg.backstopFP) as f64 * util_fp as f64 / SCALAR_F).floor() as i64;
+    let interest_supply_apr =
+        (((cur_ir as f64 * supply_capture as f64 / SCALAR_F).floor() as i64) as f64 / SCALAR_F)
+            * 100.0;
+
     let supply_blnd_yr = fixture.supplyEps as f64 * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
     let borrow_blnd_yr = fixture.borrowEps as f64 * SECONDS_PER_YEAR / SCALAR_F / SCALAR_F;
-    
+
     let proj_supply_usd = proj_supply * fixture.priceUsd;
     let proj_borrow_usd = proj_borrow * fixture.priceUsd;
-    
+
     let blnd_supply_apr = if proj_supply_usd > 0.0 {
         (supply_blnd_yr * fixture.blndPrice / proj_supply_usd) * 100.0
     } else {
         0.0
     };
-    
+
     let blnd_borrow_apr = if proj_borrow_usd > 0.0 {
         (borrow_blnd_yr * fixture.blndPrice / proj_borrow_usd) * 100.0
     } else {
         0.0
     };
-    
+
     ProjectedRates {
         interestSupplyApr: interest_supply_apr,
         interestBorrowApr: interest_borrow_apr,
@@ -108,7 +119,7 @@ fn main() {
         eprintln!("Failed to read stdin: {}", e);
         std::process::exit(1);
     }
-    
+
     let fixtures: Vec<InputFixture> = match serde_json::from_str(&input) {
         Ok(f) => f,
         Err(e) => {
@@ -116,12 +127,12 @@ fn main() {
             std::process::exit(1);
         }
     };
-    
+
     let mut results = Vec::new();
     for fix in &fixtures {
         results.push(compute_rates(fix));
     }
-    
+
     let output = serde_json::to_string_pretty(&results).unwrap();
     println!("{}", output);
 }

--- a/src/bin/simulate.rs
+++ b/src/bin/simulate.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 
 // ── Pool constants ────────────────────────────────────────────────────────────
 
-const POOL_ID:   &str = "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI";
-const USDC_ID:   &str = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+const POOL_ID: &str = "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI";
+const USDC_ID: &str = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
 
 /// Arbitrary read-only account for simulation calls (no signing required).
 const DUMMY_ADDR: &str = "GBHD3V2XKX6DXHYZDSHA2UYZTO4MKB2R6QNSCDT4XEKNGTLPXT7A36EA";
@@ -38,7 +38,7 @@ const DUMMY_ADDR: &str = "GBHD3V2XKX6DXHYZDSHA2UYZTO4MKB2R6QNSCDT4XEKNGTLPXT7A36
 //
 // Utilization = (d_supply × d_rate) / (b_supply × b_rate)
 
-const SCALAR_7:  f64 = 1e7;
+const SCALAR_7: f64 = 1e7;
 const SCALAR_12: f64 = 1e12;
 const SECONDS_PER_YEAR: f64 = 31_536_000.0;
 
@@ -51,37 +51,38 @@ struct PoolConfig {
 
 #[derive(Deserialize, Debug)]
 struct ReserveConfig {
-    c_factor:   i64,
-    decimals:   u32,
-    index:      u32,
-    l_factor:   i64,
-    max_util:   i64,
-    r_base:     i64,
-    r_one:      i64,
-    r_two:      i64,
-    r_three:    i64,
+    c_factor: i64,
+    decimals: u32,
+    index: u32,
+    l_factor: i64,
+    max_util: i64,
+    r_base: i64,
+    r_one: i64,
+    r_two: i64,
+    r_three: i64,
     supply_cap: String, // i128 comes as quoted string from stellar-cli
-    util:       i64,    // target utilization
+    util: i64,          // target utilization
 }
 
 #[derive(Deserialize, Debug)]
 struct ReserveData {
-    b_rate:  String, // i128 quoted
+    b_rate: String, // i128 quoted
     b_supply: String,
-    d_rate:  String, // i128 quoted
+    d_rate: String, // i128 quoted
     d_supply: String,
-    ir_mod:  String,
+    ir_mod: String,
 }
 
 #[derive(Deserialize, Debug)]
 struct Reserve {
     config: ReserveConfig,
-    data:   ReserveData,
+    data: ReserveData,
 }
 
 #[derive(Deserialize, Debug)]
 struct EmissionData {
-    eps:        u64,
+    eps: u64,
+    #[allow(dead_code)] // present in ledger JSON; kept to document the entry shape
     expiration: u64,
 }
 
@@ -90,10 +91,15 @@ struct EmissionData {
 fn stellar_invoke(args: &[&str]) -> Value {
     let stellar = which_stellar();
     let mut cmd = Command::new(&stellar);
-    cmd.args(["contract", "invoke",
-        "--id",             POOL_ID,
-        "--source-account", DUMMY_ADDR,
-        "--network",        "mainnet",
+    cmd.args([
+        "contract",
+        "invoke",
+        "--id",
+        POOL_ID,
+        "--source-account",
+        DUMMY_ADDR,
+        "--network",
+        "mainnet",
         "--send=no",
         "--",
     ]);
@@ -118,12 +124,11 @@ fn stellar_invoke(args: &[&str]) -> Value {
 
 fn which_stellar() -> String {
     let home = env::var("HOME").unwrap_or_default();
-    let candidates = [
-        format!("{home}/.cargo/bin/stellar"),
-        "stellar".to_string(),
-    ];
+    let candidates = [format!("{home}/.cargo/bin/stellar"), "stellar".to_string()];
     for c in &candidates {
-        if std::path::Path::new(c).exists() { return c.clone(); }
+        if std::path::Path::new(c).exists() {
+            return c.clone();
+        }
     }
     "stellar".to_string()
 }
@@ -131,27 +136,27 @@ fn which_stellar() -> String {
 // ── Interest rate model ───────────────────────────────────────────────────────
 
 fn compute_rates(cfg: &ReserveConfig, data: &ReserveData, bstop_rate: f64) -> (f64, f64, f64) {
-    let b_rate   = data.b_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
-    let d_rate   = data.d_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
+    let b_rate = data.b_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
+    let d_rate = data.d_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
     let b_supply = data.b_supply.parse::<i128>().unwrap() as f64;
     let d_supply = data.d_supply.parse::<i128>().unwrap() as f64;
-    let ir_mod   = data.ir_mod.parse::<i128>().unwrap() as f64 / SCALAR_7;
+    let ir_mod = data.ir_mod.parse::<i128>().unwrap() as f64 / SCALAR_7;
 
     // b = balance (supply), d = debt (borrows)
     let supply_underlying = b_supply * b_rate;
-    let debt_underlying   = d_supply * d_rate;
+    let debt_underlying = d_supply * d_rate;
     let util = if supply_underlying > 0.0 {
         (debt_underlying / supply_underlying).min(1.0) // capped at 1 per protocol
     } else {
         0.0
     };
 
-    let util_target = cfg.util     as f64 / SCALAR_7;
-    let max_util    = cfg.max_util as f64 / SCALAR_7;
-    let r_base      = cfg.r_base   as f64 / SCALAR_7;
-    let r_one       = cfg.r_one    as f64 / SCALAR_7;
-    let r_two       = cfg.r_two    as f64 / SCALAR_7;
-    let r_three     = cfg.r_three  as f64 / SCALAR_7;
+    let util_target = cfg.util as f64 / SCALAR_7;
+    let max_util = cfg.max_util as f64 / SCALAR_7;
+    let r_base = cfg.r_base as f64 / SCALAR_7;
+    let r_one = cfg.r_one as f64 / SCALAR_7;
+    let r_two = cfg.r_two as f64 / SCALAR_7;
+    let r_three = cfg.r_three as f64 / SCALAR_7;
 
     let base_rate = if util <= util_target {
         r_base + r_one * util / util_target
@@ -190,29 +195,29 @@ fn main() {
     println!("Fetching live data from Stellar mainnet…");
 
     // ── 1. Pool config ────────────────────────────────────────────────────────
-    let pool_cfg: PoolConfig = serde_json::from_value(stellar_invoke(&["get_config"]))
-        .expect("parse pool config");
+    let pool_cfg: PoolConfig =
+        serde_json::from_value(stellar_invoke(&["get_config"])).expect("parse pool config");
     let bstop_rate = pool_cfg.bstop_rate as f64 / SCALAR_7;
 
     // ── 2. USDC reserve ───────────────────────────────────────────────────────
-    let reserve: Reserve = serde_json::from_value(
-        stellar_invoke(&["get_reserve", "--asset", USDC_ID])
-    ).expect("parse reserve");
+    let reserve: Reserve =
+        serde_json::from_value(stellar_invoke(&["get_reserve", "--asset", USDC_ID]))
+            .expect("parse reserve");
 
-    let cfg  = &reserve.config;
+    let cfg = &reserve.config;
     let data = &reserve.data;
 
-    let c_factor   = cfg.c_factor  as f64 / SCALAR_7;
-    let l_factor   = cfg.l_factor  as f64 / SCALAR_7;
-    let scalar_f   = 10_f64.powi(cfg.decimals as i32); // 1e7 for USDC
+    let c_factor = cfg.c_factor as f64 / SCALAR_7;
+    let l_factor = cfg.l_factor as f64 / SCALAR_7;
+    let scalar_f = 10_f64.powi(cfg.decimals as i32); // 1e7 for USDC
 
     let supply_cap_usdc = cfg.supply_cap.parse::<i128>().unwrap() as f64 / scalar_f;
 
-    let b_rate_n   = data.b_rate.parse::<i128>().unwrap()   as f64 / SCALAR_12;
-    let d_rate_n   = data.d_rate.parse::<i128>().unwrap()   as f64 / SCALAR_12;
-    let b_supply   = data.b_supply.parse::<i128>().unwrap() as f64;
-    let d_supply   = data.d_supply.parse::<i128>().unwrap() as f64;
-    let ir_mod     = data.ir_mod.parse::<i128>().unwrap()   as f64 / SCALAR_7;
+    let b_rate_n = data.b_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
+    let d_rate_n = data.d_rate.parse::<i128>().unwrap() as f64 / SCALAR_12;
+    let b_supply = data.b_supply.parse::<i128>().unwrap() as f64;
+    let d_supply = data.d_supply.parse::<i128>().unwrap() as f64;
+    let ir_mod = data.ir_mod.parse::<i128>().unwrap() as f64 / SCALAR_7;
 
     let pool_supplied_usdc = b_supply * b_rate_n / scalar_f;
     let pool_borrowed_usdc = d_supply * d_rate_n / scalar_f;
@@ -226,12 +231,20 @@ fn main() {
     let supply_eps_idx = (cfg.index * 2 + 1).to_string();
     let borrow_eps_idx = (cfg.index * 2).to_string();
 
-    let supply_emission: Option<EmissionData> = serde_json::from_value(
-        stellar_invoke(&["get_reserve_emissions", "--reserve_token_index", &supply_eps_idx])
-    ).ok().flatten();
-    let borrow_emission: Option<EmissionData> = serde_json::from_value(
-        stellar_invoke(&["get_reserve_emissions", "--reserve_token_index", &borrow_eps_idx])
-    ).ok().flatten();
+    let supply_emission: Option<EmissionData> = serde_json::from_value(stellar_invoke(&[
+        "get_reserve_emissions",
+        "--reserve_token_index",
+        &supply_eps_idx,
+    ]))
+    .ok()
+    .flatten();
+    let borrow_emission: Option<EmissionData> = serde_json::from_value(stellar_invoke(&[
+        "get_reserve_emissions",
+        "--reserve_token_index",
+        &borrow_eps_idx,
+    ]))
+    .ok()
+    .flatten();
 
     let supply_eps = supply_emission.as_ref().map(|e| e.eps).unwrap_or(0);
     let borrow_eps = borrow_emission.as_ref().map(|e| e.eps).unwrap_or(0);
@@ -244,42 +257,87 @@ fn main() {
     let pool_borrow_blnd_yr = borrow_eps as f64 * SECONDS_PER_YEAR / SCALAR_7 / SCALAR_7;
 
     // BLND per $1 supplied/borrowed per year
-    let blnd_per_usdc_supply = if pool_supplied_usdc > 0.0 { pool_supply_blnd_yr / pool_supplied_usdc } else { 0.0 };
-    let blnd_per_usdc_borrow = if pool_borrowed_usdc > 0.0 { pool_borrow_blnd_yr / pool_borrowed_usdc } else { 0.0 };
+    let blnd_per_usdc_supply = if pool_supplied_usdc > 0.0 {
+        pool_supply_blnd_yr / pool_supplied_usdc
+    } else {
+        0.0
+    };
+    let blnd_per_usdc_borrow = if pool_borrowed_usdc > 0.0 {
+        pool_borrow_blnd_yr / pool_borrowed_usdc
+    } else {
+        0.0
+    };
 
     // ── 4. Print reserve summary ──────────────────────────────────────────────
     println!();
     println!("  ┌─────────────────────────────────────────────────────────┐");
     println!("  │        USDC Reserve (live Stellar mainnet)              │");
     println!("  ├─────────────────────────────────────────────────────────┤");
-    println!("  │  Collateral factor (c):  {:>7.1}%                       │", c_factor * 100.0);
-    println!("  │  Liquidation factor:     {:>7.1}%                       │", l_factor * 100.0);
-    println!("  │  Utilization (actual):   {:>7.2}%                       │", util * 100.0);
-    println!("  │  Supply APR:             {:>7.2}%                       │", supply_apr * 100.0);
-    println!("  │  Borrow APR:             {:>7.2}%                       │", borrow_apr * 100.0);
-    println!("  │  Backstop take rate:     {:>7.1}%                       │", bstop_rate * 100.0);
-    println!("  │  IR modifier:           {:>8.6}                        │", ir_mod);
+    println!(
+        "  │  Collateral factor (c):  {:>7.1}%                       │",
+        c_factor * 100.0
+    );
+    println!(
+        "  │  Liquidation factor:     {:>7.1}%                       │",
+        l_factor * 100.0
+    );
+    println!(
+        "  │  Utilization (actual):   {:>7.2}%                       │",
+        util * 100.0
+    );
+    println!(
+        "  │  Supply APR:             {:>7.2}%                       │",
+        supply_apr * 100.0
+    );
+    println!(
+        "  │  Borrow APR:             {:>7.2}%                       │",
+        borrow_apr * 100.0
+    );
+    println!(
+        "  │  Backstop take rate:     {:>7.1}%                       │",
+        bstop_rate * 100.0
+    );
+    println!(
+        "  │  IR modifier:           {:>8.6}                        │",
+        ir_mod
+    );
     println!("  ├─────────────────────────────────────────────────────────┤");
-    println!("  │  Pool supplied:   {:>14.2} USDC                    │", pool_supplied_usdc);
-    println!("  │  Pool borrowed:   {:>14.2} USDC                    │", pool_borrowed_usdc);
-    println!("  │  Supply cap:      {:>14.2} USDC                    │", supply_cap_usdc);
+    println!(
+        "  │  Pool supplied:   {:>14.2} USDC                    │",
+        pool_supplied_usdc
+    );
+    println!(
+        "  │  Pool borrowed:   {:>14.2} USDC                    │",
+        pool_borrowed_usdc
+    );
+    println!(
+        "  │  Supply cap:      {:>14.2} USDC                    │",
+        supply_cap_usdc
+    );
     let cap_pct = pool_supplied_usdc / supply_cap_usdc * 100.0;
     let cap_room = supply_cap_usdc - pool_supplied_usdc;
-    println!("  │  Cap used:        {:>7.2}%  ({:.2} USDC room)          │", cap_pct, cap_room);
+    println!(
+        "  │  Cap used:        {:>7.2}%  ({:.2} USDC room)          │",
+        cap_pct, cap_room
+    );
     println!("  ├─────────────────────────────────────────────────────────┤");
 
     if supply_eps == 0 && borrow_eps == 0 {
         println!("  │  BLND emissions:  NONE configured for this reserve     │");
     } else {
         if supply_eps > 0 {
-            println!("  │  Supply BLND/yr:  {:>12.1}  ({:.4} per $1/yr)      │",
-                pool_supply_blnd_yr, blnd_per_usdc_supply);
+            println!(
+                "  │  Supply BLND/yr:  {:>12.1}  ({:.4} per $1/yr)      │",
+                pool_supply_blnd_yr, blnd_per_usdc_supply
+            );
         } else {
             println!("  │  Supply BLND/yr:  NONE                                  │");
         }
         if borrow_eps > 0 {
-            println!("  │  Borrow BLND/yr:  {:>12.1}  ({:.4} per $1/yr)      │",
-                pool_borrow_blnd_yr, blnd_per_usdc_borrow);
+            println!(
+                "  │  Borrow BLND/yr:  {:>12.1}  ({:.4} per $1/yr)      │",
+                pool_borrow_blnd_yr, blnd_per_usdc_borrow
+            );
         } else {
             println!("  │  Borrow BLND/yr:  NONE                                  │");
         }
@@ -288,61 +346,95 @@ fn main() {
     println!("  └─────────────────────────────────────────────────────────┘");
 
     // ── 5. Leverage table ─────────────────────────────────────────────────────
-    let initial    = 1_000.0_f64;
-    let max_lev    = 1.0 / (1.0 - c_factor);
+    let initial = 1_000.0_f64;
+    let max_lev = 1.0 / (1.0 - c_factor);
 
     println!();
-    println!("  Initial deposit: ${:.0}    c_factor: {:.0}%    max leverage: {:.2}×",
-        initial, c_factor * 100.0, max_lev);
+    println!(
+        "  Initial deposit: ${:.0}    c_factor: {:.0}%    max leverage: {:.2}×",
+        initial,
+        c_factor * 100.0,
+        max_lev
+    );
     if supply_apr >= borrow_apr {
-        println!("  ✓ Rate spread: +{:.3}%  (interest is positive carry)",
-            (supply_apr - borrow_apr) * 100.0);
+        println!(
+            "  ✓ Rate spread: +{:.3}%  (interest is positive carry)",
+            (supply_apr - borrow_apr) * 100.0
+        );
     } else {
-        println!("  ✗ Rate spread: {:.3}%  (NEGATIVE carry — BLND is only yield)",
-            (supply_apr - borrow_apr) * 100.0);
+        println!(
+            "  ✗ Rate spread: {:.3}%  (NEGATIVE carry — BLND is only yield)",
+            (supply_apr - borrow_apr) * 100.0
+        );
     }
     println!();
-    println!("  {:>4}  {:>12}  {:>12}  {:>8}  {:>8}  {:>10}  {:>10}  {}",
-        "Loop", "Supplied ($)", "Borrowed ($)", "Leverage", "HF", "Net APY", "BLND/yr", "⚠");
+    println!(
+        "  {:>4}  {:>12}  {:>12}  {:>8}  {:>8}  {:>10}  {:>10}  ⚠",
+        "Loop", "Supplied ($)", "Borrowed ($)", "Leverage", "HF", "Net APY", "BLND/yr"
+    );
     println!("  {}", "─".repeat(84));
 
     let mut last_safe_loop = 0;
 
     for n in 0..=n_loops {
-        let lev      = leverage(n, c_factor);
+        let lev = leverage(n, c_factor);
         let supplied = initial * lev;
         let borrowed = supplied - initial;
-        let hf       = if borrowed > 0.0 { (supplied * c_factor) / borrowed } else { f64::INFINITY };
-        let hf_str   = if borrowed > 0.0 { format!("{:.4}", hf) } else { "     ∞".to_string() };
+        let hf = if borrowed > 0.0 {
+            (supplied * c_factor) / borrowed
+        } else {
+            f64::INFINITY
+        };
+        let hf_str = if borrowed > 0.0 {
+            format!("{:.4}", hf)
+        } else {
+            "     ∞".to_string()
+        };
 
         let net_yield = supply_apr * supplied - borrow_apr * borrowed;
-        let net_apy   = net_yield / initial * 100.0;
+        let net_apy = net_yield / initial * 100.0;
 
-        let blnd_yr   = supplied * blnd_per_usdc_supply + borrowed * blnd_per_usdc_borrow;
+        let blnd_yr = supplied * blnd_per_usdc_supply + borrowed * blnd_per_usdc_borrow;
 
-        let cap_warn  = if supplied > pool_supplied_usdc + cap_room { "CAP" } else { "" };
+        let cap_warn = if supplied > pool_supplied_usdc + cap_room {
+            "CAP"
+        } else {
+            ""
+        };
 
-        println!("  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>8}  {:>9.2}%  {:>10.1}  {}",
-            n, supplied, borrowed, lev, hf_str, net_apy, blnd_yr, cap_warn);
+        println!(
+            "  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>8}  {:>9.2}%  {:>10.1}  {}",
+            n, supplied, borrowed, lev, hf_str, net_apy, blnd_yr, cap_warn
+        );
 
-        if hf >= 1.05 { last_safe_loop = n; }
-        if lev / max_lev > 0.9999 { break; }
+        if hf >= 1.05 {
+            last_safe_loop = n;
+        }
+        if lev / max_lev > 0.9999 {
+            break;
+        }
     }
 
     // Theoretical ∞ row
-    let max_sup      = initial * max_lev;
-    let max_bor      = max_sup - initial;
-    let max_net_apy  = (supply_apr * max_sup - borrow_apr * max_bor) / initial * 100.0;
-    let max_blnd_yr  = max_sup * blnd_per_usdc_supply + max_bor * blnd_per_usdc_borrow;
-    let max_cap_warn = if max_sup > pool_supplied_usdc + cap_room { "CAP" } else { "" };
+    let max_sup = initial * max_lev;
+    let max_bor = max_sup - initial;
+    let max_net_apy = (supply_apr * max_sup - borrow_apr * max_bor) / initial * 100.0;
+    let max_blnd_yr = max_sup * blnd_per_usdc_supply + max_bor * blnd_per_usdc_borrow;
+    let max_cap_warn = if max_sup > pool_supplied_usdc + cap_room {
+        "CAP"
+    } else {
+        ""
+    };
 
     println!("  {}", "─".repeat(84));
-    println!("  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>8.4}  {:>9.2}%  {:>10.1}  {}",
-        "∞", max_sup, max_bor, max_lev, 1.0_f64, max_net_apy, max_blnd_yr, max_cap_warn);
+    println!(
+        "  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>8.4}  {:>9.2}%  {:>10.1}  {}",
+        "∞", max_sup, max_bor, max_lev, 1.0_f64, max_net_apy, max_blnd_yr, max_cap_warn
+    );
 
     // ── 6. Risk summary ───────────────────────────────────────────────────────
-    let safe_lev   = leverage(last_safe_loop, c_factor);
-    let safe_blnd  = safe_lev * initial * blnd_per_usdc_supply
+    let safe_lev = leverage(last_safe_loop, c_factor);
+    let safe_blnd = safe_lev * initial * blnd_per_usdc_supply
         + (safe_lev * initial - initial) * blnd_per_usdc_borrow;
 
     println!();
@@ -366,15 +458,21 @@ fn main() {
 
     let max_safe_util: f64 = 0.85;
     if util > max_safe_util {
-        println!("  │  ⛔ UTILIZATION: {:.1}% — ABOVE {:.0}% SAFETY CAP           │",
-            util * 100.0, max_safe_util * 100.0);
+        println!(
+            "  │  ⛔ UTILIZATION: {:.1}% — ABOVE {:.0}% SAFETY CAP           │",
+            util * 100.0,
+            max_safe_util * 100.0
+        );
         println!("  │    Collateral d-tokens are ILLIQUID at this level.       │");
         println!("  │    Liquidators cannot redeem → bad debt accumulates.     │");
         println!("  │    DO NOT open new leveraged positions.                  │");
         println!("  ├─────────────────────────────────────────────────────────┤");
     } else if util > 0.75 {
-        println!("  │  ⚠  Utilization {:.1}% — approaching {:.0}% cap            │",
-            util * 100.0, max_safe_util * 100.0);
+        println!(
+            "  │  ⚠  Utilization {:.1}% — approaching {:.0}% cap            │",
+            util * 100.0,
+            max_safe_util * 100.0
+        );
         println!("  │    Opening large loops may push utilization past limit.  │");
         println!("  ├─────────────────────────────────────────────────────────┤");
     }
@@ -382,33 +480,45 @@ fn main() {
     // Rate manipulation guard
     let spread = borrow_apr - supply_apr;
     if spread > 0.15 {
-        println!("  │  ⛔ RATE SPREAD: {:.1}%/yr — ABNORMALLY HIGH             │",
-            spread * 100.0);
+        println!(
+            "  │  ⛔ RATE SPREAD: {:.1}%/yr — ABNORMALLY HIGH             │",
+            spread * 100.0
+        );
         println!("  │    May indicate rate manipulation attack. Do not open    │");
         println!("  │    new positions until rates stabilize.                  │");
         println!("  ├─────────────────────────────────────────────────────────┤");
     }
 
     println!("  │  Collateral = Borrowed = USDC → NO price-based liq     │");
-    println!("  │  Safe max: {:>2} loops → {:.3}× leverage (HF ≥ 1.05)    │",
-        last_safe_loop, safe_lev);
+    println!(
+        "  │  Safe max: {:>2} loops → {:.3}× leverage (HF ≥ 1.05)    │",
+        last_safe_loop, safe_lev
+    );
     println!("  ├─────────────────────────────────────────────────────────┤");
 
     if supply_apr >= borrow_apr {
-        println!("  │  ✓ Interest spread: +{:.3}%/yr                         │",
-            (supply_apr - borrow_apr) * 100.0);
+        println!(
+            "  │  ✓ Interest spread: +{:.3}%/yr                         │",
+            (supply_apr - borrow_apr) * 100.0
+        );
     } else {
-        println!("  │  ✗ Interest spread: {:.3}%/yr  (NEGATIVE carry)       │",
-            (supply_apr - borrow_apr) * 100.0);
+        println!(
+            "  │  ✗ Interest spread: {:.3}%/yr  (NEGATIVE carry)       │",
+            (supply_apr - borrow_apr) * 100.0
+        );
         println!("  │    Pure interest loop loses money without BLND          │");
     }
 
     if blnd_per_usdc_borrow > 0.0 {
         println!("  ├─────────────────────────────────────────────────────────┤");
-        println!("  │  BLND at safe max ({} loops, {:.2}×):  {:.1} BLND/yr │",
-            last_safe_loop, safe_lev, safe_blnd);
-        println!("  │  BLND at max ({:.0}×):        {:.1} BLND/yr        │",
-            max_lev, max_blnd_yr);
+        println!(
+            "  │  BLND at safe max ({} loops, {:.2}×):  {:.1} BLND/yr │",
+            last_safe_loop, safe_lev, safe_blnd
+        );
+        println!(
+            "  │  BLND at max ({:.0}×):        {:.1} BLND/yr        │",
+            max_lev, max_blnd_yr
+        );
         println!("  │  ⚠ Only borrow side earns BLND (supply side: NONE)     │");
         println!("  │  ⚠ Claim via pool.claim() — does NOT auto-compound     │");
         println!("  │  ⚠ BLND must be sold to realize yield                  │");
@@ -416,9 +526,14 @@ fn main() {
 
     if cap_room < max_sup {
         println!("  ├─────────────────────────────────────────────────────────┤");
-        println!("  │  ⚠ SUPPLY CAP: ${:.0} room left before pool cap       │", cap_room);
-        println!("  │    Max safe supply for $1000: ${:.2}                │",
-            (pool_supplied_usdc + cap_room).min(max_sup));
+        println!(
+            "  │  ⚠ SUPPLY CAP: ${:.0} room left before pool cap       │",
+            cap_room
+        );
+        println!(
+            "  │    Max safe supply for $1000: ${:.2}                │",
+            (pool_supplied_usdc + cap_room).min(max_sup)
+        );
     }
 
     println!("  └─────────────────────────────────────────────────────────┘");

--- a/tests/leverage_sim.rs
+++ b/tests/leverage_sim.rs
@@ -153,8 +153,10 @@ fn simulate_usdc_leverage() {
 
     // Supply cap + current pool totals.
     let scalar_f = 10_f64.powi(cfg.decimals as i32);
-    let pool_supplied = reserve.data.d_supply as f64 * reserve.data.d_rate as f64 / SCALAR / scalar_f;
-    let pool_borrowed = reserve.data.b_supply as f64 * reserve.data.b_rate as f64 / SCALAR / scalar_f;
+    let pool_supplied =
+        reserve.data.d_supply as f64 * reserve.data.d_rate as f64 / SCALAR / scalar_f;
+    let pool_borrowed =
+        reserve.data.b_supply as f64 * reserve.data.b_rate as f64 / SCALAR / scalar_f;
     let supply_cap_usdc = if cfg.supply_cap > 0 {
         Some(cfg.supply_cap as f64 / scalar_f)
     } else {
@@ -166,34 +168,79 @@ fn simulate_usdc_leverage() {
     // BLND emissions: d-token index = cfg.index * 2, b-token = cfg.index * 2 + 1.
     // eps is in 1e7-scaled BLND per second (1 BLND/s = eps of 1e7).
     const SECONDS_PER_YEAR: f64 = 31_536_000.0;
-    let supply_eps = pool.get_reserve_emissions(&(cfg.index * 2))
-        .map(|e| e.eps).unwrap_or(0);
-    let borrow_eps = pool.get_reserve_emissions(&(cfg.index * 2 + 1))
-        .map(|e| e.eps).unwrap_or(0);
+    let supply_eps = pool
+        .get_reserve_emissions(&(cfg.index * 2))
+        .map(|e| e.eps)
+        .unwrap_or(0);
+    let borrow_eps = pool
+        .get_reserve_emissions(&(cfg.index * 2 + 1))
+        .map(|e| e.eps)
+        .unwrap_or(0);
     let pool_supply_blnd_yr = supply_eps as f64 * SECONDS_PER_YEAR / SCALAR;
     let pool_borrow_blnd_yr = borrow_eps as f64 * SECONDS_PER_YEAR / SCALAR;
 
     // BLND per $1 supplied/borrowed per year (pool-dilution approximation).
-    let blnd_per_usdc_supply = if pool_supplied > 0.0 { pool_supply_blnd_yr / pool_supplied } else { 0.0 };
-    let blnd_per_usdc_borrow = if pool_borrowed > 0.0 { pool_borrow_blnd_yr / pool_borrowed } else { 0.0 };
+    let blnd_per_usdc_supply = if pool_supplied > 0.0 {
+        pool_supply_blnd_yr / pool_supplied
+    } else {
+        0.0
+    };
+    let blnd_per_usdc_borrow = if pool_borrowed > 0.0 {
+        pool_borrow_blnd_yr / pool_borrowed
+    } else {
+        0.0
+    };
 
     println!("\n  ┌─────────────────────────────────────────────────────────┐");
     println!("  │        USDC Reserve (live from mainnet fork)            │");
     println!("  ├─────────────────────────────────────────────────────────┤");
-    println!("  │  Collateral factor (c):  {:>7.1}%                       │", c_factor * 100.0);
-    println!("  │  Liquidation factor:     {:>7.1}%                       │", l_factor * 100.0);
-    println!("  │  Utilization:            {:>7.2}%                       │", util * 100.0);
-    println!("  │  Supply APR:             {:>7.2}%                       │", supply_apr * 100.0);
-    println!("  │  Borrow APR:             {:>7.2}%                       │", borrow_apr * 100.0);
-    println!("  │  Backstop take rate:     {:>7.1}%                       │", bstop_rate * 100.0);
-    println!("  │  IR modifier:            {:>8.4}                       │", reserve.data.ir_mod as f64 / SCALAR);
+    println!(
+        "  │  Collateral factor (c):  {:>7.1}%                       │",
+        c_factor * 100.0
+    );
+    println!(
+        "  │  Liquidation factor:     {:>7.1}%                       │",
+        l_factor * 100.0
+    );
+    println!(
+        "  │  Utilization:            {:>7.2}%                       │",
+        util * 100.0
+    );
+    println!(
+        "  │  Supply APR:             {:>7.2}%                       │",
+        supply_apr * 100.0
+    );
+    println!(
+        "  │  Borrow APR:             {:>7.2}%                       │",
+        borrow_apr * 100.0
+    );
+    println!(
+        "  │  Backstop take rate:     {:>7.1}%                       │",
+        bstop_rate * 100.0
+    );
+    println!(
+        "  │  IR modifier:            {:>8.4}                       │",
+        reserve.data.ir_mod as f64 / SCALAR
+    );
     println!("  ├─────────────────────────────────────────────────────────┤");
-    println!("  │  Pool supplied:   {:>14.2} USDC                    │", pool_supplied);
-    println!("  │  Pool borrowed:   {:>14.2} USDC                    │", pool_borrowed);
+    println!(
+        "  │  Pool supplied:   {:>14.2} USDC                    │",
+        pool_supplied
+    );
+    println!(
+        "  │  Pool borrowed:   {:>14.2} USDC                    │",
+        pool_borrowed
+    );
     match (supply_cap_usdc, cap_pct, cap_room) {
         (Some(cap), Some(pct), Some(room)) => {
-            println!("  │  Supply cap:      {:>14.2} USDC  ({:>5.1}% used)     │", cap, pct);
-            println!("  │  Room remaining:  {:>14.2} USDC                    │", room);
+            println!(
+                "  │  Supply cap:      {:>14.2} USDC  ({:>5.1}% used)     │",
+                cap, pct
+            );
+            println!(
+                "  │  Room remaining:  {:>14.2} USDC                    │",
+                room
+            );
         }
         _ => {
             println!("  │  Supply cap:           uncapped                         │");
@@ -203,12 +250,30 @@ fn simulate_usdc_leverage() {
     if supply_eps == 0 && borrow_eps == 0 {
         println!("  │  BLND emissions:   NONE configured for this reserve     │");
     } else {
-        println!("  │  BLND supply eps: {:>12} (raw 1e7-scaled BLND/s)   │", supply_eps);
-        println!("  │  BLND borrow eps: {:>12} (raw 1e7-scaled BLND/s)   │", borrow_eps);
-        println!("  │  Pool supply BLND/yr: {:>10.1}                       │", pool_supply_blnd_yr);
-        println!("  │  Pool borrow BLND/yr: {:>10.1}                       │", pool_borrow_blnd_yr);
-        println!("  │  Per $1 supplied: {:>10.4} BLND/yr                    │", blnd_per_usdc_supply);
-        println!("  │  Per $1 borrowed: {:>10.4} BLND/yr                    │", blnd_per_usdc_borrow);
+        println!(
+            "  │  BLND supply eps: {:>12} (raw 1e7-scaled BLND/s)   │",
+            supply_eps
+        );
+        println!(
+            "  │  BLND borrow eps: {:>12} (raw 1e7-scaled BLND/s)   │",
+            borrow_eps
+        );
+        println!(
+            "  │  Pool supply BLND/yr: {:>10.1}                       │",
+            pool_supply_blnd_yr
+        );
+        println!(
+            "  │  Pool borrow BLND/yr: {:>10.1}                       │",
+            pool_borrow_blnd_yr
+        );
+        println!(
+            "  │  Per $1 supplied: {:>10.4} BLND/yr                    │",
+            blnd_per_usdc_supply
+        );
+        println!(
+            "  │  Per $1 borrowed: {:>10.4} BLND/yr                    │",
+            blnd_per_usdc_borrow
+        );
         println!("  │  ⚠  Net APY below excludes BLND. Multiply by price.   │");
     }
     println!("  └─────────────────────────────────────────────────────────┘");
@@ -216,8 +281,11 @@ fn simulate_usdc_leverage() {
     // ── 5. Show user's current positions ─────────────────────────────────────
     let user = Address::from_str(&env, USER_ADDR);
     let positions = pool.get_positions(&user);
-    println!("\n  User positions ({}…{}):",
-        &USER_ADDR[..6], &USER_ADDR[USER_ADDR.len()-4..]);
+    println!(
+        "\n  User positions ({}…{}):",
+        &USER_ADDR[..6],
+        &USER_ADDR[USER_ADDR.len() - 4..]
+    );
     if positions.collateral.is_empty() && positions.liabilities.is_empty() {
         println!("    None — using hypothetical $1,000 USDC for simulation below");
     } else {
@@ -232,16 +300,24 @@ fn simulate_usdc_leverage() {
     let max_lev = 1.0 / (1.0 - c_factor);
 
     println!("  Initial deposit:          ${:.0}", initial);
-    println!("  Collateral factor (c):     {:.0}%  (borrow up to c × collateral)", c_factor * 100.0);
-    println!("  Max theoretical leverage:  {:.2}×  (= 1 / (1 − c))", max_lev);
+    println!(
+        "  Collateral factor (c):     {:.0}%  (borrow up to c × collateral)",
+        c_factor * 100.0
+    );
+    println!(
+        "  Max theoretical leverage:  {:.2}×  (= 1 / (1 − c))",
+        max_lev
+    );
     println!("  Max leveraged exposure:   ${:.0}", initial * max_lev);
 
     // Combined BLND per $1 (supply + borrow sides scale together in a loop).
     let blnd_per_usdc_net = blnd_per_usdc_supply + blnd_per_usdc_borrow;
 
     println!();
-    println!("  {:>4}  {:>12}  {:>12}  {:>8}  {:>11}  {:>10}  {:>10}  {}",
-        "Loop", "Supplied ($)", "Borrowed ($)", "Leverage", "HF", "Net APY", "BLND/yr", "⚠");
+    println!(
+        "  {:>4}  {:>12}  {:>12}  {:>8}  {:>11}  {:>10}  {:>10}  {}",
+        "Loop", "Supplied ($)", "Borrowed ($)", "Leverage", "HF", "Net APY", "BLND/yr", "⚠"
+    );
     println!("  {}", "─".repeat(85));
 
     let mut last_safe_loops = 0usize;
@@ -268,12 +344,22 @@ fn simulate_usdc_leverage() {
             _ => "",
         };
 
-        println!("  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>11}  {:>9.2}%  {:>10.1}  {}",
-            n, supplied, borrowed, lev, hf_str, net_apy, blnd_yr, cap_warn);
+        println!(
+            "  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>11}  {:>9.2}%  {:>10.1}  {}",
+            n, supplied, borrowed, lev, hf_str, net_apy, blnd_yr, cap_warn
+        );
 
-        let hf = if borrowed > 0.0 { (supplied * c_factor) / borrowed } else { f64::INFINITY };
-        if hf >= 1.05 { last_safe_loops = n; }
-        if lev / max_lev > 0.9999 { break; }
+        let hf = if borrowed > 0.0 {
+            (supplied * c_factor) / borrowed
+        } else {
+            f64::INFINITY
+        };
+        if hf >= 1.05 {
+            last_safe_loops = n;
+        }
+        if lev / max_lev > 0.9999 {
+            break;
+        }
     }
 
     // Theoretical infinity row
@@ -281,10 +367,15 @@ fn simulate_usdc_leverage() {
     let max_bor = max_sup - initial;
     let max_net_apy = (supply_apr * max_sup - borrow_apr * max_bor) / initial * 100.0;
     let max_blnd_yr = max_sup * blnd_per_usdc_supply + max_bor * blnd_per_usdc_borrow;
-    let max_cap_warn = match cap_room { Some(room) if max_sup > pool_supplied + room => "CAP", _ => "" };
+    let max_cap_warn = match cap_room {
+        Some(room) if max_sup > pool_supplied + room => "CAP",
+        _ => "",
+    };
     println!("  {}", "─".repeat(85));
-    println!("  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>11.4}  {:>9.2}%  {:>10.1}  {}",
-        "∞", max_sup, max_bor, max_lev, 1.0_f64, max_net_apy, max_blnd_yr, max_cap_warn);
+    println!(
+        "  {:>4}  {:>12.2}  {:>12.2}  {:>7.2}×  {:>11.4}  {:>9.2}%  {:>10.1}  {}",
+        "∞", max_sup, max_bor, max_lev, 1.0_f64, max_net_apy, max_blnd_yr, max_cap_warn
+    );
 
     // ── 7. Liquidation risk analysis ──────────────────────────────────────────
     println!();
@@ -300,37 +391,54 @@ fn simulate_usdc_leverage() {
     println!("  ├─────────────────────────────────────────────────────────┤");
 
     let safe_lev = leverage(last_safe_loops, c_factor);
-    println!("  │  Safe max: {} loops → {:.2}× leverage (HF ≥ 1.05)  │",
-        last_safe_loops,
-        safe_lev,
+    println!(
+        "  │  Safe max: {} loops → {:.2}× leverage (HF ≥ 1.05)  │",
+        last_safe_loops, safe_lev,
     );
     println!("  │  At 20× max: HF → 1.0000 — one accrual tick risks liq  │");
     println!("  ├─────────────────────────────────────────────────────────┤");
 
     if supply_apr > borrow_apr {
-        println!("  │  ✓ Rate spread: +{:.2}%  (strategy earns interest)      │",
-            (supply_apr - borrow_apr) * 100.0);
-        println!("  │    Max net interest APY at {:.0}×: {:.2}%               │",
-            max_lev, max_net_apy);
+        println!(
+            "  │  ✓ Rate spread: +{:.2}%  (strategy earns interest)      │",
+            (supply_apr - borrow_apr) * 100.0
+        );
+        println!(
+            "  │    Max net interest APY at {:.0}×: {:.2}%               │",
+            max_lev, max_net_apy
+        );
     } else {
-        println!("  │  ✗ Borrow APR ({:.2}%) > Supply APR ({:.2}%)           │",
-            borrow_apr * 100.0, supply_apr * 100.0);
+        println!(
+            "  │  ✗ Borrow APR ({:.2}%) > Supply APR ({:.2}%)           │",
+            borrow_apr * 100.0,
+            supply_apr * 100.0
+        );
         println!("  │    Interest spread is NEGATIVE — BLND is the only yield │");
     }
     println!("  ├─────────────────────────────────────────────────────────┤");
     if blnd_per_usdc_net > 0.0 {
         let safe_blnd = initial * leverage(last_safe_loops, c_factor) * blnd_per_usdc_supply
             + (initial * leverage(last_safe_loops, c_factor) - initial) * blnd_per_usdc_borrow;
-        println!("  │  BLND at safe max ({} loops, {:.2}×): {:.1} BLND/yr   │",
-            last_safe_loops, leverage(last_safe_loops, c_factor), safe_blnd);
-        println!("  │  BLND at 20× max:  {:.1} BLND/yr                    │", max_blnd_yr);
+        println!(
+            "  │  BLND at safe max ({} loops, {:.2}×): {:.1} BLND/yr   │",
+            last_safe_loops,
+            leverage(last_safe_loops, c_factor),
+            safe_blnd
+        );
+        println!(
+            "  │  BLND at 20× max:  {:.1} BLND/yr                    │",
+            max_blnd_yr
+        );
         println!("  │  ⚠  BLND earned must be sold to realize APY.           │");
         println!("  │  ⚠  claim() required — does not compound automatically. │");
         if let Some(room) = cap_room {
             if max_sup > pool_supplied + room {
                 println!("  │  ⚠  Supply cap hit before 20× — max safe supply:       │");
-                println!("  │     ${:.2} total (cap room: ${:.2})              │",
-                    pool_supplied + room, room);
+                println!(
+                    "  │     ${:.2} total (cap room: ${:.2})              │",
+                    pool_supplied + room,
+                    room
+                );
             }
         }
     } else {
@@ -392,8 +500,12 @@ fn execute_leverage_loop() {
 
     let (supply_apr, borrow_apr) = compute_rates(&reserve, bstop_rate);
 
-    println!("  c_factor = {:.1}%  supply APR = {:.2}%  borrow APR = {:.2}%",
-        c_factor * 100.0, supply_apr * 100.0, borrow_apr * 100.0);
+    println!(
+        "  c_factor = {:.1}%  supply APR = {:.2}%  borrow APR = {:.2}%",
+        c_factor * 100.0,
+        supply_apr * 100.0,
+        borrow_apr * 100.0
+    );
 
     // ── 3. Create test account and fund with 1 000 USDC ──────────────────────
     println!("[3/4] Minting 1 000 USDC to test account…");
@@ -416,8 +528,10 @@ fn execute_leverage_loop() {
     const N_LOOPS: usize = 13;
 
     println!("[4/4] Executing {N_LOOPS} supply+borrow loops on mainnet fork…\n");
-    println!("  {:>4}  {:>14}  {:>14}  {:>9}  {:>9}  {:>8}",
-        "Loop", "Supplied  ($)", "Borrowed  ($)", "Actual", "Theory", "Δ lev");
+    println!(
+        "  {:>4}  {:>14}  {:>14}  {:>9}  {:>9}  {:>8}",
+        "Loop", "Supplied  ($)", "Borrowed  ($)", "Actual", "Theory", "Δ lev"
+    );
     println!("  {}", "─".repeat(67));
 
     for n in 0..N_LOOPS {
@@ -454,9 +568,15 @@ fn execute_leverage_loop() {
 
         let theory_lev = leverage(n + 1, c_factor);
 
-        println!("  {:>4}  {:>14.2}  {:>14.2}  {:>8.4}×  {:>8.4}×  {:>+8.5}",
-            n + 1, actual_supplied, actual_borrowed,
-            actual_lev, theory_lev, actual_lev - theory_lev);
+        println!(
+            "  {:>4}  {:>14.2}  {:>14.2}  {:>8.4}×  {:>8.4}×  {:>+8.5}",
+            n + 1,
+            actual_supplied,
+            actual_borrowed,
+            actual_lev,
+            theory_lev,
+            actual_lev - theory_lev
+        );
     }
 
     println!("  {}", "─".repeat(67));
@@ -481,11 +601,17 @@ fn execute_leverage_loop() {
     println!("    Borrowed:  ${final_borrowed:.2}");
     println!("    Leverage:  {final_lev:.4}×");
     println!("    Health:    {final_hf:.4}");
-    println!("    Δ from theory: {:+.5}×", final_lev - leverage(N_LOOPS, c_factor));
+    println!(
+        "    Δ from theory: {:+.5}×",
+        final_lev - leverage(N_LOOPS, c_factor)
+    );
     println!();
 
     // Sanity checks.
-    assert!(final_hf >= 1.05, "health factor dropped below safe threshold: {final_hf:.4}");
+    assert!(
+        final_hf >= 1.05,
+        "health factor dropped below safe threshold: {final_hf:.4}"
+    );
     assert!(
         (final_lev - leverage(N_LOOPS, c_factor)).abs() < 0.01,
         "actual leverage deviates too far from theory: {final_lev:.4}× vs {:.4}×",


### PR DESCRIPTION
Unblocks #223 (Clippy + rustfmt CI), which would otherwise fail on every Rust PR.

## What
- Removes the dead RPC helper block (`MAINNET_RPC`, `RpcResponse`, `rpc_call`) and the never-read `supply_cap_usdc` field from `src/bin/execute_loop.rs`.
- `#[allow(dead_code)]` on `simulate.rs`'s documented-but-unread `expiration` ledger field.
- `cargo fmt` applied.

## Verification
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo build --workspace`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)