### PR TITLE
feat(alerts): swap_routes A/B telemetry (SCF T2.1 Phase A)

### DIFF
--- a/alerts/migrations/0002_swap_routes.sql
+++ b/alerts/migrations/0002_swap_routes.sql
@@ -1,0 +1,29 @@
+-- SCF T2.1 — Broker-vs-Soroswap A/B routing telemetry.
+--
+-- Run ONCE against the existing production D1 (fresh deploys get it from
+-- src/schema.sql):
+--   wrangler d1 execute turbolong-alerts --remote \
+--     --file=migrations/0002_swap_routes.sql
+
+CREATE TABLE IF NOT EXISTS swap_routes (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts             TEXT NOT NULL DEFAULT (datetime('now')),
+  network        TEXT NOT NULL DEFAULT 'mainnet',
+  strategy_id    TEXT NOT NULL,
+  asset_symbol   TEXT NOT NULL,
+  amount_in      TEXT NOT NULL,
+  broker_quote   TEXT,
+  soroswap_quote TEXT,
+  chosen         TEXT NOT NULL,
+  reason         TEXT NOT NULL,
+  executed_out   TEXT,
+  amount_out_min TEXT NOT NULL,
+  slippage_bps   INTEGER,
+  uplift_bps     INTEGER,
+  tx_hash        TEXT,
+  keeper         TEXT,
+  status         TEXT NOT NULL DEFAULT 'executed'
+);
+
+CREATE INDEX IF NOT EXISTS idx_swap_routes_ts ON swap_routes(ts);
+CREATE INDEX IF NOT EXISTS idx_swap_routes_net_strat ON swap_routes(network, strategy_id);

--- a/alerts/src/index.ts
+++ b/alerts/src/index.ts
@@ -12,6 +12,10 @@
  *   GET  /push/unsubscribe?token= — remove web-push subscription
  *   GET  /snapshots              — paginated rate time-series
  *                                  (?pool_id=&asset=&limit=&before=)
+ *   GET  /swap-routes            — Broker-vs-Soroswap A/B report
+ *                                  (?network=&strategy_id=&limit=)
+ *   POST /swap-routes            — keeper ingests one routing record
+ *                                  (Authorization: Bearer KEEPER_INGEST_KEY)
  *
  * Cron (every 15 min):
  *   Fetch pool reserve rates → write a rate_snapshots row → APY-negative alerts
@@ -37,6 +41,8 @@ interface Env {
   VAPID_PUBLIC_KEY: string;
   VAPID_PRIVATE_KEY: string;
   VAPID_SUBJECT?: string;
+  /** Shared secret the keeper sends to POST /swap-routes (Authorization: Bearer). */
+  KEEPER_INGEST_KEY?: string;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -557,6 +563,116 @@ async function handleSnapshots(request: Request, env: Env): Promise<Response> {
   }
 }
 
+// ── Swap-route A/B telemetry (T2.1) ──────────────────────────────────────────
+
+/**
+ * POST /swap-routes — keeper ingests one Broker-vs-Soroswap routing record.
+ * Auth: `Authorization: Bearer <KEEPER_INGEST_KEY>` (financial telemetry write).
+ */
+async function handleSwapRoutesPost(request: Request, env: Env): Promise<Response> {
+  if (!env.KEEPER_INGEST_KEY) {
+    return jsonResponse({ ok: false, error: "Ingestion not configured" }, 503, env);
+  }
+  const auth = request.headers.get("Authorization") ?? "";
+  if (auth !== `Bearer ${env.KEEPER_INGEST_KEY}`) {
+    return jsonResponse({ ok: false, error: "Unauthorized" }, 401, env);
+  }
+
+  let b: any;
+  try {
+    b = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: "Invalid JSON" }, 400, env);
+  }
+
+  // Required fields.
+  for (const f of ["strategy_id", "asset_symbol", "amount_in", "chosen", "reason", "amount_out_min"]) {
+    if (b[f] == null || b[f] === "") {
+      return jsonResponse({ ok: false, error: `Missing field: ${f}` }, 400, env);
+    }
+  }
+  if (!["broker", "soroswap"].includes(b.chosen)) {
+    return jsonResponse({ ok: false, error: "chosen must be 'broker' or 'soroswap'" }, 400, env);
+  }
+
+  try {
+    await env.DB.prepare(`
+      INSERT INTO swap_routes
+        (network, strategy_id, asset_symbol, amount_in, broker_quote, soroswap_quote,
+         chosen, reason, executed_out, amount_out_min, slippage_bps, uplift_bps, tx_hash, keeper, status)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+    `).bind(
+      b.network ?? "mainnet", b.strategy_id, b.asset_symbol, String(b.amount_in),
+      b.broker_quote != null ? String(b.broker_quote) : null,
+      b.soroswap_quote != null ? String(b.soroswap_quote) : null,
+      b.chosen, b.reason,
+      b.executed_out != null ? String(b.executed_out) : null,
+      String(b.amount_out_min),
+      b.slippage_bps != null ? Math.round(Number(b.slippage_bps)) : null,
+      b.uplift_bps != null ? Math.round(Number(b.uplift_bps)) : null,
+      b.tx_hash ?? null, b.keeper ?? null, b.status ?? "executed",
+    ).run();
+  } catch (e) {
+    console.error("[swap-routes] insert failed:", e);
+    return jsonResponse({ ok: false, error: "Database error" }, 500, env);
+  }
+  return jsonResponse({ ok: true }, 200, env);
+}
+
+/**
+ * GET /swap-routes — public A/B report. Aggregates the Broker-vs-Soroswap
+ * win-rate + uplift over executed mainnet harvests, plus the recent rows.
+ * Query: network (default mainnet), strategy_id, limit (≤500).
+ */
+async function handleSwapRoutesGet(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const network = url.searchParams.get("network") ?? "mainnet";
+  const strategyId = url.searchParams.get("strategy_id");
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? 100), 1), 500);
+
+  const filter: string[] = [`network = ?1`];
+  const binds: any[] = [network];
+  if (strategyId) { filter.push(`strategy_id = ?${binds.length + 1}`); binds.push(strategyId); }
+  const whereSql = `WHERE ${filter.join(" AND ")}`;
+
+  try {
+    const agg = await env.DB.prepare(`
+      SELECT
+        COUNT(*) AS total,
+        SUM(CASE WHEN status = 'executed' THEN 1 ELSE 0 END) AS executed,
+        SUM(CASE WHEN status = 'executed' AND chosen = 'broker' THEN 1 ELSE 0 END) AS broker_wins,
+        AVG(CASE WHEN status = 'executed' THEN uplift_bps END) AS avg_uplift_bps,
+        AVG(CASE WHEN status = 'executed' THEN slippage_bps END) AS avg_slippage_bps
+      FROM swap_routes ${whereSql}
+    `).bind(...binds).first<any>();
+
+    const rows = await env.DB.prepare(`
+      SELECT id, ts, network, strategy_id, asset_symbol, amount_in, broker_quote, soroswap_quote,
+             chosen, reason, executed_out, amount_out_min, slippage_bps, uplift_bps, tx_hash, status
+      FROM swap_routes ${whereSql}
+      ORDER BY id DESC LIMIT ?${binds.length + 1}
+    `).bind(...binds, limit).all();
+
+    const executed = Number(agg?.executed ?? 0);
+    const brokerWins = Number(agg?.broker_wins ?? 0);
+    return jsonResponse({
+      report: {
+        network,
+        total: Number(agg?.total ?? 0),
+        executed,
+        broker_wins: brokerWins,
+        broker_win_rate: executed > 0 ? brokerWins / executed : null,
+        avg_uplift_bps: agg?.avg_uplift_bps ?? null,
+        avg_slippage_bps: agg?.avg_slippage_bps ?? null,
+      },
+      rows: rows?.results ?? [],
+    }, 200, env);
+  } catch (e) {
+    console.error("[swap-routes] query failed:", e);
+    return jsonResponse({ error: "Database error" }, 500, env);
+  }
+}
+
 // ── Worker entry ─────────────────────────────────────────────────────────────
 
 export default {
@@ -600,6 +716,11 @@ export default {
           return jsonResponse({ error: "Method not allowed" }, 405, env);
         }
         return handleSnapshots(request, env);
+
+      case "/swap-routes":
+        if (request.method === "POST") return handleSwapRoutesPost(request, env);
+        if (request.method === "GET") return handleSwapRoutesGet(request, env);
+        return jsonResponse({ error: "Method not allowed" }, 405, env);
 
       default:
         return jsonResponse({ error: "Not found" }, 404);

--- a/alerts/src/schema.sql
+++ b/alerts/src/schema.sql
@@ -63,3 +63,29 @@ CREATE TABLE IF NOT EXISTS rate_snapshots (
 
 CREATE INDEX IF NOT EXISTS idx_snapshots_pool_asset_time
   ON rate_snapshots(pool_id, asset_symbol, recorded_at);
+
+-- A/B routing telemetry: one row per harvest swap comparing Stellar Broker vs
+-- Soroswap quotes + the executed result (SCF T2.1). Public read endpoint powers
+-- the Broker-vs-Soroswap win-rate / uplift report.
+CREATE TABLE IF NOT EXISTS swap_routes (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts             TEXT NOT NULL DEFAULT (datetime('now')),
+  network        TEXT NOT NULL DEFAULT 'mainnet',   -- only 'mainnet' counts toward the ≥50
+  strategy_id    TEXT NOT NULL,
+  asset_symbol   TEXT NOT NULL,
+  amount_in      TEXT NOT NULL,                       -- BLND in (stroops, i128 as string)
+  broker_quote   TEXT,                                -- estimated underlying out, NULL if unavailable
+  soroswap_quote TEXT,                                -- router_get_amounts_out, NULL if unavailable
+  chosen         TEXT NOT NULL,                       -- 'broker' | 'soroswap'
+  reason         TEXT NOT NULL,                       -- 'best' | 'fallback_unavailable' | 'fallback_worse' | 'fallback_error'
+  executed_out   TEXT,                                -- actual underlying received
+  amount_out_min TEXT NOT NULL,                       -- min-output enforced on the executed path
+  slippage_bps   INTEGER,                             -- (chosen_quote - executed_out)/chosen_quote * 1e4
+  uplift_bps     INTEGER,                             -- (chosen_quote - other_quote)/other_quote * 1e4, signed
+  tx_hash        TEXT,
+  keeper         TEXT,
+  status         TEXT NOT NULL DEFAULT 'executed'     -- 'executed' | 'quote_only' | 'failed'
+);
+
+CREATE INDEX IF NOT EXISTS idx_swap_routes_ts ON swap_routes(ts);
+CREATE INDEX IF NOT EXISTS idx_swap_routes_net_strat ON swap_routes(network, strategy_id);


### PR DESCRIPTION
**SCF #43 Tranche 2, Deliverable 1 (Stellar Broker) — Phase A.** Stacked on #267 (T2.5 alerts), since both touch `alerts/`; rebases onto main when #267 merges.

The A/B logging infrastructure for Broker-vs-Soroswap harvest routing:
- **`swap_routes` D1 table** — per-harvest `broker_quote`, `soroswap_quote`, `chosen`, `reason`, `executed_out`, `slippage_bps`, `uplift_bps`, `tx_hash`, `status`, `network`. Migration `0002` for the existing prod DB.
- **`POST /swap-routes`** — the keeper ingests a record; **auth-gated** via `Authorization: Bearer KEEPER_INGEST_KEY` (financial-telemetry write; secret set with `wrangler secret put`).
- **`GET /swap-routes`** — **public A/B report**: Broker win-rate + avg `uplift_bps` + avg `slippage_bps` over executed mainnet harvests, plus recent rows. This endpoint **is** the deliverable's A/B report, served live.

## Verification
- `wrangler deploy --dry-run` builds (56.9 KiB); `tsc` clean for changed files.

## Rest of T2.1
- **Phase B** (next): contract harvest-split (`harvest_claim` + `harvest_reinvest`).
- **Phase C**: keeper `scripts/harvest_router.ts` (dual-quote, best-route, dry-run logs real mainnet quotes → POSTs here).
- **Phase D** (mainnet-gated): ≥50 executed harvests.