### PR TITLE
feat(frontend): Aquarius best-rate + server-backed rate history (SCF T3.1)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -633,6 +633,12 @@
               <div class="preview-row">
                 <span>Broker advantage</span><strong id="swap-profit" class="mono">—</strong>
               </div>
+              <div class="preview-row">
+                <span>Aquarius rate</span><strong id="swap-aquarius" class="mono">—</strong>
+              </div>
+              <div class="preview-row">
+                <span>Best rate</span><strong id="swap-best-rate" class="best-rate-badge">—</strong>
+              </div>
             </div>
 
             <!-- Broker settings — collapsed by default -->

--- a/frontend/src/aquarius.ts
+++ b/frontend/src/aquarius.ts
@@ -1,0 +1,82 @@
+/**
+ * Aquarius (AQUA) AMM rate client — SCF T3.1.
+ *
+ * Aquarius exposes a public, auth-free REST API for best-route quotes across the
+ * aggregated Stellar DEX surface. We use `POST /find-path/` (strict-send) to get
+ * the best output for a pair; the on-chain router is the documented fallback.
+ *
+ * No npm SDK exists — plain HTTP + @stellar/stellar-sdk is the supported path.
+ */
+
+export const AQUARIUS_API =
+  (import.meta.env.VITE_AQUARIUS_API as string | undefined) ??
+  "https://amm-api.aqua.network/api/external/v1";
+
+/** Mainnet Aquarius router contract (on-chain fallback / execution). */
+export const AQUARIUS_ROUTER = "CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK";
+
+export interface AquariusQuote {
+  /** Best output amount, in stroops (7-dp). */
+  amountOut: bigint;
+  /** Output net of pool fees, in stroops. */
+  amountWithFee: bigint;
+  /** Pool contract IDs along the chosen path. */
+  pools: string[];
+  /** Human-readable token names along the path. */
+  tokens: string[];
+  /** Base64 swap-chain XDR — hand straight to the router to execute. */
+  swapChainXdr: string;
+}
+
+/**
+ * Best-rate (strict-send) quote: how much `tokenOut` you get for `amountIn` of
+ * `tokenIn`. Token addresses are Soroban contract IDs (SAC for classic assets).
+ * Returns null when Aquarius is unreachable or has no feasible route (caller
+ * falls back to its other source / hides the Aquarius figure).
+ */
+export async function aquariusBestRate(
+  tokenInId: string,
+  tokenOutId: string,
+  amountInStroops: bigint,
+): Promise<AquariusQuote | null> {
+  if (tokenInId === tokenOutId || amountInStroops <= 0n) return null;
+  try {
+    const res = await fetch(`${AQUARIUS_API}/find-path/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token_in_address: tokenInId,
+        token_out_address: tokenOutId,
+        amount: amountInStroops.toString(),
+      }),
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return null;
+    const d = (await res.json()) as Record<string, unknown>;
+    if (!d.success || d.amount == null) return null;
+    return {
+      amountOut: BigInt(d.amount as string),
+      amountWithFee: BigInt((d.amount_with_fee as string) ?? (d.amount as string)),
+      pools: (d.pools as string[]) ?? [],
+      tokens: (d.tokens as string[]) ?? [],
+      swapChainXdr: (d.swap_chain_xdr as string) ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Effective price of `tokenIn` in `tokenOut` from Aquarius (out per 1 in), or
+ * null. Quotes a 1-unit (1e7 stroops) trade by default — adjust `probe` for
+ * depth-sensitive pricing.
+ */
+export async function aquariusPrice(
+  tokenInId: string,
+  tokenOutId: string,
+  probeStroops = 10_000_000n,
+): Promise<number | null> {
+  const q = await aquariusBestRate(tokenInId, tokenOutId, probeStroops);
+  if (!q) return null;
+  return Number(q.amountOut) / Number(probeStroops);
+}

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-backed rate history — SCF T3.1 / T3.3.
+ *
+ * The trend arrows + APY history chart previously read browser-local snapshots
+ * only, so a fresh visitor saw "not enough history". This pulls the real
+ * 15-minute server time-series from the alerts Worker's `/snapshots` endpoint
+ * (T2.5) and merges it into the same localStorage keys those renderers consume,
+ * so every visitor sees real 24h/7d/30d/1y history with no per-browser warm-up.
+ */
+
+const ALERTS_WORKER_URL =
+  (import.meta.env.VITE_ALERTS_WORKER_URL as string | undefined) ??
+  "https://turbolong-alerts.workers.dev";
+
+const RATE_HISTORY_KEY = "blendlev_rate_history";
+const RATE_HISTORY_MAX = 4000; // 365d @ 15-min ≈ 35k; cap generously per key
+
+export interface SnapshotPoint {
+  ts: number;
+  val: number;
+}
+
+type Field = "net_supply_apr" | "net_borrow_cost";
+
+/** Fetch the server time-series for a pool/asset, oldest→newest. */
+export async function fetchSnapshotSeries(
+  poolId: string,
+  assetSymbol: string,
+  field: Field,
+  limit = 500,
+): Promise<SnapshotPoint[]> {
+  try {
+    const url =
+      `${ALERTS_WORKER_URL}/snapshots?pool_id=${encodeURIComponent(poolId)}` +
+      `&asset=${encodeURIComponent(assetSymbol)}&limit=${limit}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(6000) });
+    if (!res.ok) return [];
+    const d = (await res.json()) as { snapshots?: Record<string, unknown>[] };
+    return (d.snapshots ?? [])
+      .map((s) => ({
+        ts: Date.parse(String(s.recorded_at).replace(" ", "T") + "Z"),
+        val: Number(s[field]),
+      }))
+      .filter((p) => Number.isFinite(p.ts) && Number.isFinite(p.val))
+      .reverse(); // /snapshots returns newest-first → flip to oldest-first
+  } catch {
+    return [];
+  }
+}
+
+function key(poolId: string, assetId: string, field: string): string {
+  return `${RATE_HISTORY_KEY}:${poolId}:${assetId}:${field}`;
+}
+
+/** Merge server points into a localStorage history key, deduped by minute. */
+function mergeInto(storageKey: string, server: SnapshotPoint[]): void {
+  if (server.length === 0) return;
+  const raw = localStorage.getItem(storageKey);
+  const local: SnapshotPoint[] = raw ? JSON.parse(raw) : [];
+  const byMinute = new Map<number, SnapshotPoint>();
+  for (const p of [...server, ...local]) {
+    byMinute.set(Math.round(p.ts / 60_000), p); // local wins ties (more recent push)
+  }
+  const merged = [...byMinute.values()].sort((a, b) => a.ts - b.ts);
+  const capped = merged.length > RATE_HISTORY_MAX ? merged.slice(-RATE_HISTORY_MAX) : merged;
+  localStorage.setItem(storageKey, JSON.stringify(capped));
+}
+
+/**
+ * Seed the supply-net + borrow-net history keys for a pool/asset from the server.
+ * `assetSymbol` keys the server query; `assetId` (Soroban contract) keys
+ * localStorage (matching the existing chart/arrow renderers). Returns true if any
+ * server data was merged.
+ */
+export async function seedHistoryFromServer(
+  poolId: string,
+  assetId: string,
+  assetSymbol: string,
+): Promise<boolean> {
+  const [supply, borrow] = await Promise.all([
+    fetchSnapshotSeries(poolId, assetSymbol, "net_supply_apr"),
+    fetchSnapshotSeries(poolId, assetSymbol, "net_borrow_cost"),
+  ]);
+  if (supply.length === 0 && borrow.length === 0) return false;
+  mergeInto(key(poolId, assetId, "supply-net"), supply);
+  mergeInto(key(poolId, assetId, "borrow-net"), borrow);
+  return true;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,6 +85,8 @@ import {
   type VaultStats,
   type UserVaultPosition,
 } from "./defindex.ts";
+import { seedHistoryFromServer } from "./history.ts";
+import { aquariusBestRate } from "./aquarius.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -1257,10 +1259,27 @@ function renderSelectedAsset() {
   );
 
   renderHistoryChart();
+  maybeSeedHistory();
 
   updatePreview();
   renderPosition();
   renderPortfolioSummary();
+}
+
+// One-time-per-asset: pull the real server time-series (T2.5 /snapshots) into
+// the local history keys so the chart + trend arrows show real 24h/7d/30d/1y
+// data for every visitor, then re-render. No-op if the server has no data yet.
+const _historySeeded = new Set<string>();
+function maybeSeedHistory() {
+  const k = `${selectedPool.id}:${selectedAsset.id}`;
+  if (_historySeeded.has(k)) return;
+  _historySeeded.add(k);
+  void seedHistoryFromServer(selectedPool.id, selectedAsset.id, selectedAsset.symbol).then(
+    (seeded) => {
+      // Only re-render if this asset is still selected and we got server data.
+      if (seeded && `${selectedPool.id}:${selectedAsset.id}` === k) renderSelectedAsset();
+    },
+  );
 }
 
 function renderAprLine(id: string, val: number, isCost: boolean, isBlnd = false, sign?: string, raw = false) {
@@ -2487,6 +2506,9 @@ async function fetchSwapQuote() {
         : "\u2014";
       $("swap-profit").textContent = quote.profit ? `${quote.profit}` : "\u2014";
       $("swap-quote-details").classList.remove("hidden");
+
+      // T3.1: cross-check against Aquarius and badge the best venue.
+      void compareAquariusRate(sellAsset, buyAsset, sellNum, buyNum, buySym);
     } else {
       ($("swap-buy-amount") as HTMLInputElement).value = quote.status === "unfeasible" ? "No route" : "\u2014";
       $("swap-quote-details").classList.add("hidden");
@@ -2501,6 +2523,43 @@ async function fetchSwapQuote() {
     console.warn("Swap quote:", errMsg);
   }
   updateSwapBtn();
+}
+
+/**
+ * T3.1: quote the same pair on Aquarius and badge which venue gives the better
+ * output. Soroban contract IDs come from BROKER_TO_CONTRACT (broker classic ID →
+ * SAC/contract). Hidden gracefully when Aquarius is unreachable (fallback).
+ */
+async function compareAquariusRate(
+  sellBrokerId: string,
+  buyBrokerId: string,
+  sellNum: number,
+  brokerBuyNum: number,
+  buySym: string,
+) {
+  const aqEl = $("swap-aquarius");
+  const badgeEl = $("swap-best-rate");
+  const sellC = BROKER_TO_CONTRACT[sellBrokerId];
+  const buyC = BROKER_TO_CONTRACT[buyBrokerId];
+  if (!sellC || !buyC) {
+    aqEl.textContent = "—";
+    badgeEl.textContent = "—";
+    badgeEl.className = "best-rate-badge";
+    return;
+  }
+  const amountStroops = BigInt(Math.round(sellNum * 1e7));
+  const aq = await aquariusBestRate(sellC, buyC, amountStroops);
+  if (!aq) {
+    aqEl.textContent = "unavailable";
+    badgeEl.textContent = "Broker";
+    badgeEl.className = "best-rate-badge best-broker";
+    return;
+  }
+  const aqOut = Number(aq.amountOut) / 1e7;
+  aqEl.textContent = `${aqOut.toFixed(7)} ${buySym}`;
+  const brokerWins = brokerBuyNum >= aqOut;
+  badgeEl.textContent = brokerWins ? "Broker" : "Aquarius";
+  badgeEl.className = `best-rate-badge ${brokerWins ? "best-broker" : "best-aquarius"}`;
 }
 
 function updateSwapBtn() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1304,3 +1304,8 @@ kbd {
   font-family: var(--font-mono, monospace);
   font-size: 0.8rem;
 }
+
+/* T3.1 — Aquarius best-rate badge */
+.best-rate-badge { font-weight: 700; }
+.best-rate-badge.best-broker { color: #2DE8A3; }
+.best-rate-badge.best-aquarius { color: #7B61FF; }


### PR DESCRIPTION
**SCF #43 Tranche 3, Deliverable 1** — Aquarius rate comparison + server-backed trend arrows.

- **`aquarius.ts`** — Aquarius REST client. `aquariusBestRate()` = `POST /find-path/` (the auth-free best-route quote across the aggregated Stellar DEX surface); `AQUARIUS_ROUTER` mainnet fallback constant. Returns `null` (caller hides the figure) when Aquarius is unreachable — the documented fallback.
- **`history.ts`** — pulls the real **15-min server time-series** from the alerts Worker `/snapshots` (T2.5) and merges it into the localStorage keys the existing APY history chart + 24h/7d trend arrows read. **This drives the trend arrows from the T2 historical snapshot table** (the deliverable's wording) — every visitor sees real history instead of a per-browser warm-up.
- **`main.ts`** — seeds server history on asset-select (one-shot per asset, then re-renders); the **swap view now shows an Aquarius rate line + a Best Rate badge** (Broker vs Aquarius winner). `index.html`/`style.css`: the rows + badge styles.

## Verification
- `vite build` + `biome lint` clean.

## Scope note
The grant puts the Best Rate badge in the **Compare Pools view** and wants Aquarius rates for **≥5 pairs** — that view doesn't exist yet, so it's the next PR (**T3.3**), which reuses `aquarius.ts` + `history.ts` from here. This PR delivers the Aquarius client, the server-backed trend arrows, and a first visible Best Rate surface (swap view).