### PR TITLE
ci(contracts): enforce clippy + rustfmt (SCF T1 D5)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -23,14 +23,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32v1-none
+          components: rustfmt, clippy
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: contracts/strategies/blend_leverage
 
-      # TODO: add `cargo clippy --all-targets -- -D warnings` once the
-      # existing lint debt in the crate (digit grouping etc.) is paid down.
+      - name: Rustfmt
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Test
         run: cargo test
 

--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -36,10 +36,7 @@ pub fn submit_leverage_loop(
 
     // Get pre-loop positions
     let pre_positions = pool_client.get_positions(&strategy);
-    let pre_b = pre_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let pre_b = pre_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let pre_d = pre_positions
         .liabilities
         .get(config.reserve_id)
@@ -96,17 +93,19 @@ pub fn submit_leverage_loop(
             sub_invocations: vec![e],
         }),
     ]);
-    token_client.approve(&strategy, &config.pool, &total_supply, &(e.ledger().sequence() + 1));
+    token_client.approve(
+        &strategy,
+        &config.pool,
+        &total_supply,
+        &(e.ledger().sequence() + 1),
+    );
 
     // Single atomic submit using allowance-based transfers
     pool_client.submit_with_allowance(&strategy, &strategy, &strategy, &requests);
 
     // Read final positions
     let new_positions = pool_client.get_positions(&strategy);
-    let new_b = new_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let new_b = new_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let new_d = new_positions
         .liabilities
         .get(config.reserve_id)
@@ -146,10 +145,7 @@ pub fn submit_unwind(
     let strategy = e.current_contract_address();
 
     let pre_positions = pool_client.get_positions(&strategy);
-    let pre_b = pre_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let pre_b = pre_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let pre_d = pre_positions
         .liabilities
         .get(config.reserve_id)
@@ -246,7 +242,12 @@ pub fn submit_unwind(
                 sub_invocations: vec![e],
             }),
         ]);
-        token_client_inner.approve(&strategy, &config.pool, &total_repay, &(e.ledger().sequence() + 1));
+        token_client_inner.approve(
+            &strategy,
+            &config.pool,
+            &total_repay,
+            &(e.ledger().sequence() + 1),
+        );
     }
 
     // Single atomic submit using allowance-based transfers
@@ -265,12 +266,7 @@ pub fn submit_unwind(
                 context: ContractContext {
                     contract: config.asset.clone(),
                     fn_name: Symbol::new(e, "transfer"),
-                    args: (
-                        strategy.clone(),
-                        to.clone(),
-                        equity,
-                    )
-                        .into_val(e),
+                    args: (strategy.clone(), to.clone(), equity).into_val(e),
                 },
                 sub_invocations: vec![e],
             }),
@@ -280,17 +276,18 @@ pub fn submit_unwind(
 
     // Read final positions for return
     let end_positions = pool_client.get_positions(&strategy);
-    let end_b = end_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let end_b = end_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let end_d = end_positions
         .liabilities
         .get(config.reserve_id)
         .unwrap_or(0);
 
-    let b_removed = pre_b.checked_sub(end_b).ok_or(StrategyError::UnderflowOverflow)?;
-    let d_removed = pre_d.checked_sub(end_d).ok_or(StrategyError::UnderflowOverflow)?;
+    let b_removed = pre_b
+        .checked_sub(end_b)
+        .ok_or(StrategyError::UnderflowOverflow)?;
+    let d_removed = pre_d
+        .checked_sub(end_d)
+        .ok_or(StrategyError::UnderflowOverflow)?;
 
     Ok((b_removed, d_removed))
 }
@@ -307,10 +304,7 @@ pub fn submit_deleverage(
     let strategy = e.current_contract_address();
 
     let pre_positions = pool_client.get_positions(&strategy);
-    let pre_b = pre_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let pre_b = pre_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let pre_d = pre_positions
         .liabilities
         .get(config.reserve_id)
@@ -342,7 +336,7 @@ pub fn submit_deleverage(
 
     for i in 0..loops_to_unwind {
         let idx = n_layers - 1 - i;
-        let layer_amount = layers.get(idx as u32).unwrap_or(0);
+        let layer_amount = layers.get(idx).unwrap_or(0);
         if layer_amount == 0 {
             continue;
         }
@@ -379,7 +373,12 @@ pub fn submit_deleverage(
                 sub_invocations: vec![e],
             }),
         ]);
-        token_client.approve(&strategy, &config.pool, &total_repay, &(e.ledger().sequence() + 1));
+        token_client.approve(
+            &strategy,
+            &config.pool,
+            &total_repay,
+            &(e.ledger().sequence() + 1),
+        );
     }
 
     if !requests.is_empty() {
@@ -387,10 +386,7 @@ pub fn submit_deleverage(
     }
 
     let new_positions = pool_client.get_positions(&strategy);
-    let new_b = new_positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let new_b = new_positions.collateral.get(config.reserve_id).unwrap_or(0);
     let new_d = new_positions
         .liabilities
         .get(config.reserve_id)
@@ -498,14 +494,8 @@ pub fn get_strategy_positions(e: &Env, config: &Config) -> (i128, i128) {
     let pool_client = BlendPoolClient::new(e, &config.pool);
     let positions = pool_client.get_positions(&e.current_contract_address());
 
-    let b_tokens = positions
-        .collateral
-        .get(config.reserve_id)
-        .unwrap_or(0);
-    let d_tokens = positions
-        .liabilities
-        .get(config.reserve_id)
-        .unwrap_or(0);
+    let b_tokens = positions.collateral.get(config.reserve_id).unwrap_or(0);
+    let d_tokens = positions.liabilities.get(config.reserve_id).unwrap_or(0);
 
     (b_tokens, d_tokens)
 }

--- a/contracts/strategies/blend_leverage/src/leverage.rs
+++ b/contracts/strategies/blend_leverage/src/leverage.rs
@@ -66,11 +66,7 @@ pub fn compute_loop_pairs(
 }
 
 /// Compute total supply and total borrow from the loop.
-pub fn compute_totals(
-    initial_amount: i128,
-    c_factor: i128,
-    n_loops: u32,
-) -> (i128, i128) {
+pub fn compute_totals(initial_amount: i128, c_factor: i128, n_loops: u32) -> (i128, i128) {
     let count = loop_step_count(n_loops);
     let mut total_supply = 0i128;
     let mut total_borrow = 0i128;
@@ -187,6 +183,7 @@ pub fn compute_health_factor(
 /// - Pool utilization must be below MAX_SAFE_UTILIZATION
 /// - Projected utilization after the loop must be below MAX_SAFE_UTILIZATION
 /// - Post-loop HF must be above min_hf
+#[allow(clippy::too_many_arguments)] // safety check legitimately needs the full pool + position context
 pub fn check_deposit_safety(
     e: &Env,
     pool_supply_underlying: i128,
@@ -331,5 +328,5 @@ pub fn compute_partial_unwind(
     }
 
     let loops = ((repay_underlying + layer_size - 1) / layer_size) as u32;
-    Ok((repay_underlying, loops.max(1).min(20)))
+    Ok((repay_underlying, loops.clamp(1, 20)))
 }

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -1,4 +1,13 @@
 #![no_std]
+// Cosmetic only: many 1e7/1e12-scaled financial literals use intentional
+// non-uniform underscore grouping for readability (e.g. 10_500_000 = 1.05).
+// Rewriting 100+ numeric constants risks a value typo in a fund-holding
+// contract, so this purely-stylistic lint is allowed crate-wide.
+#![allow(clippy::inconsistent_digit_grouping)]
+// TODO(events): migrate `e.events().publish(...)` to the #[contractevent]
+// macro alongside the SEP-41 receipt-token event rework (SCF T1 D2), then
+// drop this allow.
+#![allow(deprecated)]
 
 mod blend_pool;
 mod constants;
@@ -9,9 +18,9 @@ mod soroswap;
 mod storage;
 
 #[cfg(test)]
-mod test_leverage;
-#[cfg(test)]
 mod test_integration;
+#[cfg(test)]
+mod test_leverage;
 
 use constants::SCALAR_12;
 pub use defindex_strategy_core::{event, DeFindexStrategyTrait, StrategyError};
@@ -57,38 +66,20 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
             .get(0)
             .expect("Missing: pool address")
             .into_val(&e);
-        let blend_token: Address = init_args
-            .get(1)
-            .expect("Missing: blend_token")
-            .into_val(&e);
-        let router: Address = init_args
-            .get(2)
-            .expect("Missing: router")
-            .into_val(&e);
+        let blend_token: Address = init_args.get(1).expect("Missing: blend_token").into_val(&e);
+        let router: Address = init_args.get(2).expect("Missing: router").into_val(&e);
         let reward_threshold: i128 = init_args
             .get(3)
             .expect("Missing: reward_threshold")
             .into_val(&e);
-        let keeper: Address = init_args
-            .get(4)
-            .expect("Missing: keeper")
-            .into_val(&e);
-        let c_factor: i128 = init_args
-            .get(5)
-            .expect("Missing: c_factor")
-            .into_val(&e);
+        let keeper: Address = init_args.get(4).expect("Missing: keeper").into_val(&e);
+        let c_factor: i128 = init_args.get(5).expect("Missing: c_factor").into_val(&e);
         let target_loops: u32 = init_args
             .get(6)
             .expect("Missing: target_loops")
             .into_val(&e);
-        let min_hf: i128 = init_args
-            .get(7)
-            .expect("Missing: min_hf")
-            .into_val(&e);
-        let orange_hf: i128 = init_args
-            .get(8)
-            .expect("Missing: orange_hf")
-            .into_val(&e);
+        let min_hf: i128 = init_args.get(7).expect("Missing: min_hf").into_val(&e);
+        let orange_hf: i128 = init_args.get(8).expect("Missing: orange_hf").into_val(&e);
 
         // Look up the reserve index from the pool
         let pool_client = blend_contract_sdk::pool::Client::new(&e, &pool);
@@ -96,10 +87,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
         let reserve_id = reserve.config.index;
 
         // Claim IDs: supply side = index*2+1, borrow side = index*2
-        let claim_ids: Vec<u32> = Vec::from_array(
-            &e,
-            [reserve_id * 2 + 1, reserve_id * 2],
-        );
+        let claim_ids: Vec<u32> = Vec::from_array(&e, [reserve_id * 2 + 1, reserve_id * 2]);
 
         check_positive_amount(reward_threshold).expect("reward_threshold must be positive");
 
@@ -143,8 +131,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
         // Safety: check pool utilization before depositing
         let (pool_supply, pool_borrow) = blend_pool::get_pool_utilization(&e, &config);
-        let (add_supply, add_borrow) =
-            compute_totals(amount, config.c_factor, config.target_loops);
+        let (add_supply, add_borrow) = compute_totals(amount, config.c_factor, config.target_loops);
 
         // Compute projected position for HF check
         let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
@@ -184,7 +171,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
         // Transfer the initial deposit from user to strategy contract
         let token_client = TokenClient::new(&e, &config.asset);
-        token_client.transfer(&from, &e.current_contract_address(), &amount);
+        token_client.transfer(&from, e.current_contract_address(), &amount);
 
         // Execute the leverage loop — contract sends `amount` to pool,
         // pool processes supply+borrow atomically, netting means only `amount` leaves
@@ -196,12 +183,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
         let underlying_balance = shares_to_underlying(vault_shares, &updated_reserves)?;
 
-        event::emit_deposit(
-            &e,
-            String::from_str(&e, STRATEGY_NAME),
-            amount,
-            from,
-        );
+        event::emit_deposit(&e, String::from_str(&e, STRATEGY_NAME), amount, from);
 
         Ok(underlying_balance)
     }
@@ -237,7 +219,8 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
         };
 
         // Swap BLND → underlying, then re-leverage
-        let (b_delta, d_delta, realized_underlying) = blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
+        let (b_delta, d_delta, realized_underlying) =
+            blend_pool::perform_reinvest(&e, &config, amount_out_min)?;
 
         // Update reserves without minting shares (yield accrues to existing holders)
         if b_delta > 0 {
@@ -252,7 +235,10 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
             // Emit custom event for realized underlying
             e.events().publish(
-                (Symbol::new(&e, "harvest_realized"), String::from_str(&e, STRATEGY_NAME)),
+                (
+                    Symbol::new(&e, "harvest_realized"),
+                    String::from_str(&e, STRATEGY_NAME),
+                ),
                 realized_underlying,
             );
         }
@@ -284,12 +270,7 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
 
         let underlying_balance = shares_to_underlying(remaining_shares, &updated_reserves)?;
 
-        event::emit_withdraw(
-            &e,
-            String::from_str(&e, STRATEGY_NAME),
-            amount,
-            from,
-        );
+        event::emit_withdraw(&e, String::from_str(&e, STRATEGY_NAME), amount, from);
 
         Ok(underlying_balance)
     }
@@ -337,15 +318,19 @@ impl BlendLeverageStrategy {
 
         // Use orange_hf as target so we restore to the safe zone, not just min_hf
         let (_, unwind_loops) = compute_partial_unwind(
-            b_tokens, d_tokens, b_rate, d_rate, config.c_factor, config.orange_hf,
+            b_tokens,
+            d_tokens,
+            b_rate,
+            d_rate,
+            config.c_factor,
+            config.orange_hf,
         )?;
 
         if unwind_loops == 0 {
             return Ok(());
         }
 
-        let (b_removed, d_removed) =
-            blend_pool::submit_deleverage(&e, unwind_loops, &config)?;
+        let (b_removed, d_removed) = blend_pool::submit_deleverage(&e, unwind_loops, &config)?;
 
         reserves::deleverage(&e, b_removed, d_removed, &config)?;
 
@@ -383,15 +368,19 @@ impl BlendLeverageStrategy {
         let effective_target = target_hf.max(config.orange_hf);
 
         let (_, loops) = compute_partial_unwind(
-            b_tokens, d_tokens, b_rate, d_rate, config.c_factor, effective_target,
+            b_tokens,
+            d_tokens,
+            b_rate,
+            d_rate,
+            config.c_factor,
+            effective_target,
         )?;
 
         if loops == 0 {
             return Ok(0);
         }
 
-        let (b_removed, d_removed) =
-            blend_pool::submit_deleverage(&e, loops, &config)?;
+        let (b_removed, d_removed) = blend_pool::submit_deleverage(&e, loops, &config)?;
 
         reserves::deleverage(&e, b_removed, d_removed, &config)?;
 

--- a/contracts/strategies/blend_leverage/src/receipt.rs
+++ b/contracts/strategies/blend_leverage/src/receipt.rs
@@ -67,18 +67,20 @@ impl BlendLeverageStrategy {
         storage::set_vault_shares(
             &e,
             &from,
-            from_shares.checked_sub(amount).ok_or(StrategyError::UnderflowOverflow)?,
+            from_shares
+                .checked_sub(amount)
+                .ok_or(StrategyError::UnderflowOverflow)?,
         );
         storage::set_vault_shares(
             &e,
             &to,
-            to_shares.checked_add(amount).ok_or(StrategyError::UnderflowOverflow)?,
+            to_shares
+                .checked_add(amount)
+                .ok_or(StrategyError::UnderflowOverflow)?,
         );
 
-        e.events().publish(
-            (symbol_short!("transfer"), from, to),
-            amount,
-        );
+        e.events()
+            .publish((symbol_short!("transfer"), from, to), amount);
 
         Ok(())
     }

--- a/contracts/strategies/blend_leverage/src/soroswap.rs
+++ b/contracts/strategies/blend_leverage/src/soroswap.rs
@@ -54,12 +54,7 @@ pub fn internal_swap_exact_tokens_for_tokens(
                     }
                 },
                 fn_name: Symbol::new(e, "transfer"),
-                args: (
-                    e.current_contract_address(),
-                    pair_address,
-                    amount_in.clone(),
-                )
-                    .into_val(e),
+                args: (e.current_contract_address(), pair_address, *amount_in).into_val(e),
             },
             sub_invocations: vec![e],
         }),

--- a/contracts/strategies/blend_leverage/src/storage.rs
+++ b/contracts/strategies/blend_leverage/src/storage.rs
@@ -65,7 +65,7 @@ pub fn get_config(e: &Env) -> Config {
 // ── Leverage reserves (strategy-level accounting) ────────────────────────────
 
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct LeverageReserves {
     /// Total shares outstanding across all depositors
     pub total_shares: i128,
@@ -79,22 +79,8 @@ pub struct LeverageReserves {
     pub d_rate: i128,
 }
 
-impl Default for LeverageReserves {
-    fn default() -> Self {
-        Self {
-            total_shares: 0,
-            total_b_tokens: 0,
-            total_d_tokens: 0,
-            b_rate: 0,
-            d_rate: 0,
-        }
-    }
-}
-
 pub fn set_strategy_reserves(e: &Env, reserves: LeverageReserves) {
-    e.storage()
-        .persistent()
-        .set(&DataKey::Reserves, &reserves);
+    e.storage().persistent().set(&DataKey::Reserves, &reserves);
     e.storage().persistent().extend_ttl(
         &DataKey::Reserves,
         PERSISTENT_LIFETIME_THRESHOLD,
@@ -114,9 +100,11 @@ pub fn get_strategy_reserves(e: &Env) -> LeverageReserves {
 pub fn set_vault_shares(e: &Env, address: &Address, shares: i128) {
     let key = DataKey::VaultPos(address.clone());
     e.storage().persistent().set(&key, &shares);
-    e.storage()
-        .persistent()
-        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    e.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 }
 
 pub fn get_vault_shares(e: &Env, address: &Address) -> i128 {
@@ -135,9 +123,7 @@ pub fn get_vault_shares(e: &Env, address: &Address) -> i128 {
 // ── Keeper ───────────────────────────────────────────────────────────────────
 
 pub fn set_keeper(e: &Env, keeper: &Address) {
-    e.storage()
-        .persistent()
-        .set(&DataKey::Keeper, keeper);
+    e.storage().persistent().set(&DataKey::Keeper, keeper);
     e.storage().persistent().extend_ttl(
         &DataKey::Keeper,
         PERSISTENT_LIFETIME_THRESHOLD,

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -27,9 +27,7 @@ use crate::constants::{
     REQUEST_TYPE_BORROW, REQUEST_TYPE_REPAY, REQUEST_TYPE_SUPPLY_COLLATERAL,
     REQUEST_TYPE_WITHDRAW_COLLATERAL, SCALAR_12, SCALAR_7,
 };
-use crate::leverage::{
-    compute_health_factor, compute_loop_pairs, shares_to_underlying,
-};
+use crate::leverage::{compute_health_factor, compute_loop_pairs, shares_to_underlying};
 use crate::storage::LeverageReserves;
 use crate::{blend_pool, reserves, storage};
 
@@ -106,7 +104,7 @@ fn setup_blend_env(e: &Env) -> (Address, Address, Address, BlendFixture<'_>, Add
         &String::from_str(e, "test_leverage_pool"),
         &BytesN::<32>::random(e),
         &oracle,
-        &0_1000000,
+        &1_000_000,
         &4,
         &0,
     );
@@ -158,21 +156,19 @@ fn seed_pool_liquidity(e: &Env, pool_addr: &Address, token: &Address, amount: i1
         .mock_all_auths()
         .mint(&whale, &amount);
 
-    pool::Client::new(e, pool_addr)
-        .mock_all_auths()
-        .submit(
-            &whale,
-            &whale,
-            &whale,
-            &vec![
-                e,
-                pool::Request {
-                    address: token.clone(),
-                    amount,
-                    request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
-                },
-            ],
-        );
+    pool::Client::new(e, pool_addr).mock_all_auths().submit(
+        &whale,
+        &whale,
+        &whale,
+        &vec![
+            e,
+            pool::Request {
+                address: token.clone(),
+                amount,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
 }
 
 /// Execute a leverage loop step-by-step: supply→borrow in separate pool.submit() calls.
@@ -211,12 +207,9 @@ fn execute_leverage_loop_stepped(
             });
         }
 
-        pool_client.mock_all_auths().submit(
-            strategy,
-            strategy,
-            strategy,
-            &requests,
-        );
+        pool_client
+            .mock_all_auths()
+            .submit(strategy, strategy, strategy, &requests);
     }
 
     // Read final positions
@@ -317,7 +310,11 @@ fn test_simple_supply_and_borrow() {
 
     let positions = pool_client.get_positions(&strategy);
     let b_tokens = positions.collateral.get(0).unwrap_or(0);
-    assert!(b_tokens > 0, "Should have b-tokens after supply: {}", b_tokens);
+    assert!(
+        b_tokens > 0,
+        "Should have b-tokens after supply: {}",
+        b_tokens
+    );
 
     // Borrow 900 (c=0.90, below pool's c=0.95 to keep HF > 1.0)
     pool_client.mock_all_auths().submit(
@@ -336,7 +333,11 @@ fn test_simple_supply_and_borrow() {
 
     let positions = pool_client.get_positions(&strategy);
     let d_tokens = positions.liabilities.get(0).unwrap_or(0);
-    assert!(d_tokens > 0, "Should have d-tokens after borrow: {}", d_tokens);
+    assert!(
+        d_tokens > 0,
+        "Should have d-tokens after borrow: {}",
+        d_tokens
+    );
 
     // Strategy should have received borrow proceeds
     let token_client = TokenClient::new(&e, &token);
@@ -461,15 +462,7 @@ fn test_deposit_withdraw_full_cycle() {
     });
 
     // Execute the actual unwind on pool
-    execute_unwind(
-        &e,
-        &pool_addr,
-        &strategy,
-        &user,
-        &token,
-        b_tokens,
-        d_tokens,
-    );
+    execute_unwind(&e, &pool_addr, &strategy, &user, &token, b_tokens, d_tokens);
 
     // User received full withdrawal (b_tokens underlying value).
     // The net equity = withdrawal - repay = b_tokens_value - d_tokens_value ≈ deposit_amount.
@@ -511,9 +504,7 @@ fn test_two_users_proportional() {
 
     // Alice deposits 1000
     let alice_amount = 1_000_0000000_i128;
-    token_admin
-        .mock_all_auths()
-        .mint(&strategy, &alice_amount);
+    token_admin.mock_all_auths().mint(&strategy, &alice_amount);
 
     let (b1, d1) = execute_leverage_loop_stepped(
         &e,
@@ -562,10 +553,8 @@ fn test_two_users_proportional() {
         };
         storage::set_strategy_reserves(&e, init.clone());
 
-        let (alice_shares, after_alice) =
-            reserves::deposit(&e, &alice, b1, d1, &init).unwrap();
-        let (bob_shares, after_bob) =
-            reserves::deposit(&e, &bob, b2, d2, &after_alice).unwrap();
+        let (alice_shares, after_alice) = reserves::deposit(&e, &alice, b1, d1, &init).unwrap();
+        let (bob_shares, after_bob) = reserves::deposit(&e, &bob, b2, d2, &after_alice).unwrap();
 
         let alice_val = shares_to_underlying(alice_shares, &after_bob).unwrap();
         let bob_val = shares_to_underlying(bob_shares, &after_bob).unwrap();
@@ -619,11 +608,7 @@ fn test_health_factor_from_pool() {
         config.min_hf
     );
     // HF should be reasonable (not astronomical)
-    assert!(
-        hf < 100 * SCALAR_7,
-        "HF {} seems too high",
-        hf
-    );
+    assert!(hf < 100 * SCALAR_7, "HF {} seems too high", hf);
 }
 
 #[test]
@@ -635,16 +620,8 @@ fn test_pool_rates_query() {
     e.cost_estimate().budget().reset_unlimited();
 
     let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
-    assert!(
-        b_rate >= SCALAR_12,
-        "b_rate should be >= 1.0: {}",
-        b_rate
-    );
-    assert!(
-        d_rate >= SCALAR_12,
-        "d_rate should be >= 1.0: {}",
-        d_rate
-    );
+    assert!(b_rate >= SCALAR_12, "b_rate should be >= 1.0: {}", b_rate);
+    assert!(d_rate >= SCALAR_12, "d_rate should be >= 1.0: {}", d_rate);
 }
 
 #[test]

--- a/contracts/strategies/blend_leverage/src/test_leverage.rs
+++ b/contracts/strategies/blend_leverage/src/test_leverage.rs
@@ -93,8 +93,12 @@ fn test_totals_leverage_ratio() {
 
     let leverage_x100 = total_supply * 100 / initial;
     // Leverage should be between 7 and 9
-    assert!(leverage_x100 > 700 && leverage_x100 < 900,
-        "Leverage {}.{} out of expected range", leverage_x100 / 100, leverage_x100 % 100);
+    assert!(
+        leverage_x100 > 700 && leverage_x100 < 900,
+        "Leverage {}.{} out of expected range",
+        leverage_x100 / 100,
+        leverage_x100 % 100
+    );
 
     // Borrow should be supply - initial (equity)
     assert_eq!(total_supply - total_borrow, initial);
@@ -106,8 +110,12 @@ fn test_totals_net_equals_initial() {
     for n in 0..15 {
         let initial = 1_000_0000000_i128;
         let (total_supply, total_borrow) = compute_totals(initial, 9_500_000, n);
-        assert_eq!(total_supply - total_borrow, initial,
-            "Net supply != initial at {} loops", n);
+        assert_eq!(
+            total_supply - total_borrow,
+            initial,
+            "Net supply != initial at {} loops",
+            n
+        );
     }
 }
 
@@ -222,7 +230,10 @@ fn test_underlying_to_shares_first_deposit() {
         d_rate: SCALAR_12,
     };
     // First deposit: 1 share = 1 unit
-    assert_eq!(underlying_to_shares(1_000_0000000, &reserves).unwrap(), 1_000_0000000);
+    assert_eq!(
+        underlying_to_shares(1_000_0000000, &reserves).unwrap(),
+        1_000_0000000
+    );
 }
 
 #[test]
@@ -255,8 +266,12 @@ fn test_shares_roundtrip() {
     let shares = underlying_to_shares(equity, &reserves).unwrap();
     let recovered = shares_to_underlying(shares, &reserves).unwrap();
     // Allow 1 stroop rounding
-    assert!((recovered - equity).abs() <= 1,
-        "Roundtrip error: equity={}, recovered={}", equity, recovered);
+    assert!(
+        (recovered - equity).abs() <= 1,
+        "Roundtrip error: equity={}, recovered={}",
+        equity,
+        recovered
+    );
 }
 
 // ── compute_health_factor ────────────────────────────────────────────────────
@@ -277,7 +292,8 @@ fn test_hf_equal_rates() {
         SCALAR_12,
         SCALAR_12,
         9_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     // HF = supply_value * c_factor / debt_value = 2000 * 9500000 / 1000 = 19_000_000
     assert_eq!(hf, 19_000_000);
 }
@@ -292,7 +308,8 @@ fn test_hf_near_liquidation() {
         SCALAR_12,
         SCALAR_12,
         9_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     // 8000 * 9500000 / 7000 = 76000000000000000 / 7000_0000000 = 10_857_142
     assert_eq!(hf, 10_857_142);
     assert!(hf > SCALAR_7); // HF > 1.0
@@ -307,7 +324,8 @@ fn test_hf_below_one() {
         SCALAR_12,
         SCALAR_12,
         9_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(hf, 9_500_000);
     assert!(hf < SCALAR_7); // HF < 1.0 → liquidatable
 }
@@ -324,7 +342,8 @@ fn test_partial_unwind_already_at_target_returns_zero() {
         SCALAR_12,
         9_500_000,
         11_500_000, // target_hf = 1.15
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(repay, 0);
     assert_eq!(loops, 0);
 }
@@ -338,7 +357,8 @@ fn test_partial_unwind_no_debt_returns_zero() {
         SCALAR_12,
         9_500_000,
         11_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(repay, 0);
     assert_eq!(loops, 0);
 }
@@ -354,7 +374,8 @@ fn test_partial_unwind_single_loop_position() {
         SCALAR_12,
         9_500_000,
         11_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(repay, 0);
     assert_eq!(loops, 0);
 
@@ -366,7 +387,8 @@ fn test_partial_unwind_single_loop_position() {
         SCALAR_12,
         9_500_000,
         11_500_000,
-    ).unwrap();
+    )
+    .unwrap();
     assert!(repay2 > 0, "Should need repayment");
     assert!(loops2 >= 1, "Should need at least 1 loop");
 
@@ -378,7 +400,11 @@ fn test_partial_unwind_single_loop_position() {
     let new_d = 1_000_0000000 - x;
     if new_d > 0 {
         let hf_new = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
-        assert!(hf_new >= 11_500_000, "HF after unwind={} should be >= target 1.15", hf_new);
+        assert!(
+            hf_new >= 11_500_000,
+            "HF after unwind={} should be >= target 1.15",
+            hf_new
+        );
     }
 }
 
@@ -393,16 +419,21 @@ fn test_partial_unwind_max_loops_position() {
         SCALAR_12,
         9_500_000,
         11_500_000, // target = 1.15
-    ).unwrap();
+    )
+    .unwrap();
     assert!(repay > 0);
-    assert!(loops >= 1 && loops <= 20, "loops={} out of range", loops);
+    assert!((1..=20).contains(&loops), "loops={} out of range", loops);
 
     // Verify restoration
     let new_b = 20_000_0000000 - repay;
     let new_d = 19_000_0000000 - repay;
     if new_d > 0 {
         let hf_new = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
-        assert!(hf_new >= 11_500_000, "HF after unwind={} should be >= 1.15", hf_new);
+        assert!(
+            hf_new >= 11_500_000,
+            "HF after unwind={} should be >= 1.15",
+            hf_new
+        );
     }
 }
 
@@ -418,15 +449,20 @@ fn test_partial_unwind_minimal_repay_is_exact() {
         SCALAR_12,
         9_500_000,
         11_500_000,
-    ).unwrap();
+    )
+    .unwrap();
 
     // Repaying 1 less stroop should leave HF below target
     if repay > 1 {
         let x_minus = repay - 2;
         let new_b = 10_500_0000000 - x_minus;
         let new_d = 9_500_0000000 - x_minus;
-        let hf_short = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
-        assert!(hf_short < 11_500_000, "Repaying less should leave HF below target");
+        let hf_short =
+            compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
+        assert!(
+            hf_short < 11_500_000,
+            "Repaying less should leave HF below target"
+        );
     }
 
     // Repaying the computed amount should reach target
@@ -434,7 +470,11 @@ fn test_partial_unwind_minimal_repay_is_exact() {
     let new_d = 9_500_0000000 - repay;
     if new_d > 0 {
         let hf_ok = compute_health_factor(new_b, new_d, SCALAR_12, SCALAR_12, 9_500_000).unwrap();
-        assert!(hf_ok >= 11_500_000, "HF after exact repay={} should be >= target", hf_ok);
+        assert!(
+            hf_ok >= 11_500_000,
+            "HF after exact repay={} should be >= target",
+            hf_ok
+        );
     }
 }
 
@@ -458,10 +498,16 @@ fn test_leverage_table_matches_simulator() {
 
         // Allow 1‰ tolerance for integer rounding
         let diff = (our_lev_x1000 - expected_x1000).abs();
-        assert!(diff <= 1,
+        assert!(
+            diff <= 1,
             "Loop {}: our={}.{:03}x, expected={}.{:03}x (diff={})",
-            n, our_lev_x1000/1000, our_lev_x1000%1000,
-            expected_x1000/1000, expected_x1000%1000, diff);
+            n,
+            our_lev_x1000 / 1000,
+            our_lev_x1000 % 1000,
+            expected_x1000 / 1000,
+            expected_x1000 % 1000,
+            diff
+        );
     }
 }
 
@@ -513,7 +559,8 @@ fn test_deposit_first_depositor() {
         // Simulating: b_delta = 8000 (leverage 8x), d_delta = 7000, equity = 1000
         let b_delta = 8_000_0000000_i128;
         let d_delta = 7_000_0000000_i128;
-        let (vault_shares, updated) = reserves::deposit(e, &user, b_delta, d_delta, &init_reserves).unwrap();
+        let (vault_shares, updated) =
+            reserves::deposit(e, &user, b_delta, d_delta, &init_reserves).unwrap();
 
         // Equity added = 8000 - 7000 = 1000 (since rates = 1.0)
         // First deposit: new_shares = 1000, vault_minted = 1000 - 1000(lockup) = 999.9999
@@ -534,12 +581,12 @@ fn test_deposit_second_depositor() {
         // First deposit
         let init = make_reserves(0, 0, 0);
         storage::set_strategy_reserves(e, init.clone());
-        let (_, after_first) = reserves::deposit(e, &user1, 8_000_0000000, 7_000_0000000, &init).unwrap();
+        let (_, after_first) =
+            reserves::deposit(e, &user1, 8_000_0000000, 7_000_0000000, &init).unwrap();
 
         // Second deposit: same equity (1000)
-        let (user2_shares, after_second) = reserves::deposit(
-            e, &user2, 8_000_0000000, 7_000_0000000, &after_first
-        ).unwrap();
+        let (user2_shares, after_second) =
+            reserves::deposit(e, &user2, 8_000_0000000, 7_000_0000000, &after_first).unwrap();
 
         // User2 should get proportional shares (1000 out of total 2000)
         assert_eq!(user2_shares, 1_000_0000000);
@@ -628,8 +675,12 @@ fn test_harvest_increases_share_value() {
 
     let post_value = shares_to_underlying(1_000_0000000, &updated).unwrap();
 
-    assert!(post_value > pre_value,
-        "Share value should increase after harvest: pre={}, post={}", pre_value, post_value);
+    assert!(
+        post_value > pre_value,
+        "Share value should increase after harvest: pre={}, post={}",
+        pre_value,
+        post_value
+    );
     assert_eq!(post_value - pre_value, 100_0000000); // +100 equity
 }
 
@@ -684,7 +735,9 @@ fn test_multi_user_proportional() {
         let alice_actual = alice_shares; // minus lockup
         assert!(
             (bob_shares as f64 / alice_actual as f64 - 2.0).abs() < 0.01,
-            "Bob should have ~2x Alice's shares: alice={}, bob={}", alice_actual, bob_shares
+            "Bob should have ~2x Alice's shares: alice={}, bob={}",
+            alice_actual,
+            bob_shares
         );
 
         // Total equity should be 3000
@@ -694,10 +747,15 @@ fn test_multi_user_proportional() {
         // Alice's value should be ~1000
         let alice_value = shares_to_underlying(alice_shares, &after_bob).unwrap();
         // Allow for lockup adjustment
-        let expected = 1_000_0000000 - (FIRST_DEPOSIT_LOCKUP * 1_000_0000000 / after_bob.total_shares);
+        let expected =
+            1_000_0000000 - (FIRST_DEPOSIT_LOCKUP * 1_000_0000000 / after_bob.total_shares);
         // Allow small rounding from fixed-point math (up to 1000 stroops)
-        assert!((alice_value - expected).abs() <= 1000,
-            "Alice value={}, expected~={}", alice_value, expected);
+        assert!(
+            (alice_value - expected).abs() <= 1000,
+            "Alice value={}, expected~={}",
+            alice_value,
+            expected
+        );
     });
 }
 
@@ -728,16 +786,17 @@ fn test_safety_rejects_high_utilization() {
     // Pool at 96% utilization → should panic (above 95% limit)
     check_deposit_safety(
         &e,
-        1_000_0000000,   // pool supply
-        960_0000000,     // pool borrow (96%)
-        100_0000000,     // add supply
-        50_0000000,      // add borrow
-        1_000_0000000,   // post b
-        500_0000000,     // post d
+        1_000_0000000, // pool supply
+        960_0000000,   // pool borrow (96%)
+        100_0000000,   // add supply
+        50_0000000,    // add borrow
+        1_000_0000000, // post b
+        500_0000000,   // post d
         SCALAR_12,
         SCALAR_12,
         &config,
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 #[test]
@@ -765,14 +824,17 @@ fn test_safety_allows_healthy_pool() {
     let result = check_deposit_safety(
         &e,
         1_000_0000000,
-        500_0000000,      // 50% util
+        500_0000000, // 50% util
         100_0000000,
         50_0000000,
-        2_000_0000000,    // plenty of collateral
+        2_000_0000000, // plenty of collateral
         500_0000000,
         SCALAR_12,
         SCALAR_12,
         &config,
     );
-    assert!(result.is_ok(), "Should allow at 50% utilization with healthy HF");
+    assert!(
+        result.is_ok(),
+        "Should allow at 50% utilization with healthy HF"
+    );
 }


### PR DESCRIPTION
Part of **SCF #43 Tranche 1, Deliverable 5** — clippy/fmt enforcement (third of three D5 PRs; #241 = Dependabot/cargo-audit, #242 = frontend Biome lint).

Flips the `# TODO` in `contracts.yml` into real gates by paying down the contract crate's lint debt.

## Lint-debt resolution
- **Real fixes:** `loops.max(1).min(20)` → `loops.clamp(1, 20)`; a confusing zero-prefixed test literal `0_1000000` → `1_000_000` (identical value).
- **`#[allow(clippy::too_many_arguments)]`** on `check_deposit_safety` — it legitimately needs the full pool + position context.
- **Crate-level `allow(clippy::inconsistent_digit_grouping)`** — 100+ 1e7/1e12-scaled financial literals use intentional non-uniform underscore grouping (e.g. `10_500_000` = 1.05). Rewriting them risks a value typo in a fund-holding contract, and the lint is purely cosmetic.
- **Crate-level `allow(deprecated)` + TODO** — the two `e.events().publish(...)` calls migrate to the `#[contractevent]` macro alongside the D2 receipt-token event rework.
- `cargo fmt` applied (most of the diff is whitespace).

## Workflow
`contracts.yml`: added `rustfmt` (`--check`) and `clippy --all-targets -- -D warnings` steps, plus the toolchain components.

## Verification
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test` — **45/45 pass**.
- `cargo build --target wasm32v1-none --release` — succeeds.

Maps to grant criteria: "Rust CI (clippy, fmt, tests)" enforced on every contract PR.