### PR TITLE
fix(frontend): trustline setup in separate classic tx (fixes broken deposit path)

### DIFF
--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -14,7 +14,6 @@ import {
   Operation,
   rpc as SorobanRpc,
   scValToNative,
-  Transaction,
   TransactionBuilder,
   xdr,
 } from "@stellar/stellar-sdk";
@@ -1524,57 +1523,42 @@ export async function getMissingTrustlines(
 }
 
 /**
- * Prepend changeTrust operations to an existing Soroban transaction XDR.
+ * Build a standalone classic transaction containing one changeTrust op per
+ * missing asset.
  *
- * When missingAssets is empty, returns the original XDR unchanged (no-op path).
- * Otherwise deserialises the XDR, prepends one changeTrust op per missing asset
- * with the Stellar maximum limit, appends the original Soroban ops, and returns
- * the rebuilt XDR ready for wallet signing.
+ * This MUST be a separate transaction from the Soroban deposit: the Stellar
+ * protocol requires any transaction containing a Soroban operation
+ * (invokeHostFunction) to contain exactly that one operation, so changeTrust
+ * ops cannot be bundled into the leverage-loop submit tx. The caller signs and
+ * submits this classic tx (via Horizon) BEFORE the Soroban deposit tx.
  *
- * @param submitXdr     Base64 XDR of the assembled Soroban transaction
- * @param missingAssets Classic assets that need trustlines
- * @param userAddress   Account address (used to reload sequence for rebuild)
- * @returns             New XDR string with changeTrust ops prepended, or original if empty
+ * Returns null when there are no missing trustlines (caller skips the step).
+ *
+ * @param missingAssets Classic assets that need a trustline
+ * @param userAddress   Source account G-address
+ * @returns             Base64 XDR of the classic changeTrust tx, or null if none needed
  */
-export async function prependTrustlineOps(
-  submitXdr: string,
+export async function buildTrustlineXdr(
   missingAssets: Asset[],
   userAddress: string,
-): Promise<string> {
-  // Fast path: nothing to do
-  if (missingAssets.length === 0) return submitXdr;
+): Promise<string | null> {
+  if (missingAssets.length === 0) return null;
 
   const MAX_TRUSTLINE_LIMIT = "922337203685.4775807"; // Stellar i64::MAX in stroops / 1e7
 
-  // Deserialise the existing Soroban transaction
-  const original = TransactionBuilder.fromXDR(submitXdr, _cfg.passphrase) as Transaction;
+  // Classic tx: load the source account from Horizon for a fresh sequence.
+  const account = await horizon.loadAccount(userAddress);
 
-  // Load current account sequence; decrement by 1 because TransactionBuilder
-  // auto-increments on build(), so we need to start one below the target sequence.
-  const accData = await server.getAccount(userAddress);
-  const adjustedAcc = new Account(
-    userAddress,
-    (BigInt(accData.sequenceNumber()) - 1n).toString(),
-  );
-
-  const builder = new TransactionBuilder(adjustedAcc, {
-    fee: original.fee,
+  const builder = new TransactionBuilder(account, {
+    fee: (BigInt(BASE_FEE) * BigInt(Math.max(1, missingAssets.length))).toString(),
     networkPassphrase: _cfg.passphrase,
-    memo: original.memo,
-    timebounds: original.timeBounds ?? undefined,
   });
 
-  // Prepend changeTrust ops for each missing trustline
   for (const asset of missingAssets) {
     builder.addOperation(
       Operation.changeTrust({ asset, limit: MAX_TRUSTLINE_LIMIT })
     );
   }
 
-  // Append all original Soroban operations unchanged
-  for (const op of original.operations) {
-    builder.addOperation(op);
-  }
-
-  return builder.build().toXDR();
+  return builder.setTimeout(180).build().toXDR();
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,7 +44,7 @@ import {
   submitSignedXdr,
   submitClassicXdr,
   getMissingTrustlines,
-  prependTrustlineOps,
+  buildTrustlineXdr,
   hfForLeverage,
   maxLeverageFor,
   getBlndPriceAssumption,
@@ -718,6 +718,25 @@ async function signAndSubmit(xdrStr: string, label: string, stepIndex?: number):
   });
   toast(`Submitting "${label}"\u2026`, "info");
   const hash = await submitSignedXdr(signedTxXdr);
+  if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
+  toast(`"${label}" confirmed!`, "success", hash);
+  addTxToHistory(label, hash, "success");
+  return hash;
+}
+
+/**
+ * Sign and submit a classic (non-Soroban) transaction via Horizon.
+ * Used for changeTrust setup, which cannot be bundled into a Soroban tx.
+ */
+async function signAndSubmitClassic(xdrStr: string, label: string, stepIndex?: number): Promise<string> {
+  if (stepIndex !== undefined) updateTxStep(stepIndex, "active");
+  toast(`Sign "${label}" in your wallet\u2026`, "info");
+  const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdrStr, {
+    networkPassphrase: getNetworkPassphrase(),
+    address: userAddress!,
+  });
+  toast(`Submitting "${label}"\u2026`, "info");
+  const hash = await submitClassicXdr(signedTxXdr);
   if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
   toast(`"${label}" confirmed!`, "success", hash);
   addTxToHistory(label, hash, "success");
@@ -1783,24 +1802,43 @@ async function openPosition() {
     return;
   }
 
+  // A Soroban transaction must contain exactly one operation, so missing
+  // trustlines are set up in a SEPARATE classic changeTrust tx submitted before
+  // the leverage-loop deposit. Steps shift accordingly.
   const hasMissingTrustlines = trustlineResult.missing.length > 0;
-  const submitLabel = hasMissingTrustlines
-    ? `Open ${liveAsset.symbol} leverage (+ trustlines)`
-    : `Open ${liveAsset.symbol} leverage`;
-  showTxStepper(["Approve", hasMissingTrustlines ? "Setup Trustlines + Submit" : "Submit"]);
+  const steps = hasMissingTrustlines ? ["Trustlines", "Approve", "Submit"] : ["Approve", "Submit"];
+  const trustStep = 0;
+  const approveStep = hasMissingTrustlines ? 1 : 0;
+  const submitStep = hasMissingTrustlines ? 2 : 1;
+  let activeStep = 0;
+  showTxStepper(steps);
 
   try {
+    if (hasMissingTrustlines) {
+      activeStep = trustStep;
+      const trustXdr = await buildTrustlineXdr(trustlineResult.missing, userAddress);
+      if (trustXdr) {
+        await signAndSubmitClassic(
+          trustXdr,
+          `Add ${trustlineResult.missing.length} trustline(s)`,
+          trustStep,
+        );
+      }
+    }
+
+    activeStep = approveStep;
     const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
-    await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, 0);
-    const rawSubmitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
-    const bundledXdr = await prependTrustlineOps(rawSubmitXdr, trustlineResult.missing, userAddress);
-    const openHash = await signAndSubmit(bundledXdr, submitLabel, 1);
+    await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, approveStep);
+
+    activeStep = submitStep;
+    const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
+    const openHash = await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, submitStep);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
     recordPositionEvent("open", openHash, hfForLeverage(leverage, liveAsset.cFactor, rs?.lFactor ?? 1));
     await loadAll();
   } catch (e: any) {
-    markStepperError(2);
+    markStepperError(activeStep);
     const msg: string = e?.message ?? "Transaction failed";
     if (msg.includes("#1205") || msg.includes("InvalidHf")) {
       toast("Health factor too low \u2014 reduce leverage.", "error");


### PR DESCRIPTION
Stacked on #239 (targets `merge/dev-into-main` so it merges into the dev integration, not main directly).

## The bug
`prependTrustlineOps` (introduced by #187, surfaced during the 2026-06 triage) prepends classic `changeTrust` ops onto the leverage-loop `invokeHostFunction` transaction. The Stellar protocol requires any transaction containing a Soroban operation to contain **exactly that one operation**, so the bundled tx is rejected by the network whenever the depositor is missing trustlines — i.e. the deposit money path is broken for every first-time depositor.

## The fix
- `blend.ts`: replace `prependTrustlineOps` with `buildTrustlineXdr`, which builds a **standalone classic** `changeTrust` transaction (fresh Horizon sequence, fee scaled by op count). Returns `null` when no trustlines are missing.
- `main.ts`: `openPosition` submits the trustline tx via Horizon (new `signAndSubmitClassic`) **before** the approve + Soroban deposit txs. Stepper becomes `[Trustlines, Approve, Submit]` when trustlines are needed, `[Approve, Submit]` otherwise. Error marking now targets the active step instead of a hardcoded index.
- Removed the now-unused `Transaction` import.

## Verification
- `npm run build`: passes
- `npm test` (parity): 2/2 pass
- Pre-existing unrelated tsc errors (`.ts` import extensions, `import.meta.env`, push-subscription overload) are unchanged — present on main too.

Once this is in, the 'known issue carried over' note in #239 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)