### PR TITLE
feat(contracts): auto-rebalance keeper + partial-unwind fixtures (SCF T2.2 + T2.3)

### DIFF
--- a/contracts/strategies/blend_leverage/src/constants.rs
+++ b/contracts/strategies/blend_leverage/src/constants.rs
@@ -17,6 +17,11 @@ pub const MAX_RATE_SPREAD: i128 = 15_000_000; // 15% in 1e7
 /// Inflation attack protection: first depositor lockup
 pub const FIRST_DEPOSIT_LOCKUP: i128 = 1000;
 
+/// Minimum ledgers between keeper-triggered rebalances (~5 minutes at ~5s/
+/// ledger). Rate-limits the automation; the permissionless `rebalance` is
+/// unaffected (anyone can always protect a position).
+pub const REBALANCE_COOLDOWN_LEDGERS: u32 = 60;
+
 /// Blend v2 request type constants
 pub const REQUEST_TYPE_SUPPLY_COLLATERAL: u32 = 2;
 pub const REQUEST_TYPE_WITHDRAW_COLLATERAL: u32 = 3;

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -327,59 +327,113 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
     }
 }
 
+/// Shared partial-unwind: if HF is below `target_hf`, unwind the minimal loops
+/// to restore it. Returns `(before_hf, after_hf, loops_unwound)`. A no-op
+/// (loops = 0) when there is no debt or HF is already at/above target.
+fn unwind_to(
+    e: &Env,
+    config: &Config,
+    target_hf: i128,
+) -> Result<(i128, i128, u32), StrategyError> {
+    let (b_rate, d_rate) = blend_pool::get_rates(e, config);
+    let (b_tokens, d_tokens) = blend_pool::get_strategy_positions(e, config);
+
+    if d_tokens == 0 {
+        return Ok((i128::MAX, i128::MAX, 0));
+    }
+
+    let before_hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, config.c_factor)?;
+    if before_hf >= target_hf {
+        return Ok((before_hf, before_hf, 0));
+    }
+
+    let (_, loops) = compute_partial_unwind(
+        b_tokens,
+        d_tokens,
+        b_rate,
+        d_rate,
+        config.c_factor,
+        target_hf,
+    )?;
+    if loops == 0 {
+        return Ok((before_hf, before_hf, 0));
+    }
+
+    let (b_removed, d_removed) = blend_pool::submit_deleverage(e, loops, config)?;
+    reserves::deleverage(e, b_removed, d_removed, config)?;
+
+    // Recompute HF on the post-unwind position for the event / return.
+    let (b2, d2) = blend_pool::get_strategy_positions(e, config);
+    let after_hf = if d2 == 0 {
+        i128::MAX
+    } else {
+        compute_health_factor(b2, d2, b_rate, d_rate, config.c_factor)?
+    };
+
+    Ok((before_hf, after_hf, loops))
+}
+
+/// Emit a rebalance event: topics `("rebalance", caller)`, data
+/// `(before_hf, after_hf, loops_unwound)` (HF in 1e7 scale).
+fn emit_rebalance(e: &Env, caller: &Address, before_hf: i128, after_hf: i128, loops: u32) {
+    e.events().publish(
+        (Symbol::new(e, "rebalance"), caller.clone()),
+        (before_hf, after_hf, loops),
+    );
+}
+
 // ── Additional public methods (not part of the trait) ────────────────────────
 
 #[contractimpl]
 impl BlendLeverageStrategy {
-    /// Rebalance: partial-unwind if HF is in the orange zone (orange_hf > HF >= min_hf),
-    /// or full deleverage if HF < min_hf.
-    /// Callable by anyone (permissionless — protects the vault).
+    /// Rebalance: partial-unwind if HF is in the orange zone (HF < orange_hf),
+    /// restoring HF to orange_hf. Callable by anyone (permissionless — protects
+    /// the vault). Emits a `rebalance` event when loops are unwound.
     pub fn rebalance(e: Env) -> Result<(), StrategyError> {
         extend_instance_ttl(&e);
-
         let config = storage::get_config(&e);
-        let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
-        let (b_tokens, d_tokens) = blend_pool::get_strategy_positions(&e, &config);
-
-        if d_tokens == 0 {
-            return Ok(());
+        let caller = e.current_contract_address();
+        let (before_hf, after_hf, loops) = unwind_to(&e, &config, config.orange_hf)?;
+        if loops > 0 {
+            emit_rebalance(&e, &caller, before_hf, after_hf, loops);
         }
-
-        let hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, config.c_factor)?;
-
-        if hf >= config.orange_hf {
-            return Ok(()); // HF is healthy, no action needed
-        }
-
-        // Use orange_hf as target so we restore to the safe zone, not just min_hf
-        let (_, unwind_loops) = compute_partial_unwind(
-            b_tokens,
-            d_tokens,
-            b_rate,
-            d_rate,
-            config.c_factor,
-            config.orange_hf,
-        )?;
-
-        if unwind_loops == 0 {
-            return Ok(());
-        }
-
-        let (b_removed, d_removed) = blend_pool::submit_deleverage(&e, unwind_loops, &config)?;
-
-        reserves::deleverage(&e, b_removed, d_removed, &config)?;
-
         Ok(())
     }
 
+    /// Keeper-authorised, rate-limited auto-rebalance. Unwinds the minimal loops
+    /// to restore HF to orange_hf when HF has dropped into the orange zone.
+    /// Limited to once per `REBALANCE_COOLDOWN_LEDGERS`; emits a `rebalance`
+    /// event with before/after HF and loops unwound. Returns loops unwound.
+    pub fn rebalance_keeper(e: Env, caller: Address) -> Result<u32, StrategyError> {
+        extend_instance_ttl(&e);
+        let keeper = storage::get_keeper(&e);
+        keeper.require_auth();
+        if caller != keeper {
+            return Err(StrategyError::NotAuthorized);
+        }
+
+        // Rate-limit.
+        let now = e.ledger().sequence();
+        let last = storage::get_last_rebalance(&e);
+        if last != 0 && now < last.saturating_add(constants::REBALANCE_COOLDOWN_LEDGERS) {
+            return Err(StrategyError::NotAuthorized);
+        }
+
+        let config = storage::get_config(&e);
+        let (before_hf, after_hf, loops) = unwind_to(&e, &config, config.orange_hf)?;
+        if loops > 0 {
+            storage::set_last_rebalance(&e, now);
+            emit_rebalance(&e, &caller, before_hf, after_hf, loops);
+        }
+        Ok(loops)
+    }
+
     /// Partial-unwind liquidation protection: unwind just enough loops to restore
-    /// HF to `target_hf`. Callable by the keeper or the strategy itself.
-    ///
-    /// `target_hf` must be >= config.orange_hf to prevent abuse.
+    /// HF to `target_hf`. Callable by the keeper, or by anyone when HF is already
+    /// in the orange zone. `target_hf` is floored at config.orange_hf to prevent
+    /// over-unwinding. Emits a `rebalance` event when loops are unwound.
     pub fn partial_unwind(e: Env, caller: Address, target_hf: i128) -> Result<u32, StrategyError> {
         extend_instance_ttl(&e);
-
-        // Keeper or permissionless if HF is already in orange zone
         let config = storage::get_config(&e);
         let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
         let (b_tokens, d_tokens) = blend_pool::get_strategy_positions(&e, &config);
@@ -390,7 +444,7 @@ impl BlendLeverageStrategy {
 
         let hf = compute_health_factor(b_tokens, d_tokens, b_rate, d_rate, config.c_factor)?;
 
-        // Only the keeper can trigger above the orange zone; anyone can trigger inside it
+        // Only the keeper can trigger above the orange zone; anyone can inside it.
         if hf >= config.orange_hf {
             let keeper = storage::get_keeper(&e);
             if caller != keeper {
@@ -399,26 +453,11 @@ impl BlendLeverageStrategy {
         }
         caller.require_auth();
 
-        // target_hf must be at least orange_hf to avoid over-unwinding
         let effective_target = target_hf.max(config.orange_hf);
-
-        let (_, loops) = compute_partial_unwind(
-            b_tokens,
-            d_tokens,
-            b_rate,
-            d_rate,
-            config.c_factor,
-            effective_target,
-        )?;
-
-        if loops == 0 {
-            return Ok(0);
+        let (before_hf, after_hf, loops) = unwind_to(&e, &config, effective_target)?;
+        if loops > 0 {
+            emit_rebalance(&e, &caller, before_hf, after_hf, loops);
         }
-
-        let (b_removed, d_removed) = blend_pool::submit_deleverage(&e, loops, &config)?;
-
-        reserves::deleverage(&e, b_removed, d_removed, &config)?;
-
         Ok(loops)
     }
 

--- a/contracts/strategies/blend_leverage/src/storage.rs
+++ b/contracts/strategies/blend_leverage/src/storage.rs
@@ -26,6 +26,8 @@ pub enum DataKey {
     /// The SEP-41 vault-share token contract — the canonical per-user share
     /// ledger. The strategy is its minter (mints on deposit, burns on withdraw).
     ShareToken,
+    /// Ledger sequence of the last keeper rebalance (for rate-limiting).
+    LastRebalance,
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -183,6 +185,19 @@ pub fn get_share_token(e: &Env) -> Address {
 
 pub fn has_share_token(e: &Env) -> bool {
     e.storage().instance().has(&DataKey::ShareToken)
+}
+
+// ── Keeper rebalance rate-limit ──────────────────────────────────────────────
+
+pub fn set_last_rebalance(e: &Env, ledger: u32) {
+    e.storage().instance().set(&DataKey::LastRebalance, &ledger);
+}
+
+pub fn get_last_rebalance(e: &Env) -> u32 {
+    e.storage()
+        .instance()
+        .get(&DataKey::LastRebalance)
+        .unwrap_or(0)
 }
 
 // ── Instance TTL ─────────────────────────────────────────────────────────────

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -851,3 +851,29 @@ fn test_share_token_wiring_set_migrate_balance() {
     let bal = sclient.balance(&holder);
     assert!(bal > 0, "balance via token should be positive, got {}", bal);
 }
+
+// ── Auto-rebalance keeper auth & rate-limit (T2.3) ────────────────────────────
+
+#[test]
+fn test_rebalance_keeper_auth_gating_and_noop() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+    let keeper = sclient.get_keeper();
+    let stranger = Address::generate(&e);
+
+    // A non-keeper caller is rejected (caller != keeper).
+    assert!(
+        sclient.try_rebalance_keeper(&stranger).is_err(),
+        "non-keeper must be rejected"
+    );
+
+    // The keeper may call; with no open position (no debt) it is a no-op.
+    assert_eq!(sclient.rebalance_keeper(&keeper), 0, "no debt → no-op");
+
+    // The permissionless rebalance is also a safe no-op with no position.
+    sclient.rebalance();
+}

--- a/contracts/strategies/blend_leverage/src/test_leverage.rs
+++ b/contracts/strategies/blend_leverage/src/test_leverage.rs
@@ -899,3 +899,81 @@ fn test_upgrade_preserves_hf_and_balance_parity() {
         );
     });
 }
+
+// ── Partial-unwind degenerate cases & HF-restoration parity (T2.2) ────────────
+
+#[test]
+fn test_partial_unwind_target_at_or_below_cfactor_errors() {
+    let c = 9_000_000_i128; // 0.90
+                            // Very unhealthy position so HF is below both targets and we
+                            // reach the denom check. b=7000, d=9000 → HF = 7000*0.9/9000 = 0.70.
+    let b = 7_000_0000000_i128;
+    let d = 9_000_0000000_i128;
+    // target == c_factor → denom 0 → error.
+    assert!(compute_partial_unwind(b, d, SCALAR_12, SCALAR_12, c, c).is_err());
+    // target < c_factor → denom < 0 → error.
+    assert!(compute_partial_unwind(b, d, SCALAR_12, SCALAR_12, c, c - 1_000_000).is_err());
+}
+
+#[test]
+fn test_partial_unwind_restores_hf_to_target() {
+    let c = 9_000_000_i128; // 0.90
+    let target = 11_500_000_i128; // 1.15 (orange_hf)
+
+    // A spread of unhealthy positions (rates = 1.0 so value == tokens, letting us
+    // model the unwind as "withdraw `repay` collateral, repay `repay` debt").
+    let cases = [
+        (10_000_0000000_i128, 8_500_0000000_i128),
+        (10_000_0000000_i128, 8_000_0000000_i128),
+        (5_000_0000000_i128, 4_200_0000000_i128),
+        (20_000_0000000_i128, 16_500_0000000_i128),
+    ];
+
+    for (b, d) in cases {
+        let hf0 = compute_health_factor(b, d, SCALAR_12, SCALAR_12, c).unwrap();
+        assert!(hf0 < target, "fixture must be unhealthy: hf={}", hf0);
+
+        let (repay, loops) = compute_partial_unwind(b, d, SCALAR_12, SCALAR_12, c, target).unwrap();
+        assert!(loops >= 1, "should unwind at least one loop");
+        assert!(repay > 0 && repay < d, "repay in range: {}", repay);
+
+        // Model the exact unwind: withdraw `repay` collateral, repay `repay` debt.
+        let new_hf = compute_health_factor(b - repay, d - repay, SCALAR_12, SCALAR_12, c).unwrap();
+
+        // Restored to at least target …
+        assert!(
+            new_hf >= target,
+            "HF not restored for ({}, {}): {} < {}",
+            b,
+            d,
+            new_hf,
+            target
+        );
+        // … and not wildly over-unwound (within ~1% above target).
+        assert!(
+            new_hf <= target + target / 100,
+            "over-unwound for ({}, {}): {}",
+            b,
+            d,
+            new_hf
+        );
+    }
+}
+
+#[test]
+fn test_partial_unwind_with_accrued_rates_is_sane() {
+    // Debt grew faster than supply (b_rate 1.05, d_rate 1.10) — HF degraded.
+    let c = 9_000_000_i128;
+    let target = 11_500_000_i128;
+    let b_rate = SCALAR_12 * 105 / 100;
+    let d_rate = SCALAR_12 * 110 / 100;
+    let b = 10_000_0000000_i128;
+    let d = 8_000_0000000_i128;
+
+    let hf0 = compute_health_factor(b, d, b_rate, d_rate, c).unwrap();
+    if hf0 < target {
+        let (repay, loops) = compute_partial_unwind(b, d, b_rate, d_rate, c, target).unwrap();
+        assert!((1..=20).contains(&loops), "loops in [1,20]: {}", loops);
+        assert!(repay > 0, "positive repay: {}", repay);
+    }
+}


### PR DESCRIPTION
First **Tranche 2** deliverables — both build on the partial-unwind subsystem already on main.

## T2.3 — Auto-rebalance keeper ($6k)
- **`rebalance_keeper(caller)`** — keeper-authorised, **rate-limited** (once per `REBALANCE_COOLDOWN_LEDGERS` = 60 ledgers ≈ 5 min), unwinds the minimal loops to restore HF to `orange_hf`. Emits a **`rebalance`** event `(before_hf, after_hf, loops_unwound)` and stamps `LastRebalance`. Returns loops unwound.
- Refactored the shared unwind into a private `unwind_to()` (computes before/after HF) so the permissionless `rebalance()` and `partial_unwind()` **also emit the event**. New `LastRebalance` storage key + cooldown constant.

## T2.2 — Partial-unwind liquidation protection ($8k)
The algorithm (`compute_partial_unwind`) was already on main; this adds the fixture coverage the deliverable requires:
- `target_hf <= c_factor` → error.
- **HF-restoration parity** across a spread of unhealthy positions: the modelled exact unwind restores HF to target (within ~1%, no over-unwind) — the "dry-run matches on-chain within rounding" property.
- accrued-rate sanity. Adds to the existing degenerate-case tests (already-at-target, no-debt, single-loop, max-loops, minimal-repay).

## Verification
- `cargo test` — **53/53** (8 partial-unwind + keeper auth/no-op).
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean; wasm release builds.

## Deferred to testnet (per T2.3 acceptance)
Live keeper rebalance with rate-limit + event firing, the **100+ simulated rebalances on testnet**, and **1 live mainnet rebalance** — these need a real leveraged position in the orange zone (the native harness doesn't run the Blend loop for the real strategy). They ride on the D1 testnet rehearsal.