### PR TITLE
feat(scripts): mainnet vault deploy script (SCF T1 D1 prep)

### DIFF
--- a/docs/mainnet-go-live-runbook.md
+++ b/docs/mainnet-go-live-runbook.md
@@ -1,0 +1,89 @@
+# Turbolong mainnet go-live runbook
+
+The ordered, copy-pasteable steps to take Tranche 1/2 live once the open PRs are
+merged. **Every step touching mainnet is real funds** — do the dry-runs first and
+keep keys in a secrets manager (`op run`), never inlined or committed.
+
+Prerequisites you provide:
+- `KEEPER_PUBKEY` — funded mainnet account (XLM for fees) that runs harvest +
+  rebalance + pulls BLND for Broker swaps.
+- `ADMIN_PUBKEY` — admin (controls upgrades + `set_share_token`/`set_swap_account`);
+  ideally multisig/hardware.
+- `DEPLOY_SECRET_KEY` — deployer secret (pays deploy fees), via `op run`.
+- Sign-off on the per-asset config in `scripts/deploy_strategy_mainnet.ts`.
+
+---
+
+## 1. Apply the D1 database migrations (alerts Worker)
+
+Run once each against the production D1 (fresh DBs get the full schema from
+`alerts/src/schema.sql`):
+
+```bash
+cd alerts
+wrangler d1 execute turbolong-alerts --remote --file=migrations/0001_t2_historical_apy_hf_alerts.sql
+wrangler d1 execute turbolong-alerts --remote --file=migrations/0002_swap_routes.sql
+wrangler secret put KEEPER_INGEST_KEY   # generate a random token; the keeper sends it as Bearer
+```
+
+## 2. Build the contract WASMs
+
+```bash
+(cd contracts/strategies/blend_leverage && cargo build --target wasm32v1-none --release)
+(cd contracts/tokens/vault_share        && cargo build --target wasm32v1-none --release)
+```
+
+## 3. Deploy the 4 vaults (DRY-RUN, then live)
+
+```bash
+cd scripts && npm install
+# Dry-run first — simulates install/deploy, submits nothing:
+DRY_RUN=1 op run -- env \
+  DEPLOY_SECRET_KEY=op://<vault>/turbolong-deployer/secret \
+  ADMIN_PUBKEY=G... KEEPER_PUBKEY=G... \
+  npx tsx deploy_strategy_mainnet.ts
+
+# Live (real funds) — only after dry-run looks right and you've signed off config:
+op run -- env \
+  DEPLOY_SECRET_KEY=op://<vault>/turbolong-deployer/secret \
+  ADMIN_PUBKEY=G... KEEPER_PUBKEY=G... \
+  npx tsx deploy_strategy_mainnet.ts
+```
+
+Writes `deployed-vaults.mainnet.json` with `{strategy, token}` per asset. It also
+runs `set_share_token` + `set_swap_account` for each.
+
+## 4. Wire the frontend
+
+In `frontend/src/defindex.ts`, populate `MAINNET_VAULTS` from
+`deployed-vaults.mainnet.json` — one entry per asset with the strategy `vaultId`,
+the share-token address, `assetId`/`poolId`, and the matching config. Remove the
+placeholder. `npm run build` to confirm.
+
+## 5. End-to-end verification (per asset, small amounts)
+
+For each vault, on mainnet: `deposit → loop → withdraw`. Capture the tx hashes and
+confirm the b/d-token deltas on Stellar Expert. This satisfies D1's acceptance.
+Get the DeFindex team to co-sign the deployments.
+
+## 6. Stand up the keeper (T2.1 / T2.3)
+
+- **Dry-run now (no key, Cloudflare cron or a cheap CI):** run
+  `scripts/harvest_router.ts` (default mode) with `SWAP_ROUTES_URL` +
+  `KEEPER_INGEST_KEY` set — it logs real Broker-vs-Soroswap quotes to
+  `/swap-routes`, building the A/B dataset before any execution.
+- **Live execution (dedicated Node service):** point `VAULTS_JSON` at the deployed
+  strategy IDs, supply `KEEPER_SECRET` behind a secrets manager / remote signer,
+  and run with `--execute`. Schedule harvest + `rebalance_keeper` calls. (Do NOT
+  put live signing on a GitHub Action — flaky cron + key-on-CI.)
+- Accumulate ≥50 executed mainnet harvests → the `GET /swap-routes` report is the
+  T2.1 A/B deliverable; the same keeper firing `rebalance_keeper` produces the
+  T2.3 live mainnet rebalance.
+
+## 7. Tranche reporting
+
+- Demonstrate the gitleaks gate: open a throwaway PR planting a fake `S…` secret,
+  confirm `secret-scan` blocks it, screenshot, close it (D5 acceptance).
+- File the SCF Tranche-1 completion report with the on-chain artifacts (4 vault IDs,
+  deposit→loop→withdraw tx hashes, token addresses, test reports) and notify SCF of
+  the revised completion dates.

--- a/scripts/deploy_strategy_mainnet.ts
+++ b/scripts/deploy_strategy_mainnet.ts
@@ -36,6 +36,9 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 const RPC_URL = process.env.RPC_URL ?? "https://mainnet.sorobanrpc.com";
 const PASSPHRASE = Networks.PUBLIC;
@@ -82,8 +85,8 @@ const ASSETS: AssetCfg[] = [
   { symbol: "XLM",   asset: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA", cFactor: 7_000_000n, targetLoops: 2, minHf: 11_000_000n, orangeHf: 12_000_000n },
 ];
 
-const STRATEGY_WASM = path.resolve(__dirname, "../contracts/strategies/blend_leverage/target/wasm32v1-none/release/blend_leverage_strategy.wasm");
-const TOKEN_WASM = path.resolve(__dirname, "../contracts/tokens/vault_share/target/wasm32v1-none/release/vault_share_token.wasm");
+const STRATEGY_WASM = path.resolve(here, "../contracts/strategies/blend_leverage/target/wasm32v1-none/release/blend_leverage_strategy.wasm");
+const TOKEN_WASM = path.resolve(here, "../contracts/tokens/vault_share/target/wasm32v1-none/release/vault_share_token.wasm");
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -198,7 +201,7 @@ async function main() {
     out[a.symbol] = { strategy, token };
   }
 
-  const file = path.resolve(__dirname, "../deployed-vaults.mainnet.json");
+  const file = path.resolve(here, "../deployed-vaults.mainnet.json");
   fs.writeFileSync(file, JSON.stringify(out, null, 2));
   console.log(`\nDeployed vaults written to ${file}`);
   console.log("Next: wire frontend/src/defindex.ts MAINNET_VAULTS, verify deposit→loop→withdraw on Stellar Expert, get DeFindex co-sign.");

--- a/scripts/deploy_strategy_mainnet.ts
+++ b/scripts/deploy_strategy_mainnet.ts
@@ -1,0 +1,211 @@
+/**
+ * Deploy the Turbolong BlendLeverage vaults to Stellar MAINNET — SCF T1 D1.
+ *
+ * For each of the four assets (USDC, USTRY, CETES, XLM) on the Etherfuse pool it:
+ *   1. deploys the blend_leverage strategy (10-arg constructor),
+ *   2. deploys its SEP-41 vault-share token (minter = the strategy),
+ *   3. wires strategy.set_share_token(token),
+ *   4. wires strategy.set_swap_account(keeper) for the Broker harvest path,
+ * then writes every deployed contract ID to deployed-vaults.mainnet.json.
+ *
+ * REAL FUNDS. Never commit a mainnet key. Run with a secure signer, e.g.:
+ *   op run -- env DEPLOY_SECRET_KEY=op://vault/turbolong-deployer/secret \
+ *     ADMIN_PUBKEY=G... KEEPER_PUBKEY=G... npx tsx scripts/deploy_strategy_mainnet.ts
+ *
+ * Env:
+ *   DEPLOY_SECRET_KEY  S... deployer (pays fees, installs WASM, deploys)
+ *   ADMIN_PUBKEY       G... admin (upgrade + set_share_token/set_swap_account); default = deployer
+ *   KEEPER_PUBKEY      G... keeper (harvest + rebalance_keeper + pulls BLND); REQUIRED
+ *   DRY_RUN=1          simulate only, do not submit
+ *
+ * Pre-req: build both wasms first —
+ *   (cd contracts/strategies/blend_leverage && cargo build --target wasm32v1-none --release)
+ *   (cd contracts/tokens/vault_share        && cargo build --target wasm32v1-none --release)
+ */
+import {
+  Address,
+  Contract,
+  Keypair,
+  Networks,
+  Operation,
+  rpc as SorobanRpc,
+  TransactionBuilder,
+  nativeToScVal,
+  xdr,
+} from "@stellar/stellar-sdk";
+import * as fs from "fs";
+import * as path from "path";
+import * as crypto from "crypto";
+
+const RPC_URL = process.env.RPC_URL ?? "https://mainnet.sorobanrpc.com";
+const PASSPHRASE = Networks.PUBLIC;
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+const SECRET = process.env.DEPLOY_SECRET_KEY;
+if (!SECRET) {
+  console.error("DEPLOY_SECRET_KEY is required (use op run / a secrets manager; never inline a mainnet key).");
+  process.exit(1);
+}
+const keypair = Keypair.fromSecret(SECRET);
+const deployer = keypair.publicKey();
+const ADMIN = process.env.ADMIN_PUBKEY ?? deployer;
+const KEEPER = process.env.KEEPER_PUBKEY;
+if (!KEEPER) {
+  console.error("KEEPER_PUBKEY is required (the account that runs harvest/rebalance).");
+  process.exit(1);
+}
+
+const server = new SorobanRpc.Server(RPC_URL);
+
+// ── Mainnet constants (sourced) ────────────────────────────────────────────────
+const POOL = "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI";   // Etherfuse pool
+const BLND = "CD25MNVTZDL4Y3XBCPCJXGXATV5WUHHOWMYFF4YBEGU5FCPGMYTVG5JY";   // mainnet BLND
+const ROUTER = "CAG5LRYQ5JVEUI5TEID72EYOVX44TTUJT5BQR2J6J77FH65PCCFAJDDH"; // Soroswap mainnet router
+
+// Per-asset config. `c_factor` is the strategy's own collateral factor (≤ the
+// pool's, leaving a borrow/HF buffer); pool c_factors read live were USDC 0.95,
+// USTRY 0.90, CETES 0.80, XLM 0.75. Risk params (loops/min_hf/orange_hf) are
+// proposed defaults — review before running. reward_threshold = 100 BLND.
+const REWARD_THRESHOLD = 1_000_000_000n; // 100 BLND @ 7dp
+interface AssetCfg {
+  symbol: string;
+  asset: string;
+  cFactor: bigint;   // 1e7
+  targetLoops: number;
+  minHf: bigint;     // 1e7
+  orangeHf: bigint;  // 1e7
+}
+const ASSETS: AssetCfg[] = [
+  { symbol: "USDC",  asset: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75", cFactor: 9_000_000n, targetLoops: 4, minHf: 10_500_000n, orangeHf: 11_500_000n },
+  { symbol: "USTRY", asset: "CBLV4ATSIWU67CFSQU2NVRKINQIKUZ2ODSZBUJTJ43VJVRSBTZYOPNUR", cFactor: 8_500_000n, targetLoops: 3, minHf: 10_500_000n, orangeHf: 11_500_000n },
+  { symbol: "CETES", asset: "CAL6ER2TI6CTRAY6BFXWNWA7WTYXUXTQCHUBCIBU5O6KM3HJFG6Z6VXV", cFactor: 7_500_000n, targetLoops: 3, minHf: 10_500_000n, orangeHf: 11_500_000n },
+  { symbol: "XLM",   asset: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA", cFactor: 7_000_000n, targetLoops: 2, minHf: 11_000_000n, orangeHf: 12_000_000n },
+];
+
+const STRATEGY_WASM = path.resolve(__dirname, "../contracts/strategies/blend_leverage/target/wasm32v1-none/release/blend_leverage_strategy.wasm");
+const TOKEN_WASM = path.resolve(__dirname, "../contracts/tokens/vault_share/target/wasm32v1-none/release/vault_share_token.wasm");
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function addr(a: string): xdr.ScVal {
+  return a.startsWith("C") ? new Contract(a).address().toScVal() : new Address(a).toScVal();
+}
+
+async function signSubmit(tx: any, label: string): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
+  const prepared = await server.prepareTransaction(tx);
+  if (DRY_RUN) {
+    console.log(`  [dry-run] ${label} prepared (not submitted)`);
+    throw new Error("DRY_RUN");
+  }
+  prepared.sign(keypair);
+  const sent = await server.sendTransaction(prepared);
+  let res = await server.getTransaction(sent.hash);
+  while (res.status === "NOT_FOUND") {
+    await new Promise((r) => setTimeout(r, 1500));
+    res = await server.getTransaction(sent.hash);
+  }
+  if (res.status !== "SUCCESS") {
+    throw new Error(`${label} failed: ${JSON.stringify(res).slice(0, 500)}`);
+  }
+  console.log(`  ✓ ${label}  tx=${sent.hash}`);
+  return res;
+}
+
+async function installWasm(wasmPath: string, label: string): Promise<string> {
+  const wasm = fs.readFileSync(wasmPath);
+  const acc = await server.getAccount(deployer);
+  const tx = new TransactionBuilder(acc, { fee: "10000000", networkPassphrase: PASSPHRASE })
+    .setTimeout(120)
+    .addOperation(Operation.uploadContractWasm({ wasm }))
+    .build();
+  const res = await signSubmit(tx, `install ${label} wasm`);
+  const hash = (res.returnValue as xdr.ScVal).bytes().toString("hex");
+  return hash;
+}
+
+async function deploy(wasmHash: string, constructorArgs: xdr.ScVal[], label: string): Promise<string> {
+  const acc = await server.getAccount(deployer);
+  const salt = crypto.randomBytes(32);
+  const op = Operation.createCustomContract({
+    wasmHash: Buffer.from(wasmHash, "hex"),
+    address: new Address(deployer),
+    salt,
+    constructorArgs,
+  });
+  const tx = new TransactionBuilder(acc, { fee: "10000000", networkPassphrase: PASSPHRASE })
+    .setTimeout(120)
+    .addOperation(op)
+    .build();
+  const res = await signSubmit(tx, `deploy ${label}`);
+  return Address.fromScVal(res.returnValue as xdr.ScVal).toString();
+}
+
+async function invoke(contractId: string, method: string, args: xdr.ScVal[], label: string): Promise<void> {
+  const acc = await server.getAccount(deployer);
+  const tx = new TransactionBuilder(acc, { fee: "10000000", networkPassphrase: PASSPHRASE })
+    .setTimeout(120)
+    .addOperation(new Contract(contractId).call(method, ...args))
+    .build();
+  await signSubmit(tx, label);
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Turbolong mainnet deploy ${DRY_RUN ? "(DRY-RUN)" : ""}`);
+  console.log(`  deployer=${deployer} admin=${ADMIN} keeper=${KEEPER}`);
+  console.log(`  pool=${POOL} router=${ROUTER}`);
+
+  const strategyHash = await installWasm(STRATEGY_WASM, "strategy");
+  const tokenHash = await installWasm(TOKEN_WASM, "token");
+  console.log(`  strategy wasm=${strategyHash}\n  token wasm=${tokenHash}`);
+
+  const out: Record<string, { strategy: string; token: string }> = {};
+
+  for (const a of ASSETS) {
+    console.log(`\n=== ${a.symbol} ===`);
+    const initArgs = xdr.ScVal.scvVec([
+      addr(POOL),                                          // [0] pool
+      addr(BLND),                                          // [1] blend_token
+      addr(ROUTER),                                        // [2] router
+      nativeToScVal(REWARD_THRESHOLD, { type: "i128" }),   // [3] reward_threshold
+      addr(KEEPER!),                                       // [4] keeper
+      nativeToScVal(a.cFactor, { type: "i128" }),          // [5] c_factor
+      nativeToScVal(a.targetLoops, { type: "u32" }),       // [6] target_loops
+      nativeToScVal(a.minHf, { type: "i128" }),            // [7] min_hf
+      nativeToScVal(a.orangeHf, { type: "i128" }),         // [8] orange_hf
+      addr(ADMIN),                                         // [9] admin
+    ]);
+    const strategy = await deploy(strategyHash, [addr(a.asset), initArgs], `${a.symbol} strategy`);
+    console.log(`  strategy=${strategy}`);
+
+    const token = await deploy(
+      tokenHash,
+      [
+        addr(ADMIN),                                              // admin
+        addr(strategy),                                           // minter = strategy
+        nativeToScVal(7, { type: "u32" }),                        // decimals
+        nativeToScVal(`BlendLeverage ${a.symbol} Share`, { type: "string" }),
+        nativeToScVal(`blv${a.symbol}`, { type: "string" }),
+      ],
+      `${a.symbol} token`,
+    );
+    console.log(`  token=${token}`);
+
+    await invoke(strategy, "set_share_token", [addr(token)], `${a.symbol} set_share_token`);
+    await invoke(strategy, "set_swap_account", [addr(KEEPER!)], `${a.symbol} set_swap_account`);
+
+    out[a.symbol] = { strategy, token };
+  }
+
+  const file = path.resolve(__dirname, "../deployed-vaults.mainnet.json");
+  fs.writeFileSync(file, JSON.stringify(out, null, 2));
+  console.log(`\nDeployed vaults written to ${file}`);
+  console.log("Next: wire frontend/src/defindex.ts MAINNET_VAULTS, verify deposit→loop→withdraw on Stellar Expert, get DeFindex co-sign.");
+}
+
+main().catch((e) => {
+  if (e.message === "DRY_RUN") { console.log("dry-run complete (no submissions)."); return; }
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
**SCF #43 Tranche 1, Deliverable 1 — deploy prep** (no mainnet broadcast; that needs your go-ahead + keeper account).

`scripts/deploy_strategy_mainnet.ts` deploys all 4 vaults: per asset it installs + deploys the **strategy** (10-arg constructor) and its **SEP-41 token** (minter = strategy), wires `set_share_token` + `set_swap_account`, and writes every ID to `deployed-vaults.mainnet.json`.

## Sourced inputs (verified, not fabricated)
- Etherfuse pool `CDMAVJPF…`, mainnet BLND `CD25MNVT…`
- **Soroswap mainnet router `CAG5LRYQ…`** (confirmed by two sources)
- **Per-asset pool c_factors read live from the pool:** USDC 0.95, USTRY 0.90, CETES 0.80, XLM 0.75

## Proposed per-asset config — needs your sign-off
`c_factor` is the strategy's own (≤ the pool's, for a borrow/HF buffer); the rest are my proposed risk defaults:

| Asset | strategy c_factor | target_loops | min_hf | orange_hf |
|---|---|---|---|---|
| USDC  | 0.90 | 4 | 1.05 | 1.15 |
| USTRY | 0.85 | 3 | 1.05 | 1.15 |
| CETES | 0.75 | 3 | 1.05 | 1.15 |
| XLM   | 0.70 | 2 | 1.10 | 1.20 |

reward_threshold = 100 BLND. (XLM most conservative — most volatile.)

## Security
Secure signer only: `DEPLOY_SECRET_KEY` via `op run` / secrets manager, **never inlined**. `KEEPER_PUBKEY` required; `ADMIN_PUBKEY` defaults to the deployer. `DRY_RUN=1` simulates without submitting.

## Still needed from you before running
1. **Keeper account** (`KEEPER_PUBKEY`) — the account that runs harvest/rebalance.
2. **Admin account** (`ADMIN_PUBKEY`) — ideally multisig/hardware (controls upgrades).
3. **Sign-off** on the config table above.
4. Build both wasms, then `DRY_RUN=1` once, then live with explicit go-ahead.

Verified: `tsc --noEmit` clean.