### PR TITLE
feat(contracts): split harvest for pluggable swap routing (SCF T2.1 Phase B)

### DIFF
--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -459,6 +459,25 @@ pub fn perform_reinvest(
     Ok((b_delta, d_delta, amount_out))
 }
 
+/// Re-leverage `amount` of the underlying asset that is already held by the
+/// strategy (the Stellar Broker harvest path: the keeper swapped BLND→underlying
+/// off-chain and transferred the proceeds back). No on-chain swap. Asserts the
+/// contract actually holds at least `amount` of underlying before leveraging.
+pub fn reinvest_underlying(
+    e: &Env,
+    config: &Config,
+    amount: i128,
+) -> Result<(i128, i128), StrategyError> {
+    if amount <= 0 {
+        return Ok((0, 0));
+    }
+    let held = TokenClient::new(e, &config.asset).balance(&e.current_contract_address());
+    if held < amount {
+        return Err(StrategyError::InsufficientBalance);
+    }
+    submit_leverage_loop(e, amount, config)
+}
+
 // ── Pool state queries ───────────────────────────────────────────────────────
 
 /// Fetch current b_rate and d_rate for the configured asset.

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -564,4 +564,123 @@ impl BlendLeverageStrategy {
         storage::set_vault_shares(&e, &holder, 0);
         Ok(legacy)
     }
+
+    // ── Split harvest for pluggable swap routing (T2.1) ──────────────────────
+    //
+    // The DeFindex-trait `harvest` stays as the atomic on-chain Soroswap path.
+    // These keeper entrypoints let an off-chain keeper choose the best swap venue
+    // per harvest (Stellar Broker vs Soroswap): `harvest_claim` claims BLND and
+    // approves the keeper's swap account to pull it (for an off-chain Broker swap)
+    // while leaving it recoverable for the on-chain Soroswap fallback;
+    // `harvest_reinvest` executes whichever path the keeper chose and re-leverages.
+
+    /// Set the keeper-controlled account allowed to pull claimed BLND for an
+    /// off-chain swap (admin-gated).
+    pub fn set_swap_account(e: Env, account: Address) -> Result<(), StrategyError> {
+        storage::get_admin(&e).require_auth();
+        storage::set_swap_account(&e, &account);
+        extend_instance_ttl(&e);
+        Ok(())
+    }
+
+    /// The configured swap account, or an error if unset.
+    pub fn swap_account(e: Env) -> Result<Address, StrategyError> {
+        if storage::has_swap_account(&e) {
+            Ok(storage::get_swap_account(&e))
+        } else {
+            Err(StrategyError::NotAuthorized)
+        }
+    }
+
+    /// Keeper-gated: claim BLND emissions into the strategy and approve the swap
+    /// account to pull them (if set) for an off-chain Broker swap. The BLND stays
+    /// in the contract until pulled, so the on-chain Soroswap path remains a valid
+    /// fallback. Returns the BLND balance available to swap.
+    pub fn harvest_claim(e: Env, from: Address) -> Result<i128, StrategyError> {
+        extend_instance_ttl(&e);
+        let keeper = storage::get_keeper(&e);
+        keeper.require_auth();
+        if from != keeper {
+            return Err(StrategyError::NotAuthorized);
+        }
+
+        let config = storage::get_config(&e);
+        blend_pool::claim(&e, &config);
+
+        let blnd = TokenClient::new(&e, &config.blend_token);
+        let bal = blnd.balance(&e.current_contract_address());
+        if bal > 0 && storage::has_swap_account(&e) {
+            let expiration = e.ledger().sequence().saturating_add(17_280); // ~1 day
+            blnd.approve(
+                &e.current_contract_address(),
+                &storage::get_swap_account(&e),
+                &bal,
+                &expiration,
+            );
+        }
+
+        e.events()
+            .publish((Symbol::new(&e, "harvest_claim"), keeper), bal);
+        Ok(bal)
+    }
+
+    /// Keeper-gated: re-leverage harvested proceeds via the chosen route.
+    ///
+    /// - `via_soroswap = true`: swap the strategy's BLND → underlying on-chain
+    ///   through Soroswap (mandatory non-zero `amount_out_min`), then re-leverage.
+    /// - `via_soroswap = false` (Broker): the keeper has already swapped off-chain
+    ///   and transferred `amount_in` of underlying back to the strategy; re-leverage
+    ///   it directly (asserted to be held). `amount_out_min` is ignored here.
+    ///
+    /// Emits a `harvest_route` event `(route, amount_in, amount_out_min, realized)`
+    /// for the keeper's A/B telemetry. Returns realized underlying re-leveraged.
+    pub fn harvest_reinvest(
+        e: Env,
+        from: Address,
+        amount_in: i128,
+        via_soroswap: bool,
+        amount_out_min: i128,
+    ) -> Result<i128, StrategyError> {
+        extend_instance_ttl(&e);
+        let keeper = storage::get_keeper(&e);
+        keeper.require_auth();
+        if from != keeper {
+            return Err(StrategyError::NotAuthorized);
+        }
+        check_positive_amount(amount_in)?;
+        let config = storage::get_config(&e);
+
+        let (b_delta, d_delta, realized) = if via_soroswap {
+            // Mandatory slippage protection on the on-chain swap.
+            if amount_out_min <= 0 {
+                return Err(StrategyError::OnlyPositiveAmountAllowed);
+            }
+            blend_pool::perform_reinvest(&e, &config, amount_out_min)?
+        } else {
+            let (b, d) = blend_pool::reinvest_underlying(&e, &config, amount_in)?;
+            (b, d, amount_in)
+        };
+
+        if b_delta > 0 {
+            let updated = reserves::harvest(&e, b_delta, d_delta, &config)?;
+            event::emit_harvest(
+                &e,
+                String::from_str(&e, STRATEGY_NAME),
+                realized,
+                keeper.clone(),
+                shares_to_underlying(SCALAR_12, &updated)?,
+            );
+        }
+
+        e.events().publish(
+            (Symbol::new(&e, "harvest_route"), keeper),
+            (
+                if via_soroswap { 0u32 } else { 1u32 },
+                amount_in,
+                amount_out_min,
+                realized,
+            ),
+        );
+        Ok(realized)
+    }
 }

--- a/contracts/strategies/blend_leverage/src/storage.rs
+++ b/contracts/strategies/blend_leverage/src/storage.rs
@@ -28,6 +28,9 @@ pub enum DataKey {
     ShareToken,
     /// Ledger sequence of the last keeper rebalance (for rate-limiting).
     LastRebalance,
+    /// Keeper-controlled account allowed to pull claimed BLND for an off-chain
+    /// (Stellar Broker) swap during the split harvest flow.
+    SwapAccount,
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -198,6 +201,23 @@ pub fn get_last_rebalance(e: &Env) -> u32 {
         .instance()
         .get(&DataKey::LastRebalance)
         .unwrap_or(0)
+}
+
+// ── Swap account (off-chain Broker harvest path) ─────────────────────────────
+
+pub fn set_swap_account(e: &Env, account: &Address) {
+    e.storage().instance().set(&DataKey::SwapAccount, account);
+}
+
+pub fn get_swap_account(e: &Env) -> Address {
+    e.storage()
+        .instance()
+        .get(&DataKey::SwapAccount)
+        .expect("swap account not set")
+}
+
+pub fn has_swap_account(e: &Env) -> bool {
+    e.storage().instance().has(&DataKey::SwapAccount)
 }
 
 // ── Instance TTL ─────────────────────────────────────────────────────────────

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -877,3 +877,60 @@ fn test_rebalance_keeper_auth_gating_and_noop() {
     // The permissionless rebalance is also a safe no-op with no position.
     sclient.rebalance();
 }
+
+// ── Split harvest entrypoints (T2.1) — auth gating + swap account ─────────────
+
+#[test]
+fn test_set_swap_account_admin_and_getter() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+
+    // Unset → error.
+    assert!(sclient.try_swap_account().is_err());
+
+    let swap_acct = Address::generate(&e);
+    sclient.set_swap_account(&swap_acct);
+    assert_eq!(sclient.swap_account(), swap_acct);
+}
+
+#[test]
+fn test_split_harvest_rejects_non_keeper() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+    let stranger = Address::generate(&e);
+
+    assert!(
+        sclient.try_harvest_claim(&stranger).is_err(),
+        "harvest_claim: non-keeper rejected"
+    );
+    assert!(
+        sclient
+            .try_harvest_reinvest(&stranger, &1_000, &true, &900)
+            .is_err(),
+        "harvest_reinvest: non-keeper rejected"
+    );
+}
+
+#[test]
+fn test_harvest_reinvest_soroswap_requires_min_out() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+    let keeper = sclient.get_keeper();
+
+    // via_soroswap with amount_out_min = 0 must be rejected (mandatory slippage).
+    assert!(
+        sclient
+            .try_harvest_reinvest(&keeper, &1_000, &true, &0)
+            .is_err(),
+        "soroswap path requires non-zero amount_out_min"
+    );
+}


### PR DESCRIPTION
**SCF #43 Tranche 2, Deliverable 1 (Stellar Broker) — Phase B.** Stacked on #265 (T2.2/T2.3 contract); rebases onto main when #265 merges.

Enables per-harvest **Broker-vs-Soroswap** routing **without losing the audited atomic re-leverage**. The DeFindex-trait `harvest()` is untouched (still the on-chain Soroswap path — backward compatible); two new keeper entrypoints add the Broker-capable flow:

- **`harvest_claim(from)`** — keeper-gated. Claims BLND into the strategy and, if a `swap_account` is set, **approves** it to pull the BLND for an off-chain Broker swap. BLND stays in the contract until pulled, so the on-chain Soroswap path stays a valid **fallback**. Emits `harvest_claim`.
- **`harvest_reinvest(from, amount_in, via_soroswap, amount_out_min)`** — keeper-gated.
  - `via_soroswap = true` → on-chain Soroswap swap (**mandatory non-zero `amount_out_min`** — closes the old `data=0` zero-slippage gap), then re-leverage.
  - `via_soroswap = false` (Broker) → re-leverage `amount_in` of underlying the keeper already swapped off-chain and sent back (**asserted held**).
  - Emits `harvest_route(route, amount_in, amount_out_min, realized)` for the keeper's A/B telemetry.
- **`set_swap_account`** (admin) + `swap_account()` getter; `SwapAccount` storage. **No constructor change.**
- `blend_pool::reinvest_underlying` — re-leverage held underlying, no swap.

## Why this shape
Keeps the security-critical re-leverage atomic and on-chain; isolates Broker's off-chain/account-based nature in the keeper; makes the route a logged per-harvest event. (Phase C keeper decides the route off-chain and calls these.)

## Verification
- `cargo test` — **56/56** (set_swap_account admin+getter; split-harvest non-keeper rejection; soroswap-path mandatory min-out). `clippy -D warnings` clean; `fmt` clean; wasm builds.
- Full `claim→swap→reinvest` (both routes) is the **testnet rehearsal** (native harness doesn't run the Blend loop/emissions for the real strategy).

## Rest of T2.1
- **Phase A** (#268): `swap_routes` A/B table + endpoints.
- **Phase C** (next): keeper `scripts/harvest_router.ts` — dual-quote, best-route, calls these entrypoints, POSTs A/B rows. Dry-run logs real mainnet quotes now.
- **Phase D** (mainnet-gated): ≥50 executed harvests.