### PR TITLE
feat(frontend): Wallets Kit Ledger + mobile deep-link + e2e (SCF T1 D4)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -44,3 +44,23 @@ jobs:
       - run: npm install
       - name: Build (wrangler dry-run)
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm install
+      - name: Install e2e deps
+        working-directory: frontend/e2e
+        run: npm install
+      - name: Install Playwright browser
+        working-directory: frontend/e2e
+        run: npx playwright install --with-deps chromium
+      - name: Run Playwright (mock-wallet harness)
+        working-directory: frontend/e2e
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ frontend/.env.local
 alerts/package-lock.json
 alerts/.dev.vars
 alerts/.wrangler/
+
+# Playwright e2e outputs
+frontend/e2e/node_modules/
+frontend/e2e/test-results/
+frontend/e2e/playwright-report/
+frontend/e2e/package-lock.json

--- a/frontend/e2e/package.json
+++ b/frontend/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "turbolong-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright end-to-end tests for the Turbolong frontend (mock-wallet harness).",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.49.1"
+  }
+}

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the Turbolong frontend E2E suite.
+ *
+ * Tests run against a `vite preview` of the built `dist/` (served on :4173).
+ * Everything is hermetic: the app is loaded with `?e2e=1` so its mock-wallet
+ * harness (frontend/src/e2e-harness.ts) replaces all wallet + RPC calls — no
+ * extension, hardware wallet, or live network is touched.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : [["list"]],
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // Build first so `vite preview` serves fresh assets, then preview on :4173.
+    command: "npm --prefix .. run build && npm --prefix .. run preview -- --port 4173 --strictPort",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/frontend/e2e/tests/wallets.spec.ts
+++ b/frontend/e2e/tests/wallets.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Wallet-kit E2E: boots the real app under the mock-wallet harness (`?e2e=1`)
+ * and verifies the kit registers all six signing modules — the five supported
+ * wallets plus the new Ledger hardware module — and that the harness installs
+ * cleanly (the seam the app routes sign/submit through is active).
+ *
+ * No browser extension, hardware wallet, or live RPC is touched. Per-operation
+ * classic/Soroban drives and live device/Ledger sign-off are tracked as the
+ * next E2E increment (the harness + TxSeam already support them).
+ */
+
+const EXPECTED_WALLET_COUNT = 6; // Freighter, xBull, Albedo, Lobstr, Hana, Ledger
+
+test.describe("Stellar Wallets Kit", () => {
+  test("boots under the E2E harness and installs the mock seam", async ({ page }) => {
+    await page.goto("/?e2e=1");
+    await page.waitForFunction(() => window.__E2E__?.installed === true, null, {
+      timeout: 30_000,
+    });
+    const installed = await page.evaluate(() => window.__E2E__?.installed);
+    expect(installed).toBe(true);
+  });
+
+  test("registers all five wallets plus Ledger", async ({ page }) => {
+    await page.goto("/?e2e=1");
+    await page.waitForFunction(
+      () => Array.isArray(window.__E2E__?.registeredWallets),
+      null,
+      { timeout: 30_000 },
+    );
+    const registered = await page.evaluate(() => window.__E2E__?.registeredWallets ?? []);
+
+    // All six modules registered (the five base wallets + the Ledger module).
+    expect(registered.length).toBe(EXPECTED_WALLET_COUNT);
+    // Ledger must be present — it is the deliverable's new hardware module.
+    expect(registered.some((id) => /ledger/i.test(id))).toBe(true);
+  });
+
+  test("exposes a submitted-tx ledger for sign->submit assertions", async ({ page }) => {
+    await page.goto("/?e2e=1");
+    await page.waitForFunction(() => window.__E2E__?.installed === true, null, {
+      timeout: 30_000,
+    });
+    // The harness seeds an empty submitted[] array that the app appends to on
+    // every signed classic/Soroban submit — the hook future op-level tests use.
+    const submitted = await page.evaluate(() => window.__E2E__?.submitted);
+    expect(Array.isArray(submitted)).toBe(true);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.1",
     "@stellar-broker/client": "^0.6.14",
-    "@stellar/stellar-sdk": "^14.6.1"
+    "@stellar/stellar-sdk": "^14.6.1",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/frontend/src/e2e-harness.ts
+++ b/frontend/src/e2e-harness.ts
@@ -1,0 +1,142 @@
+/**
+ * E2E test harness — TEST-ONLY mock wallet + network seam.
+ *
+ * This module is **never** imported by the production code path. `main.ts`
+ * dynamically imports it only when {@link isE2E} returns true (the page was
+ * loaded with `?e2e=1`, or `window.__E2E__` was pre-set by a test runner such
+ * as Playwright via `addInitScript`). It lets headless E2E tests drive the full
+ * sign → submit → history pipeline of the real app without a browser extension,
+ * hardware wallet, or live Stellar RPC.
+ *
+ * It deliberately stays small and explicit: it patches the public
+ * `StellarWalletsKit` surface (so every kit call in the app is mocked) and
+ * exposes a `TxSeam` whose methods the app calls instead of touching the
+ * network directly. Tests can pick which mock wallet "signs" via
+ * `window.__E2E__.wallet`.
+ */
+
+/** Shape of the test hook a runner may set before the app boots. */
+export interface E2EHook {
+  /** Which mock wallet is "connected". Mirrors the kit module ids + LEDGER. */
+  wallet?: "freighter" | "xbull" | "albedo" | "lobstr" | "hana" | "LEDGER";
+  /** Override the mock account address. */
+  address?: string;
+  /** Populated by the harness once installed, so tests can introspect. */
+  installed?: boolean;
+  /** Every tx the harness "submitted", newest last. Tests assert on this. */
+  submitted?: Array<{ kind: "soroban" | "classic"; xdr: string; hash: string }>;
+  /** The wallet ids the app registered with the kit (for assertions). */
+  registeredWallets?: string[];
+}
+
+declare global {
+  interface Window {
+    __E2E__?: E2EHook;
+  }
+}
+
+const DEFAULT_MOCK_ADDRESS = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBCGFJ3SHRGZ7GGNKDQY2";
+
+/** True when the app should run in E2E mode. */
+export function isE2E(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.__E2E__) return true;
+  try {
+    return new URLSearchParams(window.location.search).get("e2e") === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Read (creating if needed) the test hook object. */
+function hook(): E2EHook {
+  if (!window.__E2E__) window.__E2E__ = {};
+  if (!window.__E2E__.submitted) window.__E2E__.submitted = [];
+  return window.__E2E__;
+}
+
+/** Deterministic 64-hex tx hash derived from the input so tests can assert it. */
+function fakeHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  const seed = (h >>> 0).toString(16).padStart(8, "0");
+  return (seed + input.length.toString(16).padStart(2, "0")).repeat(8).slice(0, 64);
+}
+
+/**
+ * The network seam the app routes its tx operations through when in E2E mode.
+ * In production these delegate straight to the real implementations; under the
+ * harness they return deterministic mock data without hitting the network.
+ */
+export interface TxSeam {
+  /** True — lets the app branch on "are we mocked" cheaply. */
+  active: boolean;
+  signTransaction(xdr: string): Promise<{ signedTxXdr: string }>;
+  submitSoroban(signedXdr: string): Promise<string>;
+  submitClassic(signedXdr: string): Promise<string>;
+  /**
+   * Mock trustline lookup. Forces exactly one missing trustline (using the
+   * caller-supplied real `Asset`) so the classic `changeTrust` step is
+   * exercised, without hitting Horizon. `T` is `@stellar/stellar-sdk`'s `Asset`.
+   */
+  getMissingTrustlines<T>(forcedAsset: T): Promise<{ missing: T[]; currentCount: number }>;
+  /** Mock an XDR-build call (which would otherwise simulate against RPC). */
+  buildXdr(): Promise<string>;
+  /** The mock account address to use as the connected wallet. */
+  address(): string;
+}
+
+/** Build a {@link TxSeam} backed by the mock wallet. */
+export function makeSeam(): TxSeam {
+  return {
+    active: true,
+    address: () => hook().address ?? DEFAULT_MOCK_ADDRESS,
+    async signTransaction(xdr: string) {
+      // Echo the XDR back as the "signed" payload; submit is mocked too so the
+      // payload never needs to be a real signature.
+      return { signedTxXdr: xdr };
+    },
+    async submitSoroban(signedXdr: string) {
+      const h = fakeHash("soroban:" + signedXdr);
+      hook().submitted!.push({ kind: "soroban", xdr: signedXdr, hash: h });
+      return h;
+    },
+    async submitClassic(signedXdr: string) {
+      const h = fakeHash("classic:" + signedXdr);
+      hook().submitted!.push({ kind: "classic", xdr: signedXdr, hash: h });
+      return h;
+    },
+    async getMissingTrustlines<T>(forcedAsset: T) {
+      // Force one missing trustline so the classic changeTrust step runs.
+      return { missing: [forcedAsset], currentCount: 1 };
+    },
+    async buildXdr() {
+      // A non-empty placeholder XDR; never decoded because submit is mocked.
+      return "AAAAMOCKXDR==";
+    },
+  };
+}
+
+/**
+ * Patch the static {@link StellarWalletsKit} so connect / sign / network calls
+ * resolve against the mock wallet. Returns the seam the app should use for its
+ * build / submit operations.
+ */
+export function installKitMocks(kit: any, networkPassphrase: string): TxSeam {
+  const h = hook();
+  const address = h.address ?? DEFAULT_MOCK_ADDRESS;
+
+  kit.authModal = async () => ({ address });
+  kit.getAddress = async () => ({ address });
+  kit.fetchAddress = async () => ({ address });
+  kit.setWallet = () => {};
+  kit.disconnect = async () => {};
+  kit.getNetwork = async () => ({ network: "mock", networkPassphrase });
+  kit.signTransaction = async (xdr: string) => ({ signedTxXdr: xdr, signerAddress: address });
+
+  h.installed = true;
+  return makeSeam();
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,12 +2,19 @@
  * Turbolong UI — multi-pool support (Etherfuse, Fixed, YieldBlox)
  */
 
+// MUST be first: installs a global `Buffer` before the Ledger module (and its
+// @ledgerhq/* deps) is evaluated. Inline code can't do this — ES imports run
+// before any statement in this module.
+import "./polyfills.ts";
+
 import { StellarWalletsKit } from "@creit-tech/stellar-wallets-kit/sdk";
 import { FreighterModule }   from "@creit-tech/stellar-wallets-kit/modules/freighter";
 import { xBullModule }       from "@creit-tech/stellar-wallets-kit/modules/xbull";
 import { AlbedoModule }      from "@creit-tech/stellar-wallets-kit/modules/albedo";
 import { LobstrModule }      from "@creit-tech/stellar-wallets-kit/modules/lobstr";
 import { HanaModule }        from "@creit-tech/stellar-wallets-kit/modules/hana";
+import { LedgerModule }      from "@creit-tech/stellar-wallets-kit/modules/ledger";
+import type { ModuleInterface } from "@creit-tech/stellar-wallets-kit/types";
 import { Networks }          from "@creit-tech/stellar-wallets-kit/types";
 import { estimateSwap }      from "@stellar-broker/client";
 import {
@@ -81,16 +88,103 @@ import {
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
-StellarWalletsKit.init({
-  modules: [
+/**
+ * WalletConnect project id. When set (via the `VITE_WALLET_CONNECT_PROJECT_ID`
+ * env var) the kit registers a WalletConnect module, which renders the Reown
+ * AppKit modal. On a phone that modal shows a QR code / "open in wallet"
+ * deep-link so mobile wallets that speak WalletConnect (Lobstr, xBull, Hana,
+ * Freighter mobile, …) can sign without copy-paste. When unset, the kit still
+ * works with the extension / in-app-browser modules — WalletConnect is simply
+ * skipped (no-op fallback). See PR / README for setup.
+ */
+const WALLET_CONNECT_PROJECT_ID = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID as string | undefined;
+
+/**
+ * The synchronous base set of wallet modules. Freighter / xBull / Albedo /
+ * Lobstr / Hana are browser-extension or in-app-browser signers; Ledger is a
+ * WebUSB hardware-wallet signer (kit v2 `LedgerModule`, requires a `Buffer`
+ * global — provided in `index.html`). WalletConnect is added asynchronously by
+ * {@link initWalletKit} because constructing it spins up Reown AppKit.
+ */
+function baseWalletModules(): ModuleInterface[] {
+  return [
     new FreighterModule(),
     new xBullModule(),
     new AlbedoModule(),
     new LobstrModule(),
     new HanaModule(),
-  ],
-  network: Networks.PUBLIC,
-});
+    new LedgerModule(),
+  ];
+}
+
+/** Network passphrase → kit `Networks` enum value. */
+function kitNetwork(net: NetworkMode): Networks {
+  return net === "testnet" ? Networks.TESTNET : Networks.PUBLIC;
+}
+
+/**
+ * Build the WalletConnect module if a project id is configured. Returns
+ * `undefined` (the no-op fallback) when no project id is set or if AppKit fails
+ * to load, so wallet connection still works without mobile deep-linking.
+ */
+async function maybeWalletConnectModule(net: NetworkMode): Promise<ModuleInterface | undefined> {
+  if (!WALLET_CONNECT_PROJECT_ID) return undefined;
+  try {
+    const { WalletConnectModule, WalletConnectTargetChain } = await import(
+      "@creit-tech/stellar-wallets-kit/modules/wallet-connect"
+    );
+    return new WalletConnectModule({
+      projectId: WALLET_CONNECT_PROJECT_ID,
+      allowedChains: [
+        net === "testnet" ? WalletConnectTargetChain.TESTNET : WalletConnectTargetChain.PUBLIC,
+      ],
+      metadata: {
+        name: "Turbolong",
+        description: "Leveraged yield on Blend",
+        url: typeof window !== "undefined" ? window.location.origin : "https://turbolong.app",
+        icons: [typeof window !== "undefined" ? `${window.location.origin}/logo.svg` : ""],
+      },
+    }) as unknown as ModuleInterface;
+  } catch (e) {
+    console.warn("WalletConnect module unavailable — mobile deep-link disabled", e);
+    return undefined;
+  }
+}
+
+/**
+ * Initialise (or re-initialise) the Stellar Wallets Kit for a given network.
+ * Registers the base modules synchronously so the kit is usable immediately,
+ * then upgrades to include WalletConnect once it has loaded.
+ */
+function initWalletKit(net: NetworkMode): void {
+  const network = kitNetwork(net);
+  StellarWalletsKit.init({ modules: baseWalletModules(), network });
+  // Best-effort async upgrade with the mobile deep-link / QR module.
+  void maybeWalletConnectModule(net).then((wc) => {
+    if (!wc) return;
+    StellarWalletsKit.init({ modules: [...baseWalletModules(), wc], network });
+  });
+}
+
+initWalletKit("mainnet");
+
+// ── E2E test seam ───────────────────────────────────────────────────────────
+// In production `txSeam` is null and every tx operation talks to the real kit
+// / RPC. When the page is loaded under the E2E harness (`?e2e=1` or a
+// pre-injected `window.__E2E__`) `installE2EHarness()` swaps in deterministic
+// mocks so headless tests can drive the full sign → submit → history pipeline
+// with no extension, hardware wallet, or live network. The harness module is
+// dynamically imported so it is tree-shaken out of normal builds' hot path.
+
+import type { TxSeam } from "./e2e-harness.ts";
+
+let txSeam: TxSeam | null = null;
+
+async function installE2EHarness(): Promise<void> {
+  const { isE2E, installKitMocks } = await import("./e2e-harness.ts");
+  if (!isE2E()) return;
+  txSeam = installKitMocks(StellarWalletsKit, getNetworkPassphrase());
+}
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -116,16 +210,7 @@ async function switchNetwork(net: NetworkMode) {
   localStorage.setItem("networkMode", net);
 
   // Reinitialize wallet kit for new network
-  StellarWalletsKit.init({
-    modules: [
-      new FreighterModule(),
-      new xBullModule(),
-      new AlbedoModule(),
-      new LobstrModule(),
-      new HanaModule(),
-    ],
-    network: net === "testnet" ? Networks.TESTNET : Networks.PUBLIC,
-  });
+  initWalletKit(net);
 
   // Reset state
   reserves = [];
@@ -712,12 +797,14 @@ function renderTrendArrow(
 async function signAndSubmit(xdrStr: string, label: string, stepIndex?: number): Promise<string> {
   if (stepIndex !== undefined) updateTxStep(stepIndex, "active");
   toast(`Sign "${label}" in your wallet\u2026`, "info");
-  const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdrStr, {
-    networkPassphrase: getNetworkPassphrase(),
-    address: userAddress!,
-  });
+  const { signedTxXdr } = txSeam
+    ? await txSeam.signTransaction(xdrStr)
+    : await StellarWalletsKit.signTransaction(xdrStr, {
+        networkPassphrase: getNetworkPassphrase(),
+        address: userAddress!,
+      });
   toast(`Submitting "${label}"\u2026`, "info");
-  const hash = await submitSignedXdr(signedTxXdr);
+  const hash = txSeam ? await txSeam.submitSoroban(signedTxXdr) : await submitSignedXdr(signedTxXdr);
   if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
   toast(`"${label}" confirmed!`, "success", hash);
   addTxToHistory(label, hash, "success");
@@ -731,12 +818,14 @@ async function signAndSubmit(xdrStr: string, label: string, stepIndex?: number):
 async function signAndSubmitClassic(xdrStr: string, label: string, stepIndex?: number): Promise<string> {
   if (stepIndex !== undefined) updateTxStep(stepIndex, "active");
   toast(`Sign "${label}" in your wallet\u2026`, "info");
-  const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdrStr, {
-    networkPassphrase: getNetworkPassphrase(),
-    address: userAddress!,
-  });
+  const { signedTxXdr } = txSeam
+    ? await txSeam.signTransaction(xdrStr)
+    : await StellarWalletsKit.signTransaction(xdrStr, {
+        networkPassphrase: getNetworkPassphrase(),
+        address: userAddress!,
+      });
   toast(`Submitting "${label}"\u2026`, "info");
-  const hash = await submitClassicXdr(signedTxXdr);
+  const hash = txSeam ? await txSeam.submitClassic(signedTxXdr) : await submitClassicXdr(signedTxXdr);
   if (stepIndex !== undefined) updateTxStep(stepIndex, "done");
   toast(`"${label}" confirmed!`, "success", hash);
   addTxToHistory(label, hash, "success");
@@ -1784,7 +1873,9 @@ async function openPosition() {
   // actually going to proceed.
   let trustlineResult: MissingTrustlineResult = { missing: [], currentCount: 0 };
   try {
-    trustlineResult = await getMissingTrustlines(selectedPool, userAddress, liveAsset.id);
+    trustlineResult = txSeam
+      ? await txSeam.getMissingTrustlines(new Asset("USDC", TESTNET_USDC_ISSUER))
+      : await getMissingTrustlines(selectedPool, userAddress, liveAsset.id);
   } catch (e: any) {
     toast(`Trustline check failed: ${(e?.message ?? String(e)).slice(0, 150)}`, "error");
     setLoading($("open-btn") as HTMLButtonElement, false);
@@ -1816,7 +1907,9 @@ async function openPosition() {
   try {
     if (hasMissingTrustlines) {
       activeStep = trustStep;
-      const trustXdr = await buildTrustlineXdr(trustlineResult.missing, userAddress);
+      const trustXdr = txSeam
+        ? await txSeam.buildXdr()
+        : await buildTrustlineXdr(trustlineResult.missing, userAddress);
       if (trustXdr) {
         await signAndSubmitClassic(
           trustXdr,
@@ -1827,11 +1920,15 @@ async function openPosition() {
     }
 
     activeStep = approveStep;
-    const approveXdr = await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
+    const approveXdr = txSeam
+      ? await txSeam.buildXdr()
+      : await buildApproveXdr(selectedPool, userAddress, liveAsset.id, initialStroops + 1n);
     await signAndSubmit(approveXdr, `Approve ${liveAsset.symbol}`, approveStep);
 
     activeStep = submitStep;
-    const submitXdr = await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
+    const submitXdr = txSeam
+      ? await txSeam.buildXdr()
+      : await buildOpenPositionXdr(selectedPool, userAddress, liveAsset, initialStroops, leverage);
     const openHash = await signAndSubmit(submitXdr, `Open ${liveAsset.symbol} leverage`, submitStep);
     hideTxStepper();
     savePnlEntry(liveAsset.id, selectedPool.id, initial);
@@ -2183,10 +2280,29 @@ async function connect() {
     buildPoolTabs();
     buildAssetTabs();
     renderPoolFooter();
-    await loadAll();
+    // Under the E2E harness we seed deterministic mock reserves/positions
+    // instead of fetching from RPC, so transaction flows stay fully hermetic.
+    if (txSeam) seedE2EState();
+    else await loadAll();
   } catch (e: any) {
     if (e?.message !== "User closed the modal") toast("Failed to connect wallet", "error");
   }
+}
+
+/**
+ * Seed mock reserves / a sample position for the E2E harness. Mirrors the demo
+ * data but, unlike demo mode, leaves `demoMode === false` so real (mocked) tx
+ * flows are allowed to run.
+ */
+function seedE2EState() {
+  reserves = assets.map(a => ({
+    asset: a, cFactor: a.cFactor, lFactor: 1, interestSupplyApr: 4.2, interestBorrowApr: 6.8,
+    blndSupplyApr: 2.1, blndBorrowApr: 1.5, netSupplyApr: 6.3, netBorrowCost: 5.3,
+    totalSupply: 1_000_000, totalBorrow: 650_000, available: 350_000, priceUsd: 1.0,
+  }));
+  positions = { byAsset: new Map() };
+  renderSelectedAsset();
+  updatePreview();
 }
 
 /** Re-open wallet modal to switch to a different account without a full page reload. */
@@ -2949,7 +3065,11 @@ $("overview-refresh-btn").addEventListener("click", () => loadOverview());
 // ── Vault view ───────────────────────────────────────────────────────────────
 
 function getActiveVault(): VaultConfig {
-  return getVaults()[0];
+  const vaults = getVaults();
+  // Under the E2E harness, prefer a vault that has a deployed contract id so
+  // the deposit / withdraw flows are reachable without a live deployment.
+  if (txSeam) return vaults.find(v => !!v.vaultId) ?? vaults[0];
+  return vaults[0];
 }
 
 let _lastVaultStats: VaultStats | null = null;
@@ -2995,6 +3115,15 @@ async function refreshVaultView() {
     $("vault-hf").textContent = "--";
     $("vault-strategy-pos").classList.add("hidden");
     $("vault-hf-bar-wrap").classList.add("hidden");
+    return;
+  }
+
+  // Under the E2E harness, skip all live RPC stat fetches — the deposit/withdraw
+  // buttons are already enabled above, which is what the tests need.
+  if (txSeam) {
+    $("vault-tvl").textContent = formatUsd(1_000_000);
+    $("vault-share-price").textContent = formatUsd(1, 6);
+    $("vault-apy").textContent = "+5.00%";
     return;
   }
 
@@ -3152,9 +3281,12 @@ $("vault-deposit-btn").addEventListener("click", async () => {
     ($("vault-deposit-btn") as HTMLButtonElement).disabled = true;
     ($("vault-deposit-btn") as HTMLButtonElement).textContent = "Depositing...";
 
-    const xdr = await buildVaultDepositXdr(vault, userAddress, amount);
-    const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr);
-    await submitSignedXdr(signedTxXdr);
+    const xdr = txSeam ? await txSeam.buildXdr() : await buildVaultDepositXdr(vault, userAddress, amount);
+    const { signedTxXdr } = txSeam
+      ? await txSeam.signTransaction(xdr)
+      : await StellarWalletsKit.signTransaction(xdr);
+    const depositHash = txSeam ? await txSeam.submitSoroban(signedTxXdr) : await submitSignedXdr(signedTxXdr);
+    addTxToHistory(`Deposit ${amount} ${vault.assetSymbol}`, depositHash, "success");
     await refreshVaultView();
     ($("vault-deposit-input") as HTMLInputElement).value = "";
   } catch (err: any) {
@@ -3217,14 +3349,18 @@ $("vault-rebalance-btn").addEventListener("click", async () => {
 
 // ── Auto-reconnect saved wallet ──────────────────────────────────────────────
 (async () => {
+  // Install the E2E harness first (no-op outside test mode). When active it
+  // mocks the wallet kit + tx network seam and records which wallets registered.
+  await installE2EHarness();
+  if (txSeam && typeof window !== "undefined" && window.__E2E__) {
+    window.__E2E__.registeredWallets = baseWalletModules().map((m: any) => m.productId);
+  }
+
   // Restore network preference
   const savedNet = localStorage.getItem("networkMode") as NetworkMode | null;
   if (savedNet === "testnet") {
     setNetwork("testnet");
-    StellarWalletsKit.init({
-      modules: [new FreighterModule(), new xBullModule(), new AlbedoModule(), new LobstrModule(), new HanaModule()],
-      network: Networks.TESTNET,
-    });
+    initWalletKit("testnet");
     selectedPool = getKnownPools()[0];
     assets = getPoolAssets(selectedPool);
     selectedAsset = assets[0];
@@ -3232,6 +3368,10 @@ $("vault-rebalance-btn").addEventListener("click", async () => {
     $("network-toggle").classList.add("testnet-active");
     $("testnet-banner").classList.remove("hidden");
   }
+
+  // In E2E mode, leave the wallet disconnected so the test drives connect()
+  // via the real #connect-btn click — keeps the flow hermetic and deterministic.
+  if (txSeam) return;
 
   const saved = localStorage.getItem("walletAddress");
   if (!saved) return;

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,15 @@
+/**
+ * Browser polyfills that MUST run before any other module is evaluated.
+ *
+ * The Stellar Wallets Kit Ledger module pulls in `@ledgerhq/*` packages that
+ * reference a global `Buffer` at module-evaluation time. ES module imports are
+ * evaluated before any executable statement in the importing module, so the
+ * polyfill cannot live as inline code in main.ts — it must be a side-effect
+ * import placed first. Keep `import "./polyfills.ts"` as the very first import.
+ */
+import { Buffer as NodeBuffer } from "buffer";
+
+const g = globalThis as { Buffer?: unknown };
+if (typeof g.Buffer === "undefined") {
+  g.Buffer = NodeBuffer;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from "vite";
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   base: process.env.GITHUB_PAGES ? "/over_leveraging/" : "/",
@@ -14,5 +15,10 @@ export default defineConfig({
     esbuildOptions: {
       target: "es2020",
     },
+  },
+  test: {
+    // Playwright specs live under e2e/ and use @playwright/test; keep them out
+    // of the vitest unit run (parity.yml), which only owns test/**.
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
   },
 });


### PR DESCRIPTION
**SCF #43 Tranche 1, Deliverable 4** — Stellar Wallets Kit: mobile deep-linking + Ledger + E2E.

## What
- **Ledger** — register kit v2 `LedgerModule` (WebUSB hardware signing) alongside the 5 existing wallets (Freighter, xBull, Albedo, Lobstr, Hana). All signing stays kit-native (no Freighter-only paths).
- **Mobile deep-linking** — optional WalletConnect module (Reown AppKit modal → QR / open-in-wallet) added asynchronously when `VITE_WALLET_CONNECT_PROJECT_ID` is set, with a clean no-op fallback when unset. This is the kit-supported path for phone wallets to sign without copy-paste.
- **`src/polyfills.ts`** — installs a global `Buffer` before the Ledger module's `@ledgerhq/*` deps evaluate. Must be the first import: ES imports run before inline statements, so the original inline polyfill crashed boot with `Buffer is not defined` (caught by the e2e run).
- **`src/e2e-harness.ts`** — TEST-ONLY mock-wallet + tx seam, dynamically imported only under `?e2e=1` / `window.__E2E__`. Mocks the kit and records submitted txs so headless tests drive the full sign→submit pipeline without an extension, hardware wallet, or live RPC.
- **`e2e/`** — Playwright suite (runs against `vite preview` + the mock harness). Smoke specs assert the app boots under the harness and registers all 5 wallets **+ Ledger**. New `e2e` job in `frontend-ci.yml`.

## Verification
- `npm run build` + `biome lint` — clean.
- Playwright — **3/3 pass** locally (chromium); the e2e CI job runs the same.

## Remaining (tracked)
- Per-operation classic + Soroban e2e drives (the harness + `TxSeam` already support `submitted[]` assertions — specs to be expanded).
- **External sign-off:** live iOS/Android deep-link verification (Lobstr/xBull) and Ledger hardware run — pursued in parallel, not code-blocking.

Origin: the bulk was drafted by a background agent that died before committing; salvaged, the boot crash fixed, specs written + verified, and shipped here.