### PR TITLE
merge: integrate dev into main (#157, #187, #216, #217)

### DIFF
--- a/.kiro/specs/trustline-auto-setup/.config.kiro
+++ b/.kiro/specs/trustline-auto-setup/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "ea1253bd-dc85-4f10-ad1b-41a5dc369b64", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/trustline-auto-setup/design.md
+++ b/.kiro/specs/trustline-auto-setup/design.md
@@ -1,0 +1,228 @@
+# Design Document: Trustline Auto-Setup on First Deposit
+
+## Overview
+
+When a user opens a leveraged position for the first time, their Stellar account may be missing trustlines for the pool's b_token, d_token, and BLND classic assets. Without these trustlines the on-chain transaction fails with a "no trustline" error. This feature detects missing trustlines before the deposit is submitted and prepends the necessary `changeTrust` operations to the same transaction envelope, so the user signs once and the deposit succeeds atomically.
+
+The implementation touches two files:
+- **`frontend/src/blend.ts`** — adds `getMissingTrustlines` and `prependTrustlineOps` exports
+- **`frontend/src/main.ts`** — calls those helpers inside `openPosition()` before the submit step
+
+---
+
+## Components and Interfaces
+
+### getMissingTrustlines (blend.ts)
+
+Queries the pool contract for the reserve's b_token and d_token contract IDs, calls `symbol()` and `issuer()` on each to derive the classic `Asset`, adds the network's `blndClassic` asset, then loads the user's Horizon account to find which of those three assets lack a trustline. Returns a `MissingTrustlineResult` containing the list of missing assets and the current trustline count (for limit checking).
+
+```typescript
+export interface MissingTrustlineResult {
+  /** Classic assets that need a trustline created. Empty = no-op. */
+  missing: Asset[];
+  /** Current number of non-native trustlines on the account. */
+  currentCount: number;
+}
+
+export async function getMissingTrustlines(
+  pool: PoolDef,
+  userAddress: string,
+  assetId: string,
+): Promise<MissingTrustlineResult>
+```
+
+### prependTrustlineOps (blend.ts)
+
+Deserialises the existing Soroban transaction XDR, prepends one `Operation.changeTrust` per missing asset (limit = Stellar max `"922337203685.4775807"`), rebuilds the transaction, and returns the new XDR. If `missingAssets` is empty it returns the original XDR unchanged.
+
+```typescript
+export async function prependTrustlineOps(
+  submitXdr: string,
+  missingAssets: Asset[],
+  userAddress: string,
+): Promise<string>
+```
+
+### openPosition (main.ts)
+
+After building the approve XDR and before building the submit XDR, calls `getMissingTrustlines`. If the projected trustline count would exceed 1,000 it throws and shows a user-facing error. Otherwise it calls `prependTrustlineOps` on the submit XDR and passes the bundled result to `signAndSubmit`.
+
+---
+
+## Data Models
+
+### MissingTrustlineResult
+
+| Field | Type | Description |
+|---|---|---|
+| `missing` | `Asset[]` | Classic Stellar assets that need `changeTrust` ops. Empty when all trustlines exist. |
+| `currentCount` | `number` | Number of non-native trustlines currently on the account. Used for limit check. |
+
+### Trustline check key format
+
+Existing trustlines are indexed as `"CODE:ISSUER"` strings built from Horizon balance records where `asset_type !== "native"`. This matches the format returned by `Asset.getCode()` and `Asset.getIssuer()`.
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+openPosition() [main.ts]
+  │
+  ├─ buildApproveXdr()          ← unchanged (step 0)
+  │
+  ├─ getMissingTrustlines()     ← NEW (blend.ts)
+  │     │
+  │     ├─ get_reserve(assetId) → reserveRaw.config.b_token, .d_token
+  │     ├─ b_token.symbol() + b_token.issuer()  → classic Asset
+  │     ├─ d_token.symbol() + d_token.issuer()  → classic Asset
+  │     ├─ cfg.blndClassic                       → BLND classic Asset
+  │     ├─ horizon.loadAccount(userAddress)      → existing trustlines
+  │     └─ returns MissingTrustlineResult
+  │
+  ├─ [if limit exceeded] → throw, abort
+  │
+  ├─ buildOpenPositionXdr()     ← unchanged (produces Soroban XDR)
+  │
+  ├─ prependTrustlineOps()      ← NEW (blend.ts)
+  │     │
+  │     ├─ TransactionBuilder.fromXDR(submitXdr)
+  │     ├─ prepend changeTrust ops for each missing asset
+  │     └─ returns new XDR string (or original if nothing missing)
+  │
+  └─ signAndSubmit(bundledXdr)  ← single wallet signature
+```
+
+---
+
+## Implementation Details
+
+### Deriving b_token and d_token classic assets
+
+The Blend pool's `get_reserve` RPC call returns a `reserveRaw` object. Its `config` field contains `b_token` and `d_token` as Soroban contract IDs. Each is a Soroban-wrapped classic asset contract that exposes `symbol()` and `issuer()` entry points.
+
+```typescript
+const reserveRaw = await simulate(
+  poolContract.call("get_reserve", new Address(assetId).toScVal())
+);
+const bTokenId: string = reserveRaw.config.b_token;
+const dTokenId: string = reserveRaw.config.d_token;
+
+const bSymbol: string = await simulate(new Contract(bTokenId).call("symbol"));
+const bIssuer: string = await simulate(new Contract(bTokenId).call("issuer"));
+const dSymbol: string = await simulate(new Contract(dTokenId).call("symbol"));
+const dIssuer: string = await simulate(new Contract(dTokenId).call("issuer"));
+```
+
+**Note on XLM (native asset):** XLM does not require a trustline. If `bIssuer` or `dIssuer` is null/empty (indicating a native-wrapped token), that asset is skipped.
+
+### Checking existing trustlines
+
+```typescript
+const acc = await horizon.loadAccount(userAddress);
+const existing = new Set(
+  acc.balances
+    .filter((b: any) => b.asset_type !== "native")
+    .map((b: any) => `${b.asset_code}:${b.asset_issuer}`)
+);
+const required = [bAsset, dAsset, _cfg.blndClassic].filter(a => !a.isNative());
+const missing  = required.filter(a => !existing.has(`${a.getCode()}:${a.getIssuer()}`));
+const currentCount = acc.balances.filter((b: any) => b.asset_type !== "native").length;
+```
+
+### Trustline limit check (main.ts)
+
+```typescript
+const STELLAR_TRUSTLINE_LIMIT = 1000;
+const { missing, currentCount } = await getMissingTrustlines(selectedPool, userAddress, liveAsset.id);
+if (currentCount + missing.length > STELLAR_TRUSTLINE_LIMIT) {
+  throw new Error(
+    `Adding ${missing.length} trustline(s) would exceed the Stellar limit of 1,000. ` +
+    `You currently have ${currentCount}. Remove unused trustlines before depositing.`
+  );
+}
+```
+
+### Prepending changeTrust ops
+
+```typescript
+export async function prependTrustlineOps(
+  submitXdr: string,
+  missingAssets: Asset[],
+  userAddress: string,
+): Promise<string> {
+  if (missingAssets.length === 0) return submitXdr;
+
+  const MAX_TRUSTLINE_LIMIT = "922337203685.4775807";
+  const original = TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase) as Transaction;
+  const acc = await server.getAccount(userAddress);
+  const adjustedAcc = new Account(userAddress, (BigInt(acc.sequenceNumber()) - 1n).toString());
+
+  const builder = new TransactionBuilder(adjustedAcc, {
+    fee: original.fee,
+    networkPassphrase: _cfg.passphrase,
+    memo: original.memo,
+    timebounds: original.timeBounds ?? undefined,
+  });
+
+  for (const asset of missingAssets) {
+    builder.addOperation(Operation.changeTrust({ asset, limit: MAX_TRUSTLINE_LIMIT }));
+  }
+  for (const op of original.operations) {
+    builder.addOperation(op);
+  }
+
+  return builder.build().toXDR();
+}
+```
+
+**Sequence number handling:** `buildOpenPositionXdr` calls `server.getAccount(userAddress)` to get the current sequence. `prependTrustlineOps` is called after that XDR is built, so the sequence in the original XDR is already correct. We reconstruct the transaction using the same sequence by decrementing by 1 before passing to `TransactionBuilder` (which auto-increments).
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Horizon account load fails | `getMissingTrustlines` throws; `openPosition` catches, shows toast, aborts |
+| `get_reserve` returns null | `getMissingTrustlines` throws with descriptive message |
+| b_token/d_token `issuer` sim returns null | Asset skipped (treated as native, no trustline needed) |
+| Projected trustline count > 1,000 | `openPosition` throws before building submit XDR; toast shown |
+| All trustlines already present | Returns `missing: []`; `prependTrustlineOps` returns original XDR unchanged |
+
+---
+
+## Correctness Properties
+
+Property 1: **Atomicity** — trustline creation and the Soroban deposit are in the same transaction envelope; both succeed or both fail together.
+**Validates: Requirements 2.1, 2.4**
+
+Property 2: **No-op transparency** — when `missing.length === 0`, `prependTrustlineOps` returns the original XDR string without reconstruction; the transaction is byte-for-byte identical to what `buildOpenPositionXdr` produced.
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+Property 3: **Idempotency** — running the flow a second time (all trustlines now exist) produces the same no-op result.
+**Validates: Requirements 4.1, 4.3**
+
+Property 4: **Limit safety** — the check `currentCount + missing.length > 1000` is evaluated before any transaction is built, so the user is never presented with a transaction that would fail on-chain due to the trustline limit.
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+---
+
+## Testing Strategy
+
+Manual verification steps:
+1. **First deposit (no trustlines):** connect a fresh testnet account, open a position — confirm the wallet shows a single transaction containing `changeTrust` ops followed by the Soroban `submit_with_allowance` call.
+2. **Second deposit (trustlines exist):** open a second position on the same asset — confirm the wallet shows only the Soroban ops with no `changeTrust` ops.
+3. **Trustline limit:** use a testnet account with 999 trustlines and attempt a first deposit requiring 2 new trustlines — confirm the error toast appears and no wallet prompt is shown.
+4. **RPC failure:** simulate a Horizon outage (e.g. wrong URL) — confirm the deposit is aborted with a descriptive error toast.
+
+---
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `frontend/src/blend.ts` | Add `MissingTrustlineResult` interface, `getMissingTrustlines`, `prependTrustlineOps` exports |
+| `frontend/src/main.ts` | Import new exports; update `openPosition` to call them between approve and submit steps |

--- a/.kiro/specs/trustline-auto-setup/requirements.md
+++ b/.kiro/specs/trustline-auto-setup/requirements.md
@@ -1,0 +1,84 @@
+# Requirements Document
+
+## Introduction
+
+When a user makes their first deposit into a Blend leveraged-loop position, the transaction can fail with a "no trustline" error if the user's Stellar account has not yet established trustlines for the pool's b_tokens (supply receipt tokens), d_tokens (debt receipt tokens), and the BLND reward token. This feature eliminates that failure mode by detecting missing trustlines before the deposit is submitted and bundling the necessary `changeTrust` operations into the same signed transaction envelope, so the user only needs to sign once and the deposit succeeds on the first attempt.
+
+## Glossary
+
+- **b_token**: A Soroban-wrapped Stellar classic asset representing a user's supply (collateral) share in a Blend pool reserve. Each reserve has one b_token. Its classic asset code follows the pattern `bXXX` where `XXX` is the underlying asset symbol.
+- **d_token**: A Soroban-wrapped Stellar classic asset representing a user's debt share in a Blend pool reserve. Each reserve has one d_token. Its classic asset code follows the pattern `dXXX`.
+- **BLND**: The Blend protocol reward token (`BLND` issued by `GDJEHTBE6ZHUXSWFI642DCGLUOECLHPF3KSXHPXTSTJ7E3JF6MQ5EZYY` on mainnet). Users accumulate BLND emissions while holding positions; a trustline is required to receive them.
+- **Trustline**: A Stellar classic ledger entry that authorises an account to hold a specific asset. Created via the `changeTrust` operation. An account can hold at most 1,000 trustlines (the Stellar trustline limit).
+- **Trustline_Checker**: The module responsible for querying Horizon to determine which required trustlines are absent from a user's account.
+- **Bundle_Builder**: The module responsible for prepending `changeTrust` operations to an existing transaction XDR when missing trustlines are detected.
+- **Deposit_Flow**: The end-to-end sequence in `main.ts` that handles the "Open Position" user action, including approve, open-position, and any trustline setup steps.
+- **First Deposit**: Any deposit attempt where the user does not yet hold b_tokens or d_tokens for the target pool reserve (i.e., no existing Blend position for that asset).
+- **Horizon**: The Stellar REST API used to load account state, including existing trustlines.
+
+---
+
+## Requirements
+
+### Requirement 1: Detect Missing Trustlines Before Deposit
+
+**User Story:** As a user opening a leveraged position for the first time, I want the app to automatically detect which trustlines I am missing, so that my deposit does not fail with a "no trustline" error.
+
+#### Acceptance Criteria
+
+1. WHEN a user initiates a deposit, THE Trustline_Checker SHALL query the user's Horizon account record to retrieve the current list of established trustlines.
+2. WHEN the Horizon account record is retrieved, THE Trustline_Checker SHALL compare the existing trustlines against the required set: the b_token, d_token, and BLND token for the target pool reserve.
+3. WHEN all required trustlines are already present, THE Trustline_Checker SHALL return an empty list of missing trustlines, resulting in no `changeTrust` operations being added.
+4. IF the Horizon account query fails, THEN THE Trustline_Checker SHALL propagate the error to the Deposit_Flow so the deposit is aborted with a descriptive message rather than silently proceeding without trustline setup.
+
+---
+
+### Requirement 2: Bundle Trustline Operations Into the Deposit Transaction
+
+**User Story:** As a user, I want trustline creation to happen in the same transaction as my deposit, so that I only need to sign once and the entire operation is atomic.
+
+#### Acceptance Criteria
+
+1. WHEN the Trustline_Checker returns one or more missing trustlines, THE Bundle_Builder SHALL prepend one `changeTrust` operation per missing trustline to the existing deposit transaction XDR before it is presented to the user for signing.
+2. THE Bundle_Builder SHALL set the `limit` parameter of each `changeTrust` operation to the Stellar maximum trustline limit (`"922337203685.4775807"`), ensuring the trustline does not artificially cap the user's token balance.
+3. THE Bundle_Builder SHALL preserve all existing operations in the transaction (approve and open-position Soroban calls) unchanged after prepending the `changeTrust` operations.
+4. WHEN trustline operations are bundled, THE Deposit_Flow SHALL present the combined transaction to the user for a single wallet signature rather than requiring separate signing steps.
+5. WHEN no trustlines are missing, THE Bundle_Builder SHALL return the original transaction XDR unmodified.
+
+---
+
+### Requirement 3: Handle the Stellar Trustline Limit
+
+**User Story:** As a user whose account is near the Stellar trustline limit, I want to receive a clear error before signing, so that I am not surprised by an on-chain failure.
+
+#### Acceptance Criteria
+
+1. WHEN the Trustline_Checker determines the number of missing trustlines, THE Trustline_Checker SHALL calculate the user's projected trustline count as: `(current trustline count) + (number of missing trustlines)`.
+2. IF the projected trustline count exceeds 1,000, THEN THE Trustline_Checker SHALL return an error indicating the trustline limit would be exceeded, and THE Deposit_Flow SHALL abort the deposit and display a message instructing the user to remove unused trustlines before proceeding.
+3. WHEN the projected trustline count is exactly 1,000 or fewer, THE Trustline_Checker SHALL allow the deposit to proceed normally.
+
+---
+
+### Requirement 4: No-Op When Trustlines Already Exist
+
+**User Story:** As a returning user who already has all required trustlines, I want the deposit flow to behave exactly as before, so that no unnecessary operations are added to my transaction.
+
+#### Acceptance Criteria
+
+1. WHEN all required trustlines for the target pool reserve are already present on the user's account, THE Deposit_Flow SHALL NOT add any `changeTrust` operations to the transaction.
+2. WHEN all required trustlines are already present, THE Deposit_Flow SHALL NOT make any additional Horizon or RPC calls beyond those already performed in the normal deposit flow.
+3. FOR ALL deposit attempts where trustlines are already present, the resulting transaction XDR SHALL be byte-for-byte identical to the XDR that would have been produced without the trustline-auto-setup feature enabled (round-trip property: the no-op path is transparent).
+
+---
+
+### Requirement 5: Identify Required Trustlines for a Pool Reserve
+
+**User Story:** As a developer, I want a deterministic function that returns the full set of classic assets requiring trustlines for a given pool reserve, so that the detection logic is reusable and testable.
+
+#### Acceptance Criteria
+
+1. THE Trustline_Checker SHALL derive the b_token classic asset for a reserve by reading the Soroban token contract's `symbol` and `issuer` metadata from the active network configuration.
+2. THE Trustline_Checker SHALL derive the d_token classic asset for a reserve using the same mechanism as the b_token.
+3. THE Trustline_Checker SHALL always include the BLND classic asset (`blndClassic` from the active network config) in the required trustline set, regardless of which pool or reserve is being deposited into.
+4. WHEN the active network is testnet, THE Trustline_Checker SHALL use the testnet BLND asset and testnet b_token/d_token issuers from `TESTNET_CONFIG`.
+5. WHEN the active network is mainnet, THE Trustline_Checker SHALL use the mainnet BLND asset and mainnet b_token/d_token issuers from `MAINNET_CONFIG`.

--- a/.kiro/specs/trustline-auto-setup/tasks.md
+++ b/.kiro/specs/trustline-auto-setup/tasks.md
@@ -6,11 +6,11 @@ Implement trustline auto-setup so that on first deposit, `changeTrust` operation
 
 ## Tasks
 
-- [ ] 1. Add MissingTrustlineResult interface to blend.ts
+- [x] 1. Add MissingTrustlineResult interface to blend.ts
   - Add `export interface MissingTrustlineResult { missing: Asset[]; currentCount: number; }` to `frontend/src/blend.ts`
   - Place it alongside the other exported interfaces near the top of the file
 
-- [ ] 2. Implement getMissingTrustlines in blend.ts
+- [x] 2. Implement getMissingTrustlines in blend.ts
   - Add `export async function getMissingTrustlines(pool: PoolDef, userAddress: string, assetId: string): Promise<MissingTrustlineResult>` to `frontend/src/blend.ts`
   - Call `simulate(poolContract.call("get_reserve", new Address(assetId).toScVal()))` and throw if null
   - Extract `reserveRaw.config.b_token` and `reserveRaw.config.d_token` contract IDs
@@ -21,7 +21,7 @@ Implement trustline auto-setup so that on first deposit, `changeTrust` operation
   - Set `currentCount` to the number of non-native balances on the account
   - Return `{ missing, currentCount }`
 
-- [ ] 3. Implement prependTrustlineOps in blend.ts
+- [x] 3. Implement prependTrustlineOps in blend.ts
   - Add `export async function prependTrustlineOps(submitXdr: string, missingAssets: Asset[], userAddress: string): Promise<string>` to `frontend/src/blend.ts`
   - Return `submitXdr` immediately when `missingAssets.length === 0`
   - Deserialise with `TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase)` cast to `Transaction`
@@ -32,7 +32,7 @@ Implement trustline auto-setup so that on first deposit, `changeTrust` operation
   - Return `builder.build().toXDR()`
   - Ensure `Transaction` type is imported from `@stellar/stellar-sdk` (add to existing import if absent)
 
-- [ ] 4. Update openPosition in main.ts
+- [x] 4. Update openPosition in main.ts
   - Import `getMissingTrustlines`, `prependTrustlineOps`, and `MissingTrustlineResult` from `./blend.ts`
   - After the approve step and before `buildOpenPositionXdr`, call `getMissingTrustlines(selectedPool, userAddress, liveAsset.id)`
   - If `currentCount + missing.length > 1000`, show a descriptive toast and return early without building the submit XDR
@@ -41,7 +41,7 @@ Implement trustline auto-setup so that on first deposit, `changeTrust` operation
   - Pass `bundledXdr` to `signAndSubmit` instead of `submitXdr`
   - Update the step label for the submit step to include `"(+ trustlines)"` suffix when `missing.length > 0`
 
-- [ ] 5. Build and type-check
+- [x] 5. Build and type-check
   - Run `npm run build` or `tsc --noEmit` in `frontend/` and fix any TypeScript errors
   - Confirm no new package dependencies are introduced
   - Confirm the no-op path: when all trustlines exist, `prependTrustlineOps` returns the original XDR and the stepper shows `["Approve", "Submit"]`

--- a/.kiro/specs/trustline-auto-setup/tasks.md
+++ b/.kiro/specs/trustline-auto-setup/tasks.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Trustline Auto-Setup on First Deposit
+
+## Overview
+
+Implement trustline auto-setup so that on first deposit, `changeTrust` operations for b_token, d_token, and BLND are bundled into the same signed transaction. Changes are confined to `frontend/src/blend.ts` (new helpers) and `frontend/src/main.ts` (deposit flow update).
+
+## Tasks
+
+- [ ] 1. Add MissingTrustlineResult interface to blend.ts
+  - Add `export interface MissingTrustlineResult { missing: Asset[]; currentCount: number; }` to `frontend/src/blend.ts`
+  - Place it alongside the other exported interfaces near the top of the file
+
+- [ ] 2. Implement getMissingTrustlines in blend.ts
+  - Add `export async function getMissingTrustlines(pool: PoolDef, userAddress: string, assetId: string): Promise<MissingTrustlineResult>` to `frontend/src/blend.ts`
+  - Call `simulate(poolContract.call("get_reserve", new Address(assetId).toScVal()))` and throw if null
+  - Extract `reserveRaw.config.b_token` and `reserveRaw.config.d_token` contract IDs
+  - Simulate `symbol()` and `issuer()` on each token contract; skip the asset if issuer is null/empty (native)
+  - Build the required asset list: b_token Asset, d_token Asset, `_cfg.blndClassic`; filter out native assets
+  - Call `horizon.loadAccount(userAddress)` — propagate any error; build a Set of existing trustlines as `"CODE:ISSUER"` strings
+  - Filter required assets to find those not in the existing set
+  - Set `currentCount` to the number of non-native balances on the account
+  - Return `{ missing, currentCount }`
+
+- [ ] 3. Implement prependTrustlineOps in blend.ts
+  - Add `export async function prependTrustlineOps(submitXdr: string, missingAssets: Asset[], userAddress: string): Promise<string>` to `frontend/src/blend.ts`
+  - Return `submitXdr` immediately when `missingAssets.length === 0`
+  - Deserialise with `TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase)` cast to `Transaction`
+  - Load account via `server.getAccount(userAddress)`; construct `Account` with sequence decremented by 1
+  - Build new `TransactionBuilder` with same `fee`, `networkPassphrase`, `memo`, and `timebounds`
+  - Prepend `Operation.changeTrust({ asset, limit: "922337203685.4775807" })` for each missing asset
+  - Append all original operations from the deserialised transaction
+  - Return `builder.build().toXDR()`
+  - Ensure `Transaction` type is imported from `@stellar/stellar-sdk` (add to existing import if absent)
+
+- [ ] 4. Update openPosition in main.ts
+  - Import `getMissingTrustlines`, `prependTrustlineOps`, and `MissingTrustlineResult` from `./blend.ts`
+  - After the approve step and before `buildOpenPositionXdr`, call `getMissingTrustlines(selectedPool, userAddress, liveAsset.id)`
+  - If `currentCount + missing.length > 1000`, show a descriptive toast and return early without building the submit XDR
+  - Update TX stepper labels: `["Approve", "Setup Trustlines + Submit"]` when `missing.length > 0`, else `["Approve", "Submit"]`
+  - After `buildOpenPositionXdr` returns `submitXdr`, call `prependTrustlineOps(submitXdr, missing, userAddress)` to get `bundledXdr`
+  - Pass `bundledXdr` to `signAndSubmit` instead of `submitXdr`
+  - Update the step label for the submit step to include `"(+ trustlines)"` suffix when `missing.length > 0`
+
+- [ ] 5. Build and type-check
+  - Run `npm run build` or `tsc --noEmit` in `frontend/` and fix any TypeScript errors
+  - Confirm no new package dependencies are introduced
+  - Confirm the no-op path: when all trustlines exist, `prependTrustlineOps` returns the original XDR and the stepper shows `["Approve", "Submit"]`
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "wave": 1, "tasks": [1] },
+    { "wave": 2, "tasks": [2, 3] },
+    { "wave": 3, "tasks": [4] },
+    { "wave": 4, "tasks": [5] }
+  ],
+  "dependencies": {
+    "2": [1],
+    "3": [1],
+    "4": [2, 3],
+    "5": [4]
+  }
+}
+```
+
+Tasks 1, 2, and 3 are in `blend.ts` and can be done sequentially. Task 4 depends on 2 and 3. Task 5 validates everything.
+
+## Notes
+
+- `Transaction` (not `FeeBumpTransaction`) is the type returned by `buildOpenPositionXdr` — the cast in task 3 is safe.
+- The sequence number decrement-by-1 trick is necessary because `TransactionBuilder` always increments the sequence on `build()`. The original XDR already has the correct sequence, so we reconstruct it by starting one lower.
+- Native XLM never needs a trustline — skip any b_token or d_token whose `issuer()` simulation returns null.
+- The `horizon` variable in `blend.ts` is module-level and already used by `buildSwapBlndXdr` — no new Horizon client is needed.

--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -417,17 +417,17 @@ pub fn claim(e: &Env, config: &Config) -> i128 {
 // ── Harvest: claim + swap + re-leverage ──────────────────────────────────────
 
 /// Claim BLND, swap to underlying via Soroswap, and re-leverage the proceeds.
-/// Returns the additional (b_tokens, d_tokens) from re-leveraging.
+/// Returns (b_tokens_delta, d_tokens_delta, realized_underlying).
 pub fn perform_reinvest(
     e: &Env,
     config: &Config,
     amount_out_min: i128,
-) -> Result<(i128, i128), StrategyError> {
+) -> Result<(i128, i128, i128), StrategyError> {
     let blnd_balance =
         TokenClient::new(e, &config.blend_token).balance(&e.current_contract_address());
 
     if blnd_balance < config.reward_threshold {
-        return Ok((0, 0));
+        return Ok((0, 0, 0));
     }
 
     let swap_path = vec![e, config.blend_token.clone(), config.asset.clone()];
@@ -454,13 +454,13 @@ pub fn perform_reinvest(
         .ok_or(StrategyError::InternalSwapError)?;
 
     if amount_out <= 0 {
-        return Ok((0, 0));
+        return Ok((0, 0, 0));
     }
 
     // Re-leverage the swapped proceeds
     let (b_delta, d_delta) = submit_leverage_loop(e, amount_out, config)?;
 
-    Ok((b_delta, d_delta))
+    Ok((b_delta, d_delta, amount_out))
 }
 
 // ── Pool state queries ───────────────────────────────────────────────────────

--- a/contracts/strategies/blend_leverage/src/leverage.rs
+++ b/contracts/strategies/blend_leverage/src/leverage.rs
@@ -247,59 +247,89 @@ pub fn check_deposit_safety(
     Ok(())
 }
 
-/// Compute how many loops to unwind to bring HF back above min_hf.
-/// Returns the number of (withdraw, repay) pairs needed.
-pub fn compute_unwind_loops(
+/// Compute the minimal underlying amount to repay (and withdraw) to restore HF
+/// to `target_hf`, and the number of leverage loops that covers it.
+///
+/// Closed-form derivation (all values in underlying units):
+///   B = b_tokens × b_rate / SCALAR_12   (supply value)
+///   D = d_tokens × d_rate / SCALAR_12   (debt value)
+///   HF = B × c_factor / D               (current, in 1e7)
+///
+/// After repaying x underlying (and withdrawing x collateral):
+///   (B - x) × c_factor = target_hf × (D - x)
+///   x = (B × c_factor - target_hf × D) / (c_factor - target_hf)
+///
+/// Returns `(repay_underlying, loops_needed)`.
+/// Returns `(0, 0)` if already at or above target_hf, or if no debt.
+pub fn compute_partial_unwind(
     b_tokens: i128,
     d_tokens: i128,
     b_rate: i128,
     d_rate: i128,
     c_factor: i128,
-    min_hf: i128,
-) -> Result<u32, StrategyError> {
-    let mut current_b = b_tokens;
-    let mut current_d = d_tokens;
-    let mut loops = 0u32;
-
-    loop {
-        let hf = compute_health_factor(current_b, current_d, b_rate, d_rate, c_factor)?;
-        if hf >= min_hf || current_d == 0 {
-            break;
-        }
-
-        // Unwind one loop: withdraw enough collateral to repay one "layer" of debt.
-        // The last borrow layer ≈ d_tokens × (c_factor/SCALAR_7)^n pattern.
-        // Simplified: repay an amount equal to current_d × (1 - c_factor/SCALAR_7)
-        // which is approximately the smallest borrow layer.
-        let repay_amount = current_d
-            .checked_mul(SCALAR_7 - c_factor)
-            .ok_or(StrategyError::ArithmeticError)?
-            / SCALAR_7;
-
-        if repay_amount == 0 {
-            break;
-        }
-
-        // The d_tokens burned = repay_underlying / d_rate * SCALAR_12
-        let d_tokens_burned = repay_amount
-            .fixed_mul_floor(SCALAR_12, d_rate)
-            .ok_or(StrategyError::ArithmeticError)?;
-
-        // The b_tokens withdrawn = withdraw_underlying / b_rate * SCALAR_12
-        // We withdraw same amount as we repay (netting)
-        let b_tokens_withdrawn = repay_amount
-            .fixed_mul_floor(SCALAR_12, b_rate)
-            .ok_or(StrategyError::ArithmeticError)?;
-
-        current_d = current_d.checked_sub(d_tokens_burned).unwrap_or(0);
-        current_b = current_b.checked_sub(b_tokens_withdrawn).unwrap_or(0);
-        loops += 1;
-
-        if loops >= 5 {
-            // Safety limit on unwind iterations
-            break;
-        }
+    target_hf: i128,
+) -> Result<(i128, u32), StrategyError> {
+    if d_tokens == 0 {
+        return Ok((0, 0));
     }
 
-    Ok(loops)
+    let hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, c_factor)?;
+    if hf >= target_hf {
+        return Ok((0, 0));
+    }
+
+    // Supply and debt values in underlying (SCALAR_12 precision)
+    let supply_value = b_tokens
+        .fixed_mul_floor(b_rate, SCALAR_12)
+        .ok_or(StrategyError::ArithmeticError)?;
+    let debt_value = d_tokens
+        .fixed_mul_floor(d_rate, SCALAR_12)
+        .ok_or(StrategyError::ArithmeticError)?;
+
+    // numerator   = B × c_factor - target_hf × D  (both in 1e7 × underlying)
+    // denominator = c_factor - target_hf           (in 1e7)
+    // x = numerator / denominator
+    let numerator = supply_value
+        .checked_mul(c_factor)
+        .ok_or(StrategyError::ArithmeticError)?
+        .checked_sub(
+            target_hf
+                .checked_mul(debt_value)
+                .ok_or(StrategyError::ArithmeticError)?,
+        )
+        .ok_or(StrategyError::UnderflowOverflow)?;
+
+    // denominator = c_factor - target_hf; negative when target_hf > c_factor (always true for
+    // a healthy target), so we negate both sides.
+    let denom = target_hf
+        .checked_sub(c_factor)
+        .ok_or(StrategyError::UnderflowOverflow)?;
+
+    if denom <= 0 {
+        // target_hf <= c_factor: can't reach target by partial unwind alone
+        return Err(StrategyError::ArithmeticError);
+    }
+
+    // x = -numerator / denom  (numerator is negative when HF < target_hf)
+    let repay_underlying = numerator
+        .checked_neg()
+        .ok_or(StrategyError::ArithmeticError)?
+        .checked_div(denom)
+        .ok_or(StrategyError::DivisionByZero)?
+        + 1; // +1 stroop to ensure we clear the threshold
+
+    // Convert repay amount to loop count.
+    // Each loop layer ≈ initial × c_factor^k. The smallest layer (last borrow) ≈
+    // total_debt × (1 - c_factor/SCALAR_7). We count how many layers sum to repay_underlying.
+    let layer_size = debt_value
+        .checked_mul(SCALAR_7 - c_factor)
+        .ok_or(StrategyError::ArithmeticError)?
+        / SCALAR_7;
+
+    if layer_size == 0 {
+        return Ok((repay_underlying, 1));
+    }
+
+    let loops = ((repay_underlying + layer_size - 1) / layer_size) as u32;
+    Ok((repay_underlying, loops.max(1).min(20)))
 }

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -15,7 +15,7 @@ mod test_integration;
 use constants::SCALAR_12;
 pub use defindex_strategy_core::{event, DeFindexStrategyTrait, StrategyError};
 use leverage::{
-    check_deposit_safety, compute_health_factor, compute_totals, compute_unwind_loops,
+    check_deposit_safety, compute_health_factor, compute_partial_unwind, compute_totals,
     shares_to_underlying,
 };
 use soroban_sdk::{
@@ -49,6 +49,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
     ///   [5] c_factor: i128         — collateral factor (1e7)
     ///   [6] target_loops: u32      — number of leverage loops
     ///   [7] min_hf: i128           — minimum health factor (1e7)
+    ///   [8] orange_hf: i128        — orange-zone threshold; partial unwind triggered below this (1e7)
     fn __constructor(e: Env, asset: Address, init_args: Vec<Val>) {
         let pool: Address = init_args
             .get(0)
@@ -82,6 +83,10 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
             .get(7)
             .expect("Missing: min_hf")
             .into_val(&e);
+        let orange_hf: i128 = init_args
+            .get(8)
+            .expect("Missing: orange_hf")
+            .into_val(&e);
 
         // Look up the reserve index from the pool
         let pool_client = blend_contract_sdk::pool::Client::new(&e, &pool);
@@ -107,6 +112,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
             c_factor,
             target_loops,
             min_hf,
+            orange_hf,
         };
 
         storage::set_config(&e, config);
@@ -301,7 +307,8 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
 #[contractimpl]
 impl BlendLeverageStrategy {
-    /// Rebalance: auto-deleverage if health factor is below min_hf.
+    /// Rebalance: partial-unwind if HF is in the orange zone (orange_hf > HF >= min_hf),
+    /// or full deleverage if HF < min_hf.
     /// Callable by anyone (permissionless — protects the vault).
     pub fn rebalance(e: Env) -> Result<(), StrategyError> {
         extend_instance_ttl(&e);
@@ -311,32 +318,76 @@ impl BlendLeverageStrategy {
         let (b_tokens, d_tokens) = blend_pool::get_strategy_positions(&e, &config);
 
         if d_tokens == 0 {
-            return Ok(()); // No debt, nothing to rebalance
+            return Ok(());
         }
 
         let hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, config.c_factor)?;
 
-        if hf >= config.min_hf {
-            return Ok(()); // HF is healthy
+        if hf >= config.orange_hf {
+            return Ok(()); // HF is healthy, no action needed
         }
 
-        // Compute how many loops to unwind
-        let unwind_count = compute_unwind_loops(
-            b_tokens, d_tokens, b_rate, d_rate, config.c_factor, config.min_hf,
+        // Use orange_hf as target so we restore to the safe zone, not just min_hf
+        let (_, unwind_loops) = compute_partial_unwind(
+            b_tokens, d_tokens, b_rate, d_rate, config.c_factor, config.orange_hf,
         )?;
 
-        if unwind_count == 0 {
+        if unwind_loops == 0 {
             return Ok(());
         }
 
-        // Execute deleverage
         let (b_removed, d_removed) =
-            blend_pool::submit_deleverage(&e, unwind_count, &config)?;
+            blend_pool::submit_deleverage(&e, unwind_loops, &config)?;
 
-        // Update reserves accounting
         reserves::deleverage(&e, b_removed, d_removed, &config)?;
 
         Ok(())
+    }
+
+    /// Partial-unwind liquidation protection: unwind just enough loops to restore
+    /// HF to `target_hf`. Callable by the keeper or the strategy itself.
+    ///
+    /// `target_hf` must be >= config.orange_hf to prevent abuse.
+    pub fn partial_unwind(e: Env, caller: Address, target_hf: i128) -> Result<u32, StrategyError> {
+        extend_instance_ttl(&e);
+
+        // Keeper or permissionless if HF is already in orange zone
+        let config = storage::get_config(&e);
+        let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
+        let (b_tokens, d_tokens) = blend_pool::get_strategy_positions(&e, &config);
+
+        if d_tokens == 0 {
+            return Ok(0);
+        }
+
+        let hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, config.c_factor)?;
+
+        // Only the keeper can trigger above the orange zone; anyone can trigger inside it
+        if hf >= config.orange_hf {
+            let keeper = storage::get_keeper(&e);
+            if caller != keeper {
+                return Err(StrategyError::NotAuthorized);
+            }
+        }
+        caller.require_auth();
+
+        // target_hf must be at least orange_hf to avoid over-unwinding
+        let effective_target = target_hf.max(config.orange_hf);
+
+        let (_, loops) = compute_partial_unwind(
+            b_tokens, d_tokens, b_rate, d_rate, config.c_factor, effective_target,
+        )?;
+
+        if loops == 0 {
+            return Ok(0);
+        }
+
+        let (b_removed, d_removed) =
+            blend_pool::submit_deleverage(&e, loops, &config)?;
+
+        reserves::deleverage(&e, b_removed, d_removed, &config)?;
+
+        Ok(loops)
     }
 
     /// Set a new keeper address. Only the current keeper can call this.

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -20,7 +20,8 @@ use leverage::{
     shares_to_underlying,
 };
 use soroban_sdk::{
-    contract, contractimpl, token::TokenClient, Address, Bytes, Env, IntoVal, String, Val, Vec,
+    contract, contractimpl, token::TokenClient, Address, Bytes, Env, IntoVal, String, Symbol, Val,
+    Vec,
 };
 use storage::{extend_instance_ttl, Config};
 

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -3,6 +3,7 @@
 mod blend_pool;
 mod constants;
 mod leverage;
+mod receipt;
 mod reserves;
 mod soroswap;
 mod storage;

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -229,7 +229,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
         };
 
         // Swap BLND → underlying, then re-leverage
-        let (b_delta, d_delta) = blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
+        let (b_delta, d_delta, realized_underlying) = blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
 
         // Update reserves without minting shares (yield accrues to existing holders)
         if b_delta > 0 {
@@ -240,6 +240,12 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
                 harvested_blnd,
                 keeper,
                 shares_to_underlying(SCALAR_12, &updated_reserves)?,
+            );
+
+            // Emit custom event for realized underlying
+            e.events().publish(
+                (Symbol::new(&e, "harvest_realized"), String::from_str(&e, STRATEGY_NAME)),
+                realized_underlying,
             );
         }
 

--- a/contracts/strategies/blend_leverage/src/receipt.rs
+++ b/contracts/strategies/blend_leverage/src/receipt.rs
@@ -1,0 +1,85 @@
+/// SEP-41 receipt token for BlendLeverageStrategy vault shares.
+///
+/// Each "share" in storage maps 1:1 to one receipt token unit.
+/// Transfer moves the full proportional claim on the underlying b/d-token
+/// position from sender to receiver — no new leverage is opened or closed.
+///
+/// Backward-compatible: existing depositors already have shares in storage;
+/// their balance is immediately queryable via `receipt_balance`.
+use crate::storage;
+use defindex_strategy_core::StrategyError;
+use soroban_sdk::{contractimpl, symbol_short, Address, Env, String};
+
+use crate::BlendLeverageStrategy;
+
+// ── SEP-41 interface ─────────────────────────────────────────────────────────
+
+#[contractimpl]
+impl BlendLeverageStrategy {
+    /// Returns the number of decimals used by the receipt token.
+    /// Matches the underlying asset convention (7 decimals).
+    pub fn receipt_decimals(_e: Env) -> u32 {
+        7
+    }
+
+    /// Human-readable name of the receipt token.
+    pub fn receipt_name(e: Env) -> String {
+        String::from_str(&e, "BlendLeverage Vault Share")
+    }
+
+    /// Ticker symbol of the receipt token.
+    pub fn receipt_symbol(e: Env) -> String {
+        String::from_str(&e, "blvSHARE")
+    }
+
+    /// Total supply of receipt tokens (= total vault shares outstanding).
+    pub fn receipt_total_supply(e: Env) -> i128 {
+        storage::get_strategy_reserves(&e).total_shares
+    }
+
+    /// Receipt token balance for `id` (= vault shares held by `id`).
+    pub fn receipt_balance(e: Env, id: Address) -> i128 {
+        storage::get_vault_shares(&e, &id)
+    }
+
+    /// Transfer `amount` receipt tokens (vault shares) from `from` to `to`.
+    ///
+    /// Moves the proportional claim on the underlying leveraged position.
+    /// No pool interaction occurs — only the share accounting is updated.
+    pub fn receipt_transfer(
+        e: Env,
+        from: Address,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), StrategyError> {
+        if amount <= 0 {
+            return Err(StrategyError::OnlyPositiveAmountAllowed);
+        }
+        from.require_auth();
+
+        let from_shares = storage::get_vault_shares(&e, &from);
+        if from_shares < amount {
+            return Err(StrategyError::InsufficientBalance);
+        }
+
+        let to_shares = storage::get_vault_shares(&e, &to);
+
+        storage::set_vault_shares(
+            &e,
+            &from,
+            from_shares.checked_sub(amount).ok_or(StrategyError::UnderflowOverflow)?,
+        );
+        storage::set_vault_shares(
+            &e,
+            &to,
+            to_shares.checked_add(amount).ok_or(StrategyError::UnderflowOverflow)?,
+        );
+
+        e.events().publish(
+            (symbol_short!("transfer"), from, to),
+            amount,
+        );
+
+        Ok(())
+    }
+}

--- a/contracts/strategies/blend_leverage/src/receipt.rs
+++ b/contracts/strategies/blend_leverage/src/receipt.rs
@@ -10,7 +10,7 @@ use crate::storage;
 use defindex_strategy_core::StrategyError;
 use soroban_sdk::{contractimpl, symbol_short, Address, Env, String};
 
-use crate::BlendLeverageStrategy;
+use crate::{BlendLeverageStrategy, BlendLeverageStrategyArgs, BlendLeverageStrategyClient};
 
 // ── SEP-41 interface ─────────────────────────────────────────────────────────
 

--- a/contracts/strategies/blend_leverage/src/storage.rs
+++ b/contracts/strategies/blend_leverage/src/storage.rs
@@ -46,6 +46,9 @@ pub struct Config {
     pub target_loops: u32,
     /// Minimum health factor (1e7 scaled, e.g. 1_050_000 = 1.05)
     pub min_hf: i128,
+    /// Orange-zone threshold: HF below this triggers partial unwind (1e7 scaled).
+    /// Must satisfy min_hf < orange_hf. e.g. 1_150_000 = 1.15
+    pub orange_hf: i128,
 }
 
 pub fn set_config(e: &Env, config: Config) {

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -148,6 +148,7 @@ fn make_config(e: &Env, pool_addr: &Address, token: &Address, blnd: &Address) ->
         c_factor: 9_000_000, // 0.90: below pool's c=0.95 to keep HF > 1.0
         target_loops: 3,
         min_hf: 10_500_000,
+        orange_hf: 11_500_000,
     }
 }
 

--- a/contracts/strategies/blend_leverage/src/test_leverage.rs
+++ b/contracts/strategies/blend_leverage/src/test_leverage.rs
@@ -4,8 +4,8 @@
 
 use crate::constants::{FIRST_DEPOSIT_LOCKUP, SCALAR_12, SCALAR_7};
 use crate::leverage::{
-    compute_equity, compute_health_factor, compute_loop_pairs, compute_totals, compute_unwind_loops,
-    shares_to_underlying, underlying_to_shares,
+    compute_equity, compute_health_factor, compute_loop_pairs, compute_partial_unwind,
+    compute_totals, shares_to_underlying, underlying_to_shares,
 };
 use crate::storage::LeverageReserves;
 
@@ -312,50 +312,130 @@ fn test_hf_below_one() {
     assert!(hf < SCALAR_7); // HF < 1.0 → liquidatable
 }
 
-// ── compute_unwind_loops ─────────────────────────────────────────────────────
+// ── compute_partial_unwind ───────────────────────────────────────────────────
 
 #[test]
-fn test_unwind_healthy_position_returns_zero() {
-    // HF = 1.9 >> 1.05 → no unwinding needed
-    let loops = compute_unwind_loops(
+fn test_partial_unwind_already_at_target_returns_zero() {
+    // HF = 1.9 >> target 1.15 → no unwind needed
+    let (repay, loops) = compute_partial_unwind(
         2_000_0000000,
         1_000_0000000,
         SCALAR_12,
         SCALAR_12,
         9_500_000,
-        10_500_000, // min_hf = 1.05
+        11_500_000, // target_hf = 1.15
     ).unwrap();
+    assert_eq!(repay, 0);
     assert_eq!(loops, 0);
 }
 
 #[test]
-fn test_unwind_unhealthy_position() {
-    // HF just below 1.05 → should need some unwinding
-    // b=10500, d=9500, c=0.95 → HF = 10500*0.95/9500 ≈ 1.05 exactly
-    // Make it slightly below: b=10499, d=9500
-    let loops = compute_unwind_loops(
-        10_499_0000000,
-        9_500_0000000,
-        SCALAR_12,
-        SCALAR_12,
-        9_500_000,
-        10_500_000,
-    ).unwrap();
-    assert!(loops > 0, "Should need at least 1 unwind loop");
-    assert!(loops <= 5, "Should not exceed safety limit");
-}
-
-#[test]
-fn test_unwind_no_debt() {
-    let loops = compute_unwind_loops(
+fn test_partial_unwind_no_debt_returns_zero() {
+    let (repay, loops) = compute_partial_unwind(
         1_000_0000000,
         0,
         SCALAR_12,
         SCALAR_12,
         9_500_000,
-        10_500_000,
+        11_500_000,
     ).unwrap();
+    assert_eq!(repay, 0);
     assert_eq!(loops, 0);
+}
+
+#[test]
+fn test_partial_unwind_single_loop_position() {
+    // 1-loop position: b=1950, d=950, c=0.95
+    // HF = 1950*0.95/950 = 1.95 → healthy, no unwind
+    let (repay, loops) = compute_partial_unwind(
+        1_950_0000000,
+        950_0000000,
+        SCALAR_12,
+        SCALAR_12,
+        9_500_000,
+        11_500_000,
+    ).unwrap();
+    assert_eq!(repay, 0);
+    assert_eq!(loops, 0);
+
+    // Now make it unhealthy: b=1100, d=1000, c=0.95 → HF = 1.045 < 1.15
+    let (repay2, loops2) = compute_partial_unwind(
+        1_100_0000000,
+        1_000_0000000,
+        SCALAR_12,
+        SCALAR_12,
+        9_500_000,
+        11_500_000,
+    ).unwrap();
+    assert!(repay2 > 0, "Should need repayment");
+    assert!(loops2 >= 1, "Should need at least 1 loop");
+
+    // Verify the repay amount actually restores HF
+    // After repaying x: new_b = 1100 - x, new_d = 1000 - x
+    // HF_new = (1100-x)*0.95 / (1000-x) >= 1.15
+    let x = repay2;
+    let new_b = 1_100_0000000 - x;
+    let new_d = 1_000_0000000 - x;
+    if new_d > 0 {
+        let hf_new = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
+        assert!(hf_new >= 11_500_000, "HF after unwind={} should be >= target 1.15", hf_new);
+    }
+}
+
+#[test]
+fn test_partial_unwind_max_loops_position() {
+    // 20-loop position (max): very high leverage, HF just below orange zone
+    // b=20000, d=19000, c=0.95 → HF = 20000*0.95/19000 ≈ 1.0
+    let (repay, loops) = compute_partial_unwind(
+        20_000_0000000,
+        19_000_0000000,
+        SCALAR_12,
+        SCALAR_12,
+        9_500_000,
+        11_500_000, // target = 1.15
+    ).unwrap();
+    assert!(repay > 0);
+    assert!(loops >= 1 && loops <= 20, "loops={} out of range", loops);
+
+    // Verify restoration
+    let new_b = 20_000_0000000 - repay;
+    let new_d = 19_000_0000000 - repay;
+    if new_d > 0 {
+        let hf_new = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
+        assert!(hf_new >= 11_500_000, "HF after unwind={} should be >= 1.15", hf_new);
+    }
+}
+
+#[test]
+fn test_partial_unwind_minimal_repay_is_exact() {
+    // Verify the closed-form gives the minimum repay (not over-unwinding).
+    // b=10500, d=9500, c=0.95 → HF = 10500*0.95/9500 ≈ 1.05
+    // target = 1.15
+    let (repay, _) = compute_partial_unwind(
+        10_500_0000000,
+        9_500_0000000,
+        SCALAR_12,
+        SCALAR_12,
+        9_500_000,
+        11_500_000,
+    ).unwrap();
+
+    // Repaying 1 less stroop should leave HF below target
+    if repay > 1 {
+        let x_minus = repay - 2;
+        let new_b = 10_500_0000000 - x_minus;
+        let new_d = 9_500_0000000 - x_minus;
+        let hf_short = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
+        assert!(hf_short < 11_500_000, "Repaying less should leave HF below target");
+    }
+
+    // Repaying the computed amount should reach target
+    let new_b = 10_500_0000000 - repay;
+    let new_d = 9_500_0000000 - repay;
+    if new_d > 0 {
+        let hf_ok = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
+        assert!(hf_ok >= 11_500_000, "HF after exact repay={} should be >= target", hf_ok);
+    }
 }
 
 // ── Leverage table validation (cross-reference with simulate.rs) ─────────────
@@ -642,6 +722,7 @@ fn test_safety_rejects_high_utilization() {
         c_factor: 9_500_000,
         target_loops: 8,
         min_hf: 10_500_000,
+        orange_hf: 11_500_000,
     };
 
     // Pool at 96% utilization → should panic (above 95% limit)
@@ -677,6 +758,7 @@ fn test_safety_allows_healthy_pool() {
         c_factor: 9_500_000,
         target_loops: 8,
         min_hf: 10_500_000,
+        orange_hf: 11_500_000,
     };
 
     // Pool at 50% utilization, healthy HF

--- a/doc.md
+++ b/doc.md
@@ -30,6 +30,30 @@ With collateral factor `c = 0.95`:
 | Health factor | `(total_supplied × c) / total_borrowed` |
 | Net APY on initial | `(supply_rate × supplied − borrow_rate × borrowed) / initial` |
 
+## Harvest APY Methodology
+
+The Vault APY includes both the base lending APY (from interest and emissions) and the realized revenue from harvesting BLND rewards.
+
+### Realized Harvest Revenue
+
+When the vault harvests BLND rewards, it swaps them for the underlying asset via Soroswap and reinvests them into the leverage loop. This increases the per-share equity of the vault without minting new shares.
+
+The harvest APY is computed by:
+1. Fetching all `harvest_realized` events for the vault from the last 30 days.
+2. Summing the total amount of underlying asset realized from these swaps.
+3. Annualizing the revenue relative to the current total equity:
+   ```
+   Harvest APY = (Total Realized 30d / Current Total Equity) * (365 / 30)
+   ```
+
+### Reported APY
+
+The reported APY is the sum of:
+- **Base APY**: `(Supply APR * Leverage) - (Borrow APR * (Leverage - 1))` (annualized)
+- **Harvest APY**: The annualized realized swap revenue from the last 30 days.
+
+This provides a more accurate representation of the total yield, including the "real yield" generated from compounding rewards.
+
 **Maximum leverage** (n → ∞):
 
 ```

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -14,6 +14,7 @@ import {
   Operation,
   rpc as SorobanRpc,
   scValToNative,
+  Transaction,
   TransactionBuilder,
   xdr,
 } from "@stellar/stellar-sdk";
@@ -273,6 +274,17 @@ export interface AssetInfo {
   borrowTokenId: number;  // reserve_index * 2
   cFactor:      number;   // 0..1, set after fetching
   maxUtil:      number;   // 0..1
+}
+
+/**
+ * Result of a trustline check before deposit.
+ * `missing` is empty when all required trustlines already exist (no-op path).
+ */
+export interface MissingTrustlineResult {
+  /** Classic assets that need a changeTrust op. Empty = no-op. */
+  missing: Asset[];
+  /** Number of non-native trustlines currently on the account (for limit check). */
+  currentCount: number;
 }
 
 /** Build the AssetInfo array for a given pool from active network's asset metadata. */
@@ -1339,4 +1351,128 @@ export async function submitClassicXdr(signedXdr: string): Promise<string> {
   const tx = TransactionBuilder.fromXDR(signedXdr, _cfg.passphrase);
   const result = await horizon.submitTransaction(tx);
   return (result as any).hash;
+}
+
+// ── Trustline auto-setup ──────────────────────────────────────────────────────
+
+/**
+ * Determine which of the three required classic assets (b_token, d_token, BLND)
+ * are missing trustlines on the user's Stellar account.
+ *
+ * Queries the pool contract for the reserve's b_token and d_token contract IDs,
+ * calls symbol() and issuer() on each to derive the classic Asset, then loads
+ * the user's Horizon account to find which assets lack a trustline.
+ *
+ * @param pool        Active pool definition
+ * @param userAddress Stellar account G-address
+ * @param assetId     Soroban contract ID of the underlying asset being deposited
+ * @returns           Missing assets + current trustline count
+ * @throws            If Horizon account load fails or reserve data is unavailable
+ */
+export async function getMissingTrustlines(
+  pool: PoolDef,
+  userAddress: string,
+  assetId: string,
+): Promise<MissingTrustlineResult> {
+  // Fetch reserve config to get b_token and d_token contract IDs
+  const poolContract = new Contract(pool.id);
+  const reserveRaw = await simulate(
+    poolContract.call("get_reserve", new Address(assetId).toScVal())
+  );
+  if (!reserveRaw) {
+    throw new Error(`Failed to fetch reserve data for asset ${assetId} — cannot check trustlines.`);
+  }
+
+  const bTokenId: string = reserveRaw.config.b_token;
+  const dTokenId: string = reserveRaw.config.d_token;
+
+  // Derive classic Asset for b_token
+  const bSymbol: string | null = await simulate(new Contract(bTokenId).call("symbol"));
+  const bIssuer: string | null = await simulate(new Contract(bTokenId).call("issuer"));
+
+  // Derive classic Asset for d_token
+  const dSymbol: string | null = await simulate(new Contract(dTokenId).call("symbol"));
+  const dIssuer: string | null = await simulate(new Contract(dTokenId).call("issuer"));
+
+  // Build required asset list; skip native assets (no trustline needed for XLM)
+  const required: Asset[] = [];
+  if (bSymbol && bIssuer) required.push(new Asset(bSymbol, bIssuer));
+  if (dSymbol && dIssuer) required.push(new Asset(dSymbol, dIssuer));
+  if (!_cfg.blndClassic.isNative()) required.push(_cfg.blndClassic);
+
+  // Load account from Horizon — propagate any error to the caller
+  const acc = await horizon.loadAccount(userAddress);
+
+  // Build set of existing trustlines as "CODE:ISSUER"
+  const existing = new Set<string>(
+    acc.balances
+      .filter((b: any) => b.asset_type !== "native")
+      .map((b: any) => `${b.asset_code}:${b.asset_issuer}`)
+  );
+
+  // Count current non-native trustlines for limit check
+  const currentCount = acc.balances.filter((b: any) => b.asset_type !== "native").length;
+
+  // Filter to assets that don't yet have a trustline
+  const missing = required.filter(
+    a => !existing.has(`${a.getCode()}:${a.getIssuer()}`)
+  );
+
+  return { missing, currentCount };
+}
+
+/**
+ * Prepend changeTrust operations to an existing Soroban transaction XDR.
+ *
+ * When missingAssets is empty, returns the original XDR unchanged (no-op path).
+ * Otherwise deserialises the XDR, prepends one changeTrust op per missing asset
+ * with the Stellar maximum limit, appends the original Soroban ops, and returns
+ * the rebuilt XDR ready for wallet signing.
+ *
+ * @param submitXdr     Base64 XDR of the assembled Soroban transaction
+ * @param missingAssets Classic assets that need trustlines
+ * @param userAddress   Account address (used to reload sequence for rebuild)
+ * @returns             New XDR string with changeTrust ops prepended, or original if empty
+ */
+export async function prependTrustlineOps(
+  submitXdr: string,
+  missingAssets: Asset[],
+  userAddress: string,
+): Promise<string> {
+  // Fast path: nothing to do
+  if (missingAssets.length === 0) return submitXdr;
+
+  const MAX_TRUSTLINE_LIMIT = "922337203685.4775807"; // Stellar i64::MAX in stroops / 1e7
+
+  // Deserialise the existing Soroban transaction
+  const original = TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase) as Transaction;
+
+  // Load current account sequence; decrement by 1 because TransactionBuilder
+  // auto-increments on build(), so we need to start one below the target sequence.
+  const accData = await server.getAccount(userAddress);
+  const adjustedAcc = new Account(
+    userAddress,
+    (BigInt(accData.sequenceNumber()) - 1n).toString(),
+  );
+
+  const builder = new TransactionBuilder(adjustedAcc, {
+    fee: original.fee,
+    networkPassphrase: _cfg.passphrase,
+    memo: original.memo,
+    timebounds: original.timeBounds ?? undefined,
+  });
+
+  // Prepend changeTrust ops for each missing trustline
+  for (const asset of missingAssets) {
+    builder.addOperation(
+      Operation.changeTrust({ asset, limit: MAX_TRUSTLINE_LIMIT })
+    );
+  }
+
+  // Append all original Soroban operations unchanged
+  for (const op of original.operations) {
+    builder.addOperation(op);
+  }
+
+  return builder.build().toXDR();
 }

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -14,7 +14,6 @@ import {
   Operation,
   rpc as SorobanRpc,
   scValToNative,
-  Transaction,
   TransactionBuilder,
   xdr,
 } from "@stellar/stellar-sdk";
@@ -1524,57 +1523,42 @@ export async function getMissingTrustlines(
 }
 
 /**
- * Prepend changeTrust operations to an existing Soroban transaction XDR.
+ * Build a standalone classic transaction containing one changeTrust op per
+ * missing asset.
  *
- * When missingAssets is empty, returns the original XDR unchanged (no-op path).
- * Otherwise deserialises the XDR, prepends one changeTrust op per missing asset
- * with the Stellar maximum limit, appends the original Soroban ops, and returns
- * the rebuilt XDR ready for wallet signing.
+ * This MUST be a separate transaction from the Soroban deposit: the Stellar
+ * protocol requires any transaction containing a Soroban operation
+ * (invokeHostFunction) to contain exactly that one operation, so changeTrust
+ * ops cannot be bundled into the leverage-loop submit tx. The caller signs and
+ * submits this classic tx (via Horizon) BEFORE the Soroban deposit tx.
  *
- * @param submitXdr     Base64 XDR of the assembled Soroban transaction
- * @param missingAssets Classic assets that need trustlines
- * @param userAddress   Account address (used to reload sequence for rebuild)
- * @returns             New XDR string with changeTrust ops prepended, or original if empty
+ * Returns null when there are no missing trustlines (caller skips the step).
+ *
+ * @param missingAssets Classic assets that need a trustline
+ * @param userAddress   Source account G-address
+ * @returns             Base64 XDR of the classic changeTrust tx, or null if none needed
  */
-export async function prependTrustlineOps(
-  submitXdr: string,
+export async function buildTrustlineXdr(
   missingAssets: Asset[],
   userAddress: string,
-): Promise<string> {
-  // Fast path: nothing to do
-  if (missingAssets.length === 0) return submitXdr;
+): Promise<string | null> {
+  if (missingAssets.length === 0) return null;
 
   const MAX_TRUSTLINE_LIMIT = "922337203685.4775807"; // Stellar i64::MAX in stroops / 1e7
 
-  // Deserialise the existing Soroban transaction
-  const original = TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase) as Transaction;
+  // Classic tx: load the source account from Horizon for a fresh sequence.
+  const account = await horizon.loadAccount(userAddress);
 
-  // Load current account sequence; decrement by 1 because TransactionBuilder
-  // auto-increments on build(), so we need to start one below the target sequence.
-  const accData = await server.getAccount(userAddress);
-  const adjustedAcc = new Account(
-    userAddress,
-    (BigInt(accData.sequenceNumber()) - 1n).toString(),
-  );
-
-  const builder = new TransactionBuilder(adjustedAcc, {
-    fee: original.fee,
+  const builder = new TransactionBuilder(account, {
+    fee: (BigInt(BASE_FEE) * BigInt(Math.max(1, missingAssets.length))).toString(),
     networkPassphrase: _cfg.passphrase,
-    memo: original.memo,
-    timebounds: original.timeBounds ?? undefined,
   });
 
-  // Prepend changeTrust ops for each missing trustline
   for (const asset of missingAssets) {
     builder.addOperation(
       Operation.changeTrust({ asset, limit: MAX_TRUSTLINE_LIMIT })
     );
   }
 
-  // Append all original Soroban operations unchanged
-  for (const op of original.operations) {
-    builder.addOperation(op);
-  }
-
-  return builder.build().toXDR();
+  return builder.setTimeout(180).build().toXDR();
 }

--- a/frontend/src/defindex.ts
+++ b/frontend/src/defindex.ts
@@ -93,6 +93,7 @@ export interface VaultStats {
   debtValue: number;       // d_tokens * d_rate in underlying
   leverage: number;        // collateralValue / equity
   netApy: number | null;   // Estimated leveraged APY (null if unavailable)
+  harvestApy: number | null; // Realized harvest APY from BLND swaps
   supplyApr: number | null;
   borrowApr: number | null;
 }
@@ -180,6 +181,9 @@ export async function fetchVaultStats(
       }
     }
 
+    // Fetch realized harvest APY (30-day lookback)
+    const harvestApy = await fetchHarvestApy(vault, totalEquity);
+
     return {
       totalEquity,
       totalShares,
@@ -193,10 +197,62 @@ export async function fetchVaultStats(
       debtValue,
       leverage,
       netApy,
+      harvestApy,
       supplyApr,
       borrowApr,
     };
   } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch and annualize realized harvest revenue from on-chain logs.
+ * Looks back 30 days.
+ */
+async function fetchHarvestApy(
+  vault: VaultConfig,
+  currentEquity: number
+): Promise<number | null> {
+  if (!vault.vaultId || currentEquity <= 0) return 0;
+
+  try {
+    // 1. Get current ledger to compute start point
+    const latest = await blendServer.getLatestLedger();
+    const curSeq = latest.sequence;
+
+    // 2. Compute start ledger (~5s per ledger, 30 days = 518,400 ledgers)
+    const LOOKBACK_LEDGERS = 518400;
+    const startLedger = Math.max(1, curSeq - LOOKBACK_LEDGERS);
+
+    // 3. Fetch events with topic "harvest_realized"
+    const topicRealized = xdr.ScVal.scvSymbol("harvest_realized").toXDR("base64");
+
+    const result = await blendServer.getEvents({
+      startLedger,
+      filters: [
+        {
+          type: "contract",
+          contractIds: [vault.vaultId],
+          topics: [[topicRealized]],
+        },
+      ],
+    });
+
+    let totalRealized = 0;
+    for (const event of result.events) {
+      const val = scValToNative(event.value);
+      totalRealized += Number(val);
+    }
+
+    // 4. Annualize: (total_30d / current_equity) * (365 / 30)
+    const scalar = 10 ** vault.decimals;
+    const realizedUnderlying = totalRealized / scalar;
+    const apy = (realizedUnderlying / currentEquity) * (365 / 30);
+
+    return apy;
+  } catch (e) {
+    console.warn(`fetchHarvestApy: failed for ${vault.name}:`, e);
     return null;
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,7 +44,7 @@ import {
   submitSignedXdr,
   submitClassicXdr,
   getMissingTrustlines,
-  prependTrustlineOps,
+  buildTrustlineXdr,
   hfForLeverage,
   maxLeverageFor,
   getBlndPriceAssumption,
@@ -718,6 +718,25 @@ async function signAndSubmit(xdrStr: string, label: string, stepIndex?: number):
   });
   toast(`Submitting "${label}"\u2026`, "info");
   const hash = await submitSignedXdr(signedTxXdr);
+  if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
+  toast(`"${label}" confirmed!`, "success", hash);
+  addTxToHistory(label, hash, "success");
+  return hash;
+}
+
+/**
+ * Sign and submit a classic (non-Soroban) transaction via Horizon.
+ * Used for changeTrust setup, which cannot be bundled into a Soroban tx.
+ */
+async function signAndSubmitClassic(xdrStr: string, label: string, stepIndex?: number): Promise<string> {
+  if (stepIndex !== undefined) updateTxStep(stepIndex, "active");
+  toast(`Sign "${label}" in your wallet\u2026`, "info");
+  const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdrStr, {
+    networkPassphrase: getNetworkPassphrase(),
+    address: userAddress!,
+  });
+  toast(`Submitting "${label}"\u2026`, "info");
+  const hash = await submitClassicXdr(signedTxXdr);
   if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
   toast(`"${label}" confirmed!`, "success", hash);
   addTxToHistory(label, hash, "success");
@@ -1783,24 +1802,43 @@ async function openPosition() {
     return;
   }
 
+  // A Soroban transaction must contain exactly one operation, so missing
+  // trustlines are set up in a SEPARATE classic changeTrust tx submitted before
+  // the leverage-loop deposit. Steps shift accordingly.
   const hasMissingTrustlines = trustlineResult.missing.length > 0;
-  const submitLabel = hasMissingTrustlines
-    ? `Open ${liveAsset.symbol} leverage (+ trustlines)`
-    : `Open ${liveAsset.symbol} leverage`;
-  showTxStepper(["Approve", hasMissingTrustlines ? "Setup Trustlines + Submit" : "Submit"]);
+  const steps = hasMissingTrustlines ? ["Trustlines", "Approve", "Submit"] : ["Approve", "Submit"];
+  const trustStep = 0;
+  const approveStep = hasMissingTrustlines ? 1 : 0;
+  const submitStep = hasMissingTrustlines ? 2 : 1;
+  let activeStep = 0;
+  showTxStepper(steps);
 
   try {
+    if (hasMissingTrustlines) {
+      activeStep = trustStep;
+      const trustXdr = await buildTrustlineXdr(trustlineResult.missing, userAddress);
+      if (trustXdr) {
+        await signAndSubmitClassic(
+          trustXdr,
+          `Add ${trustlineResult.missing.length} trustline(s)`,
+          trustStep,
+        );
+      }
+    }
+
+    activeStep = approveStep;
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
-    await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
-    const rawSubmitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
-    const bundledXdr = await prependTrustlineOps(rawSubmitXdr, trustlineResult.missing, userAddress);
-    const openHash = await signAndSubmit(bundledXdr, submitLabel, 1);
+    await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, approveStep);
+
+    activeStep = submitStep;
+    const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
+    const openHash = await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, submitStep);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
     recordPositionEvent("open", openHash, hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1));
     await loadAll();
   } catch (e: any) {
-    markStepperError(2);
+    markStepperError(activeStep);
     const msg: string = e?.message ?? "Transaction failed";
     if (msg.includes("#1205") || msg.includes("InvalidHf")) {
       toast("Health factor too low \u2014 reduce leverage.", "error");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -390,6 +390,13 @@ function animateNumber(el: HTMLElement, to: number, duration = 200, formatFn: (n
   requestAnimationFrame(frame);
 }
 
+// ── Stellar Expert URL helper ─────────────────────────────────────────────────
+
+function expertUrl(type: "tx" | "contract" | "account" | "asset", id: string): string {
+  const net = getActiveNetwork() === "testnet" ? "testnet" : "public";
+  return `https://stellar.expert/explorer/${net}/${type}/${id}`;
+}
+
 // ── Toast stack (#20) ────────────────────────────────────────────────────────
 
 let _toastCounter = 0;
@@ -404,7 +411,7 @@ function toast(msg: string, type: "info" | "success" | "error", hash?: string) {
   el.setAttribute("role", "alert");
   const icon = type === "success" ? "\u2713" : type === "error" ? "\u2717" : "\u27F3";
   const linkHtml = hash
-    ? ` <a class="toast-link" href="https://stellar.expert/explorer/public/tx/${hash}" target="_blank" rel="noopener">View \u2192</a>`
+    ? ` <a class="toast-link" href="${expertUrl("tx", hash)}" target="_blank" rel="noopener">View \u2192</a>`
     : "";
   el.innerHTML = `<span>${icon}</span><span>${msg}</span>${linkHtml}`;
   stack.appendChild(el);
@@ -442,7 +449,7 @@ function renderTxHistory() {
       <span class="tx-history-status-${tx.status === "success" ? "ok" : "err"}">${tx.status === "success" ? "\u2713" : "\u2717"}</span>
       <span class="tx-history-label">${tx.label}</span>
       <span class="tx-history-time">${timeStr}</span>
-      <a class="tx-history-link" href="https://stellar.expert/explorer/public/tx/${tx.hash}" target="_blank" rel="noopener">View</a>
+      <a class="tx-history-link" href="${expertUrl("tx", tx.hash)}" target="_blank" rel="noopener">View</a>
     </div>`;
   }).join("");
 }
@@ -866,7 +873,7 @@ function renderPoolFooter() {
   const addr = selectedPool.id;
   const truncated = addr.slice(0, 6) + "\u2026" + addr.slice(-4);
   footer.innerHTML = `
-    <span>Pool: <a href="https://stellar.expert/explorer/public/contract/${addr}" target="_blank" rel="noopener" class="mono">${truncated}</a></span>
+    <span>Pool: <a href="${expertUrl("contract", addr)}" target="_blank" rel="noopener" class="mono">${truncated}</a></span>
     <span>\u00B7</span>
     <a href="https://docs.blend.capital/" target="_blank" rel="noopener">Blend Docs</a>
     <span>\u00B7</span>
@@ -2479,13 +2486,10 @@ async function refreshVaultView() {
   $("vault-loops").textContent = String(vault.targetLoops);
 
   // Contract link
-  const explorerBase = getActiveNetwork() === "testnet"
-    ? "https://stellar.expert/explorer/testnet/contract/"
-    : "https://stellar.expert/explorer/public/contract/";
   const linkEl = $("vault-contract-link") as HTMLAnchorElement;
   if (vaultReady) {
     linkEl.textContent = vault.vaultId.slice(0, 8) + "..." + vault.vaultId.slice(-4);
-    linkEl.href = explorerBase + vault.vaultId;
+    linkEl.href = expertUrl("contract", vault.vaultId);
   } else {
     linkEl.textContent = "Not deployed";
     linkEl.href = "#";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -42,6 +42,8 @@ import {
   estimateBlndSwap,
   submitSignedXdr,
   submitClassicXdr,
+  getMissingTrustlines,
+  prependTrustlineOps,
   hfForLeverage,
   maxLeverageFor,
   type NetworkMode,
@@ -50,6 +52,7 @@ import {
   type ReserveStats,
   type AssetPosition,
   type UserPositions,
+  type MissingTrustlineResult,
   projectRates,
 } from "./blend.ts";
 
@@ -1370,12 +1373,42 @@ async function openPosition() {
 
   const initialStroops = BigInt(Math.round(initial * 1e7));
   setLoading($("open-btn") as HTMLButtonElement, true);
-  showTxStepper(["Approve", "Submit"]);
+
+  // Check for missing trustlines before building the submit tx.
+  // We do this after the early-exit guards so we only hit Horizon when we're
+  // actually going to proceed.
+  let trustlineResult: MissingTrustlineResult = { missing: [], currentCount: 0 };
+  try {
+    trustlineResult = await getMissingTrustlines(selectedPool, userAddress, liveAsset.id);
+  } catch (e: any) {
+    toast(`Trustline check failed: ${(e?.message ?? String(e)).slice(0, 150)}`, "error");
+    setLoading($("open-btn") as HTMLButtonElement, false);
+    return;
+  }
+
+  const STELLAR_TRUSTLINE_LIMIT = 1000;
+  if (trustlineResult.currentCount + trustlineResult.missing.length > STELLAR_TRUSTLINE_LIMIT) {
+    toast(
+      `Adding ${trustlineResult.missing.length} trustline(s) would exceed the Stellar limit of 1,000. ` +
+      `You currently have ${trustlineResult.currentCount}. Remove unused trustlines before depositing.`,
+      "error",
+    );
+    setLoading($("open-btn") as HTMLButtonElement, false);
+    return;
+  }
+
+  const hasMissingTrustlines = trustlineResult.missing.length > 0;
+  const submitLabel = hasMissingTrustlines
+    ? `Open ${liveAsset.symbol} leverage (+ trustlines)`
+    : `Open ${liveAsset.symbol} leverage`;
+  showTxStepper(["Approve", hasMissingTrustlines ? "Setup Trustlines + Submit" : "Submit"]);
+
   try {
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
-    const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
-    await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, 1);
+    const rawSubmitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
+    const bundledXdr = await prependTrustlineOps(rawSubmitXdr, trustlineResult.missing, userAddress);
+    await signAndSubmit(bundledXdr, submitLabel, 1);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
     await loadAll();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2522,12 +2522,22 @@ async function refreshVaultView() {
     // Net APY (stats.netApy is actually APR — convert for display)
     const apyEl = $("vault-apy");
     if (stats.netApy !== null) {
-      const vaultApy = aprToApy(stats.netApy);
-      apyEl.textContent = (vaultApy >= 0 ? "+" : "") + vaultApy.toFixed(2) + "%";
-      apyEl.className = "stat-value mono " + (vaultApy > 0 ? "hf-ok" : "hf-bad");
+      const baseApy = aprToApy(stats.netApy);
+      const harvestApy = stats.harvestApy ? stats.harvestApy * 100 : 0;
+      const totalApy = baseApy + harvestApy;
+
+      apyEl.textContent = (totalApy >= 0 ? "+" : "") + totalApy.toFixed(2) + "%";
+      apyEl.className = "stat-value mono " + (totalApy > 0 ? "hf-ok" : "hf-bad");
+
       const vaultTip = $("vault-apy-tip");
-      if (vaultTip) vaultTip.setAttribute("data-tip",
-        `Approximate APY — Blend interest does not auto-compound. Actual net APR: ${fmt(stats.netApy, 2)}%`);
+      if (vaultTip) {
+        let tip = `Base APY: ${baseApy.toFixed(2)}% (from interest/emissions)`;
+        if (harvestApy > 0) {
+          tip += `\nHarvest APY: +${harvestApy.toFixed(2)}% (30-day realized BLND swaps)`;
+        }
+        tip += `\nTotal: ${totalApy.toFixed(2)}%`;
+        vaultTip.setAttribute("data-tip", tip);
+      }
     } else {
       apyEl.textContent = "--";
       apyEl.className = "stat-value mono";


### PR DESCRIPTION
## Why

The `dev` branch accumulated four merged PRs that never reached `main`: #157 (harvest revenue in vault APY), #187 (trustline auto-setup), #216 (D6 partial-unwind liquidation protection), #217 (SEP-41 receipt token). This split made every new PR screened against `main` blind to dev's work — it enabled duplicate resubmissions of already-merged features (#230, #231, since closed).

## What

- Merges `origin/dev` into a `main`-based branch.
- Conflict resolutions (both "both sides added" cases):
  - `frontend/src/blend.ts`: kept main's A25 position-event timeline **and** dev's trustline helpers.
  - `frontend/src/main.ts`: combined dev's trustline-op bundling with main's `openHash` capture for the event timeline.
- Follow-up fix commit: `blend_leverage` did not compile on dev (no contract CI caught it) — added the missing `Symbol` import in `lib.rs` and the generated `Client`/`Args` imports in `receipt.rs`.

## Verification

- `cargo test` in `contracts/strategies/blend_leverage`: **45/45 pass**
- wasm release build: passes
- Frontend parity tests (`npm test`): **2/2 pass**
- Pre-existing, unrelated: `tests/leverage_sim` mainnet-fork tests fail identically on both main and dev (environment/fork snapshot issue)

## Follow-up fix included via stacked PR

`prependTrustlineOps` (from #187) bundled classic `changeTrust` ops into the Soroban deposit tx — invalid, since a Soroban tx must contain exactly one operation, breaking deposits for users missing trustlines. **Fixed in #240** (stacked on this branch): trustlines are now set up in a separate classic tx submitted before the deposit. Merge #240 into this branch before merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

