### PR TITLE
feat(frontend): 4-asset MAINNET_VAULTS + post-deploy wiring helper (SCF T1 D1)

### DIFF
--- a/frontend/src/defindex.ts
+++ b/frontend/src/defindex.ts
@@ -44,19 +44,57 @@ export interface VaultConfig {
   targetLoops: number;
   /** Minimum HF before rebalance triggers (1e7 scaled) */
   minHf: number;
+  /** SEP-41 vault-share token contract (set post-deploy; for share queries/trading) */
+  shareToken?: string;
 }
 
+// Mainnet vaults across the four Etherfuse-pool assets. vaultId/shareToken are
+// filled post-deploy from deployed-vaults.mainnet.json (see
+// scripts/wire_mainnet_vaults.ts). Config mirrors scripts/deploy_strategy_mainnet.ts.
 const MAINNET_VAULTS: VaultConfig[] = [
   {
-    vaultId: "", // TODO: set after mainnet deployment
+    vaultId: "", // filled post-deploy
     assetId: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75", // USDC
     poolId: "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI",
     name: "Leveraged USDC (Etherfuse)",
     assetSymbol: "USDC",
     decimals: 7,
     cFactor: 0.90,
+    targetLoops: 4,
+    minHf: 1.05,
+  },
+  {
+    vaultId: "",
+    assetId: "CBLV4ATSIWU67CFSQU2NVRKINQIKUZ2ODSZBUJTJ43VJVRSBTZYOPNUR", // USTRY
+    poolId: "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI",
+    name: "Leveraged USTRY (Etherfuse)",
+    assetSymbol: "USTRY",
+    decimals: 7,
+    cFactor: 0.85,
     targetLoops: 3,
     minHf: 1.05,
+  },
+  {
+    vaultId: "",
+    assetId: "CAL6ER2TI6CTRAY6BFXWNWA7WTYXUXTQCHUBCIBU5O6KM3HJFG6Z6VXV", // CETES
+    poolId: "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI",
+    name: "Leveraged CETES (Etherfuse)",
+    assetSymbol: "CETES",
+    decimals: 7,
+    cFactor: 0.75,
+    targetLoops: 3,
+    minHf: 1.05,
+  },
+  {
+    vaultId: "",
+    assetId: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA", // XLM
+    poolId: "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI",
+    name: "Leveraged XLM (Etherfuse)",
+    assetSymbol: "XLM",
+    decimals: 7,
+    cFactor: 0.70,
+    targetLoops: 2,
+    minHf: 1.10,
   },
 ];
 

--- a/scripts/wire_mainnet_vaults.ts
+++ b/scripts/wire_mainnet_vaults.ts
@@ -1,0 +1,69 @@
+/**
+ * Wire the mainnet vault IDs into the frontend after deployment — SCF T1 D1.
+ *
+ * Reads deployed-vaults.mainnet.json (written by deploy_strategy_mainnet.ts) and
+ * fills each MAINNET_VAULTS entry in frontend/src/defindex.ts with its deployed
+ * strategy address (`vaultId`) and share-token address (`shareToken`), matched by
+ * `assetSymbol`. Idempotent.
+ *
+ * Usage: npx tsx scripts/wire_mainnet_vaults.ts
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const deployedPath = path.resolve(here, "../deployed-vaults.mainnet.json");
+const defindexPath = path.resolve(here, "../frontend/src/defindex.ts");
+
+if (!fs.existsSync(deployedPath)) {
+  console.error(`Missing ${deployedPath}. Run deploy_strategy_mainnet.ts first.`);
+  process.exit(1);
+}
+
+const deployed: Record<string, { strategy: string; token: string }> = JSON.parse(
+  fs.readFileSync(deployedPath, "utf-8"),
+);
+
+let src = fs.readFileSync(defindexPath, "utf-8");
+let changed = 0;
+
+for (const [symbol, ids] of Object.entries(deployed)) {
+  if (!ids.strategy) {
+    console.warn(`[${symbol}] no strategy address — skipping`);
+    continue;
+  }
+  // Within the object whose assetSymbol is `symbol`, set vaultId. The `[^}]*?`
+  // keeps the match inside one vault object (no nested braces in these entries).
+  const vaultIdRe = new RegExp(
+    `(vaultId:\\s*")[^"]*("[^}]*?assetSymbol:\\s*"${symbol}")`,
+  );
+  if (!vaultIdRe.test(src)) {
+    console.warn(`[${symbol}] no MAINNET_VAULTS entry found — skipping`);
+    continue;
+  }
+  src = src.replace(vaultIdRe, `$1${ids.strategy}$2`);
+
+  // Set or insert shareToken in the same object (after the vaultId line).
+  const hasShareToken = new RegExp(
+    `vaultId:\\s*"${ids.strategy}"[^}]*?shareToken:\\s*"[^"]*"[^}]*?assetSymbol:\\s*"${symbol}"`,
+  ).test(src);
+  if (ids.token) {
+    if (hasShareToken) {
+      src = src.replace(
+        new RegExp(`(shareToken:\\s*")[^"]*("[^}]*?assetSymbol:\\s*"${symbol}")`),
+        `$1${ids.token}$2`,
+      );
+    } else {
+      src = src.replace(
+        new RegExp(`(vaultId:\\s*"${ids.strategy}",)`),
+        `$1\n    shareToken: "${ids.token}",`,
+      );
+    }
+  }
+  changed++;
+  console.log(`[${symbol}] vaultId=${ids.strategy} shareToken=${ids.token}`);
+}
+
+fs.writeFileSync(defindexPath, src);
+console.log(`\nWired ${changed} vault(s) into ${defindexPath}. Run \`npm run build\` in frontend to verify.`);


### PR DESCRIPTION
**SCF #43 Tranche 1, Deliverable 1 — frontend prep.** Makes the post-deploy wiring turnkey.

- **`defindex.ts`**: expand `MAINNET_VAULTS` to all four Etherfuse assets (USDC, USTRY, CETES, XLM), config mirroring `deploy_strategy_mainnet.ts` (#271). `vaultId`/`shareToken` left empty (filled post-deploy → vaults render disabled until live). Adds an optional `shareToken` field for SEP-41 share queries/trading (T3).
- **`scripts/wire_mainnet_vaults.ts`**: reads `deployed-vaults.mainnet.json` (written by the deploy script) and fills each vault's `vaultId` + `shareToken` in `defindex.ts` by `assetSymbol`. Idempotent → step 4 of the go-live runbook becomes one command.

## Verification
- `npm run build` + `biome lint` clean with the 4 vaults.
- Wiring helper tested end-to-end with sample IDs: patches correctly, result builds.

Pairs with #271 (deploy script + runbook). After deploy: run the helper → `npm run build` → the 4 vaults go live in the UI.