### PR TITLE
feat(alerts): historical APY storage + HF/liquidation alerts (SCF T2.5)

### DIFF
--- a/alerts/migrations/0001_t2_historical_apy_hf_alerts.sql
+++ b/alerts/migrations/0001_t2_historical_apy_hf_alerts.sql
@@ -1,0 +1,34 @@
+-- SCF T2.5 — historical APY storage + HF/liquidation alert channels.
+--
+-- Run ONCE against the existing production D1 database (fresh deploys get the
+-- full schema from src/schema.sql instead):
+--   wrangler d1 execute turbolong-alerts --remote \
+--     --file=migrations/0001_t2_historical_apy_hf_alerts.sql
+--
+-- SQLite has no ADD COLUMN IF NOT EXISTS; if a column already exists the
+-- statement errors harmlessly — skip it.
+
+ALTER TABLE subscriptions ADD COLUMN alert_type TEXT NOT NULL DEFAULT 'apy';
+ALTER TABLE subscriptions ADD COLUMN hf_threshold REAL;
+ALTER TABLE subscriptions ADD COLUMN last_fired_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_subs_alert_type
+  ON subscriptions(alert_type);
+
+CREATE TABLE IF NOT EXISTS rate_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pool_id TEXT NOT NULL,
+  asset_symbol TEXT NOT NULL,
+  recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+  net_supply_apr REAL NOT NULL,
+  net_borrow_cost REAL NOT NULL,
+  interest_supply_apr REAL NOT NULL,
+  interest_borrow_apr REAL NOT NULL,
+  blnd_supply_apr REAL NOT NULL,
+  blnd_borrow_apr REAL NOT NULL,
+  util REAL NOT NULL,
+  c_factor REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_pool_asset_time
+  ON rate_snapshots(pool_id, asset_symbol, recorded_at);

--- a/alerts/src/email.ts
+++ b/alerts/src/email.ts
@@ -100,3 +100,55 @@ export async function sendApyAlert(
     html,
   );
 }
+
+export async function sendHfAlert(
+  env: Env,
+  to: string,
+  opts: {
+    poolName: string;
+    assetSymbol: string;
+    leverage: number;
+    hf: number;
+    threshold: number;
+    liquidation: boolean;
+    unsubscribeUrl: string;
+    appUrl: string;
+  },
+): Promise<SendResult> {
+  const { poolName, assetSymbol, leverage, hf, threshold, liquidation, unsubscribeUrl, appUrl } = opts;
+  const title = liquidation ? "Liquidation Imminent" : "Health Factor Alert";
+  const hfStr = Number.isFinite(hf) ? hf.toFixed(3) : "∞";
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 16px; color: #1a1a2e;">
+  <h2 style="margin: 0 0 8px; color: #FF4D6A;">${title}</h2>
+  <p style="font-size: 14px; color: #555; margin: 0 0 20px;">${assetSymbol} at ${leverage}x on ${poolName}</p>
+
+  <div style="background: #f8f8fc; border-radius: 8px; padding: 16px; margin-bottom: 20px;">
+    <table style="width: 100%; font-size: 14px; border-collapse: collapse;">
+      <tr><td style="padding: 4px 0; color: #555;">Health factor</td><td style="padding: 4px 0; text-align: right; font-weight: 700; color: #FF4D6A;">${hfStr}</td></tr>
+      <tr><td style="padding: 4px 0; color: #555;">Threshold</td><td style="padding: 4px 0; text-align: right; font-weight: 600;">${threshold.toFixed(3)}</td></tr>
+    </table>
+  </div>
+
+  <p style="line-height: 1.6; color: #555;">${liquidation
+    ? "Your position is close to liquidation. Add collateral, repay debt, or reduce leverage now."
+    : "Your position’s health factor has dropped below your threshold. Consider reducing leverage."}</p>
+
+  <a href="${appUrl}" style="display: inline-block; margin: 16px 0; padding: 12px 28px; background: #2DE8A3; color: #0B0E14; text-decoration: none; border-radius: 8px; font-weight: 600;">Open Turbolong</a>
+
+  <p style="font-size: 12px; color: #aaa; margin-top: 32px;">
+    <a href="${unsubscribeUrl}" style="color: #aaa;">Unsubscribe</a> from this alert.
+  </p>
+</body>
+</html>`.trim();
+
+  const subject = liquidation
+    ? `\u{1F6A8} Liquidation imminent: ${assetSymbol} at ${leverage}x (HF ${hfStr})`
+    : `⚠ Health factor ${hfStr}: ${assetSymbol} at ${leverage}x on ${poolName}`;
+
+  return sendEmail(env, to, subject, html);
+}

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -3,19 +3,31 @@
  *
  * Routes:
  *   POST /subscribe              — register an email alert subscription
+ *                                  (alert_type: 'apy' | 'hf' | 'liquidation';
+ *                                  hf_threshold required for 'hf')
  *   GET  /verify?token=          — verify email
  *   GET  /unsubscribe?token=     — remove email subscription
  *   GET  /vapid-public-key       — VAPID public key for web push
  *   POST /push/subscribe         — register a web-push subscription
  *   GET  /push/unsubscribe?token= — remove web-push subscription
+ *   GET  /snapshots              — paginated rate time-series
+ *                                  (?pool_id=&asset=&limit=&before=)
  *
  * Cron (every 15 min):
- *   Fetch pool reserve rates, compute APY per bracket, alert email + push subscribers.
+ *   Fetch pool reserve rates → write a rate_snapshots row → APY-negative alerts
+ *   → HF / liquidation-imminent alerts → prune snapshots past 365 days.
  */
 
-import { POOLS, LEVERAGE_BRACKETS, POOL_NAMES, fetchReserveRates, computeNetApy, type ReserveRates } from "./stellar.ts";
-import { sendVerificationEmail, sendApyAlert } from "./email.ts";
+import { POOLS, LEVERAGE_BRACKETS, POOL_NAMES, fetchReserveRates, computeNetApy, computeHealthFactor, type ReserveRates } from "./stellar.ts";
+import { sendVerificationEmail, sendApyAlert, sendHfAlert } from "./email.ts";
 import { sendApyPush } from "./push.ts";
+
+/** Liquidation-imminent HF threshold. */
+const LIQUIDATION_HF = 1.05;
+/** Minimum hours between repeat HF/liquidation alerts for a subscription. */
+const HF_ALERT_DEBOUNCE_HOURS = 6;
+/** Snapshot retention window. */
+const SNAPSHOT_RETENTION_DAYS = 365;
 
 interface Env {
   DB: D1Database;
@@ -112,16 +124,29 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
   const target = validateAlertTarget(pool_id, asset_symbol, leverage_bracket);
   if (!target.ok) return jsonResponse({ ok: false, error: target.error }, 400, env);
 
+  // Alert channel + optional HF threshold.
+  const alertType = (body.alert_type ?? "apy") as string;
+  if (!["apy", "hf", "liquidation"].includes(alertType)) {
+    return jsonResponse({ ok: false, error: "Invalid alert_type" }, 400, env);
+  }
+  let hfThreshold: number | null = null;
+  if (alertType === "hf") {
+    hfThreshold = Number(body.hf_threshold);
+    if (!Number.isFinite(hfThreshold) || hfThreshold <= 1) {
+      return jsonResponse({ ok: false, error: "hf_threshold must be > 1 for the 'hf' channel" }, 400, env);
+    }
+  }
+
   const verifyToken = generateToken();
   const unsubToken  = generateToken();
 
   try {
     await env.DB.prepare(`
-      INSERT INTO subscriptions (email, pool_id, asset_symbol, leverage_bracket, verify_token, unsub_token)
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-      ON CONFLICT(email, pool_id, asset_symbol, leverage_bracket) DO UPDATE
-        SET verify_token = ?5, unsub_token = ?6, verified = 0
-    `).bind(email, pool_id, asset_symbol, target.lev, verifyToken, unsubToken).run();
+      INSERT INTO subscriptions (email, pool_id, asset_symbol, leverage_bracket, verify_token, unsub_token, alert_type, hf_threshold)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+      ON CONFLICT(email, pool_id, asset_symbol, leverage_bracket, alert_type) DO UPDATE
+        SET verify_token = ?5, unsub_token = ?6, hf_threshold = ?8, verified = 0
+    `).bind(email, pool_id, asset_symbol, target.lev, verifyToken, unsubToken, alertType, hfThreshold).run();
   } catch (e: any) {
     console.error("DB insert failed:", e);
     return jsonResponse({ ok: false, error: "Database error" }, 500, env);
@@ -376,8 +401,90 @@ async function alertPushSubscribers(
   }
 }
 
+/** Persist a rate snapshot for the time-series endpoint + delta arrows. */
+async function writeSnapshot(env: Env, pool: { id: string }, asset: { symbol: string }, rates: ReserveRates): Promise<void> {
+  try {
+    await env.DB.prepare(`
+      INSERT INTO rate_snapshots
+        (pool_id, asset_symbol, net_supply_apr, net_borrow_cost, interest_supply_apr, interest_borrow_apr, blnd_supply_apr, blnd_borrow_apr, util, c_factor)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+    `).bind(
+      pool.id, asset.symbol, rates.netSupplyApr, rates.netBorrowCost,
+      rates.interestSupplyApr, rates.interestBorrowApr, rates.blndSupplyApr,
+      rates.blndBorrowApr, rates.util, rates.cFactor,
+    ).run();
+  } catch (e) {
+    console.error(`[cron] snapshot insert failed for ${asset.symbol}:`, e);
+  }
+}
+
+/** Fire HF / liquidation-imminent alerts for verified subscribers. */
+async function alertHfSubscribers(
+  env: Env,
+  pool: { id: string; name: string },
+  asset: { symbol: string },
+  rates: ReserveRates,
+  base: string,
+): Promise<void> {
+  let rows: any;
+  try {
+    rows = await env.DB.prepare(`
+      SELECT id, email, leverage_bracket, alert_type, hf_threshold, unsub_token, last_fired_at
+      FROM subscriptions
+      WHERE verified = 1 AND pool_id = ?1 AND asset_symbol = ?2 AND alert_type IN ('hf','liquidation')
+    `).bind(pool.id, asset.symbol).all();
+  } catch (e) {
+    console.error("[cron] HF subscriber query failed:", e);
+    return;
+  }
+
+  const nowMs = Date.now();
+  for (const row of rows?.results ?? []) {
+    const lev = Number(row.leverage_bracket);
+    const hf = computeHealthFactor(rates, lev);
+    const liquidation = row.alert_type === "liquidation";
+    const threshold = liquidation ? LIQUIDATION_HF : Number(row.hf_threshold);
+    if (!Number.isFinite(threshold) || hf >= threshold) continue;
+
+    // Debounce.
+    if (row.last_fired_at) {
+      const lastMs = Date.parse((row.last_fired_at as string).replace(" ", "T") + "Z");
+      if (Number.isFinite(lastMs) && nowMs - lastMs < HF_ALERT_DEBOUNCE_HOURS * 3600_000) continue;
+    }
+
+    const result = await sendHfAlert(
+      { RESEND_API_KEY: env.RESEND_API_KEY, RESEND_FROM: env.RESEND_FROM },
+      row.email,
+      {
+        poolName: pool.name,
+        assetSymbol: asset.symbol,
+        leverage: lev,
+        hf,
+        threshold,
+        liquidation,
+        unsubscribeUrl: `${base}/unsubscribe?token=${row.unsub_token}`,
+        appUrl: env.FRONTEND_ORIGIN,
+      },
+    );
+    if (result.ok) {
+      await env.DB.prepare(`UPDATE subscriptions SET last_fired_at = datetime('now') WHERE id = ?1`).bind(row.id).run();
+    }
+  }
+}
+
+/** Delete snapshots older than the retention window. */
+async function pruneSnapshots(env: Env): Promise<void> {
+  try {
+    await env.DB.prepare(
+      `DELETE FROM rate_snapshots WHERE recorded_at < datetime('now', ?1)`,
+    ).bind(`-${SNAPSHOT_RETENTION_DAYS} days`).run();
+  } catch (e) {
+    console.error("[cron] snapshot prune failed:", e);
+  }
+}
+
 async function handleCron(env: Env, requestBase?: string): Promise<void> {
-  console.log("[cron] APY alert check starting...");
+  console.log("[cron] rate snapshot + alert check starting...");
   const base = requestBase ?? "https://turbolong-alerts.workers.dev";
 
   for (const pool of POOLS) {
@@ -395,20 +502,59 @@ async function handleCron(env: Env, requestBase?: string): Promise<void> {
         continue;
       }
 
+      // Record the snapshot every tick (15 min).
+      await writeSnapshot(env, pool, asset, rates);
+
+      // APY-negative alerts.
       for (const bracket of LEVERAGE_BRACKETS) {
         const netApy = computeNetApy(rates, bracket);
-
         if (netApy >= 0) continue;
-
         console.log(`[cron] Negative APY: ${asset.symbol} at ${bracket}x on ${pool.name} = ${netApy.toFixed(2)}%`);
-
         await alertEmailSubscribers(env, pool, asset, bracket, netApy, rates, base);
         await alertPushSubscribers(env, pool, asset, bracket, netApy);
       }
+
+      // Health-factor + liquidation-imminent alerts.
+      await alertHfSubscribers(env, pool, asset, rates, base);
     }
   }
 
-  console.log("[cron] APY alert check complete.");
+  await pruneSnapshots(env);
+  console.log("[cron] rate snapshot + alert check complete.");
+}
+
+/**
+ * Public GET /snapshots — paginated rate time-series.
+ * Query: pool_id, asset (symbol), limit (≤500, default 100), before (id cursor).
+ */
+async function handleSnapshots(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const poolId = url.searchParams.get("pool_id");
+  const asset = url.searchParams.get("asset");
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? 100), 1), 500);
+  const before = url.searchParams.get("before");
+
+  const where: string[] = [];
+  const binds: any[] = [];
+  if (poolId) { where.push(`pool_id = ?${binds.length + 1}`); binds.push(poolId); }
+  if (asset) { where.push(`asset_symbol = ?${binds.length + 1}`); binds.push(asset); }
+  if (before) { where.push(`id < ?${binds.length + 1}`); binds.push(Number(before)); }
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  try {
+    const rows = await env.DB.prepare(
+      `SELECT id, pool_id, asset_symbol, recorded_at, net_supply_apr, net_borrow_cost,
+              interest_supply_apr, interest_borrow_apr, blnd_supply_apr, blnd_borrow_apr, util, c_factor
+       FROM rate_snapshots ${whereSql}
+       ORDER BY id DESC LIMIT ?${binds.length + 1}`,
+    ).bind(...binds, limit).all();
+    const results = rows?.results ?? [];
+    const nextCursor = results.length === limit ? (results[results.length - 1] as any).id : null;
+    return jsonResponse({ snapshots: results, nextCursor }, 200, env);
+  } catch (e) {
+    console.error("[snapshots] query failed:", e);
+    return jsonResponse({ error: "Database error" }, 500, env);
+  }
 }
 
 // ── Worker entry ─────────────────────────────────────────────────────────────
@@ -448,6 +594,12 @@ export default {
 
       case "/push/unsubscribe":
         return handlePushUnsubscribe(request, env);
+
+      case "/snapshots":
+        if (request.method !== "GET") {
+          return jsonResponse({ error: "Method not allowed" }, 405, env);
+        }
+        return handleSnapshots(request, env);
 
       default:
         return jsonResponse({ error: "Not found" }, 404);

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -9,11 +9,22 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   unsub_token TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   last_alerted_at TEXT,
-  UNIQUE(email, pool_id, asset_symbol, leverage_bracket)
+  -- Alert channel: 'apy' (default, net-APY went negative), 'hf'
+  -- (health factor below hf_threshold), 'liquidation' (HF < 1.05),
+  -- 'rate_spike' (reserved).
+  alert_type TEXT NOT NULL DEFAULT 'apy',
+  -- HF threshold for the 'hf' channel (e.g. 1.10).
+  hf_threshold REAL,
+  -- Last time any alert fired for this row (debounce).
+  last_fired_at TEXT,
+  UNIQUE(email, pool_id, asset_symbol, leverage_bracket, alert_type)
 );
 
 CREATE INDEX IF NOT EXISTS idx_subs_pool_asset_lev
   ON subscriptions(pool_id, asset_symbol, leverage_bracket);
+
+CREATE INDEX IF NOT EXISTS idx_subs_alert_type
+  ON subscriptions(alert_type);
 
 CREATE TABLE IF NOT EXISTS push_subscriptions (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -31,3 +42,24 @@ CREATE TABLE IF NOT EXISTS push_subscriptions (
 
 CREATE INDEX IF NOT EXISTS idx_push_subs_pool_asset_lev
   ON push_subscriptions(pool_id, asset_symbol, leverage_bracket);
+
+-- Historical rate snapshots, written every cron tick (15 min). Powers the
+-- public time-series endpoint and the 24h/7d delta arrows (Tranche 3) and the
+-- Aquarius comparison view. Pruned to a 365-day retention window.
+CREATE TABLE IF NOT EXISTS rate_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pool_id TEXT NOT NULL,
+  asset_symbol TEXT NOT NULL,
+  recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+  net_supply_apr REAL NOT NULL,
+  net_borrow_cost REAL NOT NULL,
+  interest_supply_apr REAL NOT NULL,
+  interest_borrow_apr REAL NOT NULL,
+  blnd_supply_apr REAL NOT NULL,
+  blnd_borrow_apr REAL NOT NULL,
+  util REAL NOT NULL,
+  c_factor REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_pool_asset_time
+  ON rate_snapshots(pool_id, asset_symbol, recorded_at);

--- a/alerts/src/stellar.ts
+++ b/alerts/src/stellar.ts
@@ -72,18 +72,6 @@ function addressToScVal(addr: string): string {
   return JSON.stringify({ type: "Address", value: addr });
 }
 
-/** Build a simulateTransaction JSON-RPC request body. */
-function buildSimulateBody(contractId: string, method: string, args: any[]): object {
-  return {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "simulateTransaction",
-    params: {
-      transaction: buildInvokeXdr(contractId, method, args),
-    },
-  };
-}
-
 // We need proper XDR encoding. Since we can't use the SDK in a worker easily,
 // we'll use the soroban-rpc's native JSON interface via stellar-sdk-like encoding.
 // Actually, the simplest approach: build a minimal transaction envelope in base64.
@@ -101,6 +89,10 @@ export interface ReserveRates {
   interestBorrowApr: number;
   blndSupplyApr: number;
   blndBorrowApr: number;
+  /** Current pool utilisation (0..1). */
+  util: number;
+  /** Collateral factor (0..1). */
+  cFactor: number;
 }
 
 /** Simulate a contract call and return the decoded result. */
@@ -217,6 +209,8 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
     const blndSupplyApr = totalSupplyUsd > 0 ? (supplyBlndYr * blndPrice / totalSupplyUsd) * 100 : 0;
     const blndBorrowApr = totalBorrowUsd > 0 ? (borrowBlndYr * blndPrice / totalBorrowUsd) * 100 : 0;
 
+    const cFactor = (reserveRaw.config?.c_factor ?? 9_500_000) / SCALAR;
+
     return {
       netSupplyApr:     interestSupplyApr + blndSupplyApr,
       netBorrowCost:    interestBorrowApr - blndBorrowApr,
@@ -224,6 +218,8 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
       interestBorrowApr,
       blndSupplyApr,
       blndBorrowApr,
+      util,
+      cFactor,
     };
   } catch (e) {
     console.error(`fetchReserveRates failed for ${asset.symbol} on ${pool.name}:`, e);
@@ -234,4 +230,17 @@ export async function fetchReserveRates(pool: PoolDef, asset: { id: string; symb
 /** Compute net APY at a given leverage. */
 export function computeNetApy(rates: ReserveRates, leverage: number): number {
   return rates.netSupplyApr * leverage - rates.netBorrowCost * (leverage - 1);
+}
+
+/**
+ * Nominal health factor of a recursive-loop position at a given leverage.
+ *
+ * For leverage L the position holds supply = L·equity, debt = (L−1)·equity, so
+ * HF = (supply · cFactor) / debt = L·cFactor / (L−1). Returns +Infinity for
+ * L ≤ 1 (no debt). This is the bracket's HF given the pool's current collateral
+ * factor — it falls as cFactor drops or leverage rises.
+ */
+export function computeHealthFactor(rates: ReserveRates, leverage: number): number {
+  if (leverage <= 1) return Number.POSITIVE_INFINITY;
+  return (leverage * rates.cFactor) / (leverage - 1);
 }


### PR DESCRIPTION
**SCF #43 Tranche 2, Deliverable 5** — historical APY storage + new alert channels ($3k).

## (a) Historical rate storage
- **`rate_snapshots`** D1 table — the existing **15-min cron** writes one row per pool/asset each tick (net / interest / BLND APRs, util, c_factor).
- **Public `GET /snapshots`** — paginated time-series: `?pool_id=&asset=&limit=<=500&before=<id cursor>` → `{ snapshots, nextCursor }`. Powers the 24h/7d delta arrows + Aquarius comparison view in Tranche 3.
- **365-day retention** — cron prunes older rows each tick.

## (b) HF + liquidation-imminent channels
- `subscriptions` extended: **`alert_type`** (`'apy'|'hf'|'liquidation'`), **`hf_threshold`**, **`last_fired_at`** (debounce). UNIQUE now includes `alert_type`, so a user can hold multiple channels for one target.
- Nominal HF per bracket = `L·cFactor/(L−1)` (`ReserveRates` now carries `util` + `cFactor`). The cron fires **`hf`** (HF < `hf_threshold`) and **`liquidation`** (HF < 1.05) alerts to verified subscribers, **debounced 6h**, via a new `sendHfAlert` email. `/subscribe` accepts `alert_type` + `hf_threshold`.
- **`migrations/0001_*.sql`** — ALTER + CREATE to apply against the existing prod D1 (fresh deploys get it from `schema.sql`).

## Drive-by
Removed dead `buildSimulateBody()` in `stellar.ts` referencing an undefined `buildInvokeXdr` — a latent error flagged in earlier reviews; the live path uses `encodeInvokeTransaction`.

## Verification
- `wrangler deploy --dry-run` builds (52.6 KiB); `tsc` clean for changed files (only repo-wide pre-existing `.ts`-extension warnings remain).

## Time/production-gated (per acceptance)
≥30 days of accumulated snapshots and a live-fired HF alert are verified post-deploy. After merge, run the migration once: `wrangler d1 execute turbolong-alerts --remote --file=alerts/migrations/0001_t2_historical_apy_hf_alerts.sql`.