### PR TITLE
ci: build and test Soroban contracts on every PR

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,38 @@
+name: Contracts
+on:
+  pull_request:
+    paths:
+      - 'contracts/**'
+      - '.github/workflows/contracts.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'contracts/**'
+
+jobs:
+  blend_leverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts/strategies/blend_leverage
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts/strategies/blend_leverage
+
+      # TODO: add `cargo clippy --all-targets -- -D warnings` once the
+      # existing lint debt in the crate (digit grouping etc.) is paid down.
+      - name: Test
+        run: cargo test
+
+      - name: Build wasm release
+        run: cargo build --target wasm32v1-none --release


### PR DESCRIPTION
## Why
No workflow builds or tests the contracts: `parity.yml` only builds `rate_calc` + frontend tests, and `blend_leverage` is not a cargo workspace member so `cargo test --workspace` never touches it. This let dev land non-compiling contract code (#157/#217) and let PRs like #233 (deposit traps at runtime) and #235 (proptests don't compile) through with zero contract verification.

## What
Adds `.github/workflows/contracts.yml`: `cargo test` + `wasm32v1-none` release build for `blend_leverage` on any PR touching `contracts/**`. Clippy `-D warnings` is left as a TODO until the crate's existing digit-grouping lint debt is paid down (would otherwise red every PR immediately).

## Verification
On current main: `cargo test` 43/43 pass, wasm release build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)