### PR TITLE
ci: Dependabot + cargo-audit + rustls-webpki patch (SCF T1 D5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot keeps dependencies current across the four surfaces of the monorepo.
+# Weekly cadence; minor/patch grouped to keep PR noise down, majors separate.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  # Frontend (Vite/TS) — npm manifest in frontend/
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(frontend)"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Alerts worker (Cloudflare Workers/TS) — npm manifest in alerts/
+  - package-ecosystem: "npm"
+    directory: "/alerts"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(alerts)"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Rust simulator / scripts crate at the repo root (over_leveraging)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(sim)"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Soroban strategy contract crate
+  # NOTE: soroban-sdk is pinned to a git branch (snapshot-source-tx) and is not
+  # version-managed by Dependabot; crates.io deps here still get bumped.
+  - package-ecosystem: "cargo"
+    directory: "/contracts/strategies/blend_leverage"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(contracts)"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,45 @@
+name: Cargo Audit
+
+# Scans both Rust crates (root simulator + the Soroban strategy contract) for
+# RustSec advisories. Runs on Cargo manifest/lock changes and weekly on a cron
+# so newly published advisories are caught even without a code change.
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/cargo-audit.yml"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/cargo-audit.yml"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - "."
+          - "contracts/strategies/blend_leverage"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit ${{ matrix.crate }}
+        working-directory: ${{ matrix.crate }}
+        # Ignored advisories (if any) are tracked in audit.toml next to each
+        # crate; an empty/missing audit.toml means "fail on any advisory".
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Part of **SCF #43 Tranche 1, Deliverable 5** — Foundational CI / supply-chain hygiene. First of three focused PRs for D5 (this one is additive + a security patch; clippy-enforcement and frontend-lint follow separately).

## What
- **`.github/dependabot.yml`** — weekly updates across the monorepo: github-actions, npm (`frontend/`, `alerts/`), cargo (root sim crate + `contracts/strategies/blend_leverage`). Minor/patch grouped.
- **`.github/workflows/cargo-audit.yml`** — RustSec scan of both crates on Cargo manifest/lock changes, a weekly cron, and manual dispatch.
- **`Cargo.lock`** — bump `rustls-webpki` 0.103.9 → 0.103.13, clearing **4 real TLS advisories** (RUSTSEC-2026-0049/0098/0099/0104) pulled in transitively via `reqwest`.

## Notes
- Remaining advisories (`paste`, `derivative` unmaintained; `rand` unsound RUSTSEC-2026-0097) are transitive via the git-pinned `soroban-sdk` and the sim deps, have no fixed versions, and `cargo audit` treats them as non-failing warnings. No `audit.toml` ignore-list needed today; if any becomes a hard error later it'll be ignored-with-rationale.
- The contract crate already had zero vulnerabilities (warnings only).

## Verification
- `cargo audit` exits 0 in both `/` and `contracts/strategies/blend_leverage`.
- `cargo build --bin rate_calc` succeeds.

Maps to grant success criteria: "Dependabot opening weekly PRs; cargo-audit passing." (Gitleaks-blocks-planted-secret demo + CI-green tracked in the sibling D5 PRs.)