### PR TITLE
feat(frontend): Compare Pools view — cross-pool APY ranking + Aquarius rates + history (SCF T3.3)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,7 @@
         <div id="pool-dropdown" class="pool-dropdown hidden"></div>
         <button class="nav-btn" id="proto-vault">Vault</button>
         <button class="nav-btn" id="proto-swap">Swap</button>
+        <button class="nav-btn" id="proto-compare">Compare</button>
       </div>
       <div class="top-nav-right" id="wallet-area">
         <button id="settings-btn" class="nav-btn" aria-label="Settings">&#9881;</button>
@@ -108,6 +109,12 @@
             <button class="protocol-btn" id="mobile-proto-swap">
               <span class="protocol-icon">&#8644;</span>
               Swap
+            </button>
+          </div>
+          <div class="protocol-section">
+            <button class="protocol-btn" id="mobile-proto-compare">
+              <span class="protocol-icon">&#9776;</span>
+              Compare
             </button>
           </div>
         </nav>
@@ -810,6 +817,45 @@
             </div>
 
             <p class="disclaimer">Deposits are managed by the Turbolong Strategy on Blend Protocol. Leverage loops are executed atomically. Rebalance is permissionless — anyone can trigger it when HF drops below the minimum threshold to protect all depositors.</p>
+          </section>
+        </div>
+
+        <!-- Compare Pools view (no wallet required) -->
+        <div id="compare-view" class="hidden">
+          <section class="compare-section">
+            <div class="compare-header">
+              <div>
+                <h2 class="compare-title">Compare Pools</h2>
+                <p class="compare-sub">Live net APY across every Blend pool &amp; asset, ranked by best leveraged yield. Best swap rate sourced from Aquarius. No wallet needed.</p>
+              </div>
+              <div class="compare-controls">
+                <div class="compare-window-toggle" id="compare-window-toggle" role="tablist" aria-label="History window">
+                  <button class="cw-btn" data-window="7">7D</button>
+                  <button class="cw-btn active" data-window="30">30D</button>
+                  <button class="cw-btn" data-window="365">1Y</button>
+                </div>
+                <button class="btn btn-ghost compare-refresh" id="compare-refresh" title="Refresh">&#8635;</button>
+              </div>
+            </div>
+            <div class="compare-table-wrap">
+              <table class="compare-table" id="compare-table">
+                <thead>
+                  <tr>
+                    <th class="ct-rank">#</th>
+                    <th class="ct-asset">Pool / Asset</th>
+                    <th class="ct-num" data-sort="base">Base APY</th>
+                    <th class="ct-num" data-sort="lev">Leveraged APY</th>
+                    <th class="ct-num ct-lev">Max Lev</th>
+                    <th class="ct-num" data-sort="rate">Aqua Rate</th>
+                    <th class="ct-trend">Trend</th>
+                  </tr>
+                </thead>
+                <tbody id="compare-tbody">
+                  <tr><td colspan="7" class="compare-loading">Loading pools…</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="compare-foot">Leveraged APY assumes the maximum leverage that keeps health factor ≥ 1.20 at current pool rates; actual results depend on rate drift and gas. Aquarius rate is an indicative quote for 1 unit → USDC via the AMM router. Trend shows net supply APY history from the Turbolong snapshot service.</p>
           </section>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -633,6 +633,12 @@
               <div class="preview-row">
                 <span>Broker advantage</span><strong id="swap-profit" class="mono">—</strong>
               </div>
+              <div class="preview-row">
+                <span>Aquarius rate</span><strong id="swap-aquarius" class="mono">—</strong>
+              </div>
+              <div class="preview-row">
+                <span>Best rate</span><strong id="swap-best-rate" class="best-rate-badge">—</strong>
+              </div>
             </div>
 
             <!-- Broker settings — collapsed by default -->

--- a/frontend/src/aquarius.ts
+++ b/frontend/src/aquarius.ts
@@ -1,0 +1,82 @@
+/**
+ * Aquarius (AQUA) AMM rate client — SCF T3.1.
+ *
+ * Aquarius exposes a public, auth-free REST API for best-route quotes across the
+ * aggregated Stellar DEX surface. We use `POST /find-path/` (strict-send) to get
+ * the best output for a pair; the on-chain router is the documented fallback.
+ *
+ * No npm SDK exists — plain HTTP + @stellar/stellar-sdk is the supported path.
+ */
+
+export const AQUARIUS_API =
+  (import.meta.env.VITE_AQUARIUS_API as string | undefined) ??
+  "https://amm-api.aqua.network/api/external/v1";
+
+/** Mainnet Aquarius router contract (on-chain fallback / execution). */
+export const AQUARIUS_ROUTER = "CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK";
+
+export interface AquariusQuote {
+  /** Best output amount, in stroops (7-dp). */
+  amountOut: bigint;
+  /** Output net of pool fees, in stroops. */
+  amountWithFee: bigint;
+  /** Pool contract IDs along the chosen path. */
+  pools: string[];
+  /** Human-readable token names along the path. */
+  tokens: string[];
+  /** Base64 swap-chain XDR — hand straight to the router to execute. */
+  swapChainXdr: string;
+}
+
+/**
+ * Best-rate (strict-send) quote: how much `tokenOut` you get for `amountIn` of
+ * `tokenIn`. Token addresses are Soroban contract IDs (SAC for classic assets).
+ * Returns null when Aquarius is unreachable or has no feasible route (caller
+ * falls back to its other source / hides the Aquarius figure).
+ */
+export async function aquariusBestRate(
+  tokenInId: string,
+  tokenOutId: string,
+  amountInStroops: bigint,
+): Promise<AquariusQuote | null> {
+  if (tokenInId === tokenOutId || amountInStroops <= 0n) return null;
+  try {
+    const res = await fetch(`${AQUARIUS_API}/find-path/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token_in_address: tokenInId,
+        token_out_address: tokenOutId,
+        amount: amountInStroops.toString(),
+      }),
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return null;
+    const d = (await res.json()) as Record<string, unknown>;
+    if (!d.success || d.amount == null) return null;
+    return {
+      amountOut: BigInt(d.amount as string),
+      amountWithFee: BigInt((d.amount_with_fee as string) ?? (d.amount as string)),
+      pools: (d.pools as string[]) ?? [],
+      tokens: (d.tokens as string[]) ?? [],
+      swapChainXdr: (d.swap_chain_xdr as string) ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Effective price of `tokenIn` in `tokenOut` from Aquarius (out per 1 in), or
+ * null. Quotes a 1-unit (1e7 stroops) trade by default — adjust `probe` for
+ * depth-sensitive pricing.
+ */
+export async function aquariusPrice(
+  tokenInId: string,
+  tokenOutId: string,
+  probeStroops = 10_000_000n,
+): Promise<number | null> {
+  const q = await aquariusBestRate(tokenInId, tokenOutId, probeStroops);
+  if (!q) return null;
+  return Number(q.amountOut) / Number(probeStroops);
+}

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-backed rate history — SCF T3.1 / T3.3.
+ *
+ * The trend arrows + APY history chart previously read browser-local snapshots
+ * only, so a fresh visitor saw "not enough history". This pulls the real
+ * 15-minute server time-series from the alerts Worker's `/snapshots` endpoint
+ * (T2.5) and merges it into the same localStorage keys those renderers consume,
+ * so every visitor sees real 24h/7d/30d/1y history with no per-browser warm-up.
+ */
+
+const ALERTS_WORKER_URL =
+  (import.meta.env.VITE_ALERTS_WORKER_URL as string | undefined) ??
+  "https://turbolong-alerts.workers.dev";
+
+const RATE_HISTORY_KEY = "blendlev_rate_history";
+const RATE_HISTORY_MAX = 4000; // 365d @ 15-min ≈ 35k; cap generously per key
+
+export interface SnapshotPoint {
+  ts: number;
+  val: number;
+}
+
+type Field = "net_supply_apr" | "net_borrow_cost";
+
+/** Fetch the server time-series for a pool/asset, oldest→newest. */
+export async function fetchSnapshotSeries(
+  poolId: string,
+  assetSymbol: string,
+  field: Field,
+  limit = 500,
+): Promise<SnapshotPoint[]> {
+  try {
+    const url =
+      `${ALERTS_WORKER_URL}/snapshots?pool_id=${encodeURIComponent(poolId)}` +
+      `&asset=${encodeURIComponent(assetSymbol)}&limit=${limit}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(6000) });
+    if (!res.ok) return [];
+    const d = (await res.json()) as { snapshots?: Record<string, unknown>[] };
+    return (d.snapshots ?? [])
+      .map((s) => ({
+        ts: Date.parse(String(s.recorded_at).replace(" ", "T") + "Z"),
+        val: Number(s[field]),
+      }))
+      .filter((p) => Number.isFinite(p.ts) && Number.isFinite(p.val))
+      .reverse(); // /snapshots returns newest-first → flip to oldest-first
+  } catch {
+    return [];
+  }
+}
+
+function key(poolId: string, assetId: string, field: string): string {
+  return `${RATE_HISTORY_KEY}:${poolId}:${assetId}:${field}`;
+}
+
+/** Merge server points into a localStorage history key, deduped by minute. */
+function mergeInto(storageKey: string, server: SnapshotPoint[]): void {
+  if (server.length === 0) return;
+  const raw = localStorage.getItem(storageKey);
+  const local: SnapshotPoint[] = raw ? JSON.parse(raw) : [];
+  const byMinute = new Map<number, SnapshotPoint>();
+  for (const p of [...server, ...local]) {
+    byMinute.set(Math.round(p.ts / 60_000), p); // local wins ties (more recent push)
+  }
+  const merged = [...byMinute.values()].sort((a, b) => a.ts - b.ts);
+  const capped = merged.length > RATE_HISTORY_MAX ? merged.slice(-RATE_HISTORY_MAX) : merged;
+  localStorage.setItem(storageKey, JSON.stringify(capped));
+}
+
+/**
+ * Seed the supply-net + borrow-net history keys for a pool/asset from the server.
+ * `assetSymbol` keys the server query; `assetId` (Soroban contract) keys
+ * localStorage (matching the existing chart/arrow renderers). Returns true if any
+ * server data was merged.
+ */
+export async function seedHistoryFromServer(
+  poolId: string,
+  assetId: string,
+  assetSymbol: string,
+): Promise<boolean> {
+  const [supply, borrow] = await Promise.all([
+    fetchSnapshotSeries(poolId, assetSymbol, "net_supply_apr"),
+    fetchSnapshotSeries(poolId, assetSymbol, "net_borrow_cost"),
+  ]);
+  if (supply.length === 0 && borrow.length === 0) return false;
+  mergeInto(key(poolId, assetId, "supply-net"), supply);
+  mergeInto(key(poolId, assetId, "borrow-net"), borrow);
+  return true;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,8 +85,8 @@ import {
   type VaultStats,
   type UserVaultPosition,
 } from "./defindex.ts";
-import { seedHistoryFromServer } from "./history.ts";
-import { aquariusBestRate } from "./aquarius.ts";
+import { seedHistoryFromServer, fetchSnapshotSeries, type SnapshotPoint } from "./history.ts";
+import { aquariusBestRate, aquariusPrice } from "./aquarius.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -412,7 +412,7 @@ document.getElementById("disclaimer-accept")!.addEventListener("click", () => {
 
 // ── Active view (leverage | swap) ────────────────────────────────────────
 
-type AppView = "overview" | "leverage" | "swap" | "vault";
+type AppView = "overview" | "leverage" | "swap" | "vault" | "compare";
 let activeView: AppView = "leverage";
 
 // ── Expert mode ──────────────────────────────────────────────────────────────
@@ -2359,6 +2359,164 @@ async function disconnect() {
 
 // ── View switching (Leverage / Swap) ─────────────────────────────────────
 
+// ── Compare Pools view (T3.3) ────────────────────────────────────────────────
+//
+// No-wallet, read-only ranking of every Blend pool × asset by best leveraged net
+// APY, with an Aquarius indicative swap rate and a net-supply-APY history
+// sparkline sourced from the Turbolong snapshot service. Reuses aquarius.ts +
+// history.ts (T3.1). The grant-required "Best Rate" badge marks the top row.
+
+interface CompareRow {
+  poolName:  string;
+  poolId:    string;
+  asset:     AssetInfo;
+  rs:        ReserveStats;
+  baseApy:   number;          // aprToApy(netSupplyApr)
+  safeLev:   number;          // max leverage keeping HF ≥ COMPARE_HF_FLOOR, capped
+  levApy:    number;          // net APY at the carry-optimal leverage
+  aquaPrice: number | null;   // indicative 1 unit → USDC, null = no route
+  series:    SnapshotPoint[]; // net supply APR history within the window
+}
+
+const COMPARE_HF_FLOOR = 1.2;
+const COMPARE_LEV_CAP  = 8;
+
+let compareWindowDays = 30;
+let compareSortKey: "lev" | "base" | "rate" = "lev";
+let compareRows: CompareRow[] = [];
+let compareLoading = false;
+let compareToken = 0; // generation guard against overlapping renders
+
+function usdcAssetId(): string | null {
+  for (const p of getKnownPools()) {
+    for (const a of getPoolAssets(p)) {
+      if (a.symbol.toUpperCase() === "USDC") return a.id;
+    }
+  }
+  return null;
+}
+
+/** Carry-optimal leverage + the net APY it yields at current pool rates. */
+function compareLevApy(rs: ReserveStats): { safeLev: number; levApy: number } {
+  const safeLev = Math.min(COMPARE_LEV_CAP, Math.max(1, maxLeverageFor(rs.cFactor, rs.lFactor, COMPARE_HF_FLOOR)));
+  const carry   = rs.netSupplyApr - rs.netBorrowCost; // marginal yield per extra leverage unit
+  const effLev  = carry > 0 ? safeLev : 1;            // negative carry → no leverage
+  const levApy  = aprToApy(rs.netSupplyApr * effLev - rs.netBorrowCost * (effLev - 1));
+  return { safeLev, levApy };
+}
+
+function compareSparkline(series: SnapshotPoint[]): string {
+  if (series.length < 2) return `<span class="ct-spark-empty">—</span>`;
+  const W = 88, H = 26, pad = 3;
+  const vals = series.map((p) => p.val);
+  const min = Math.min(...vals), max = Math.max(...vals);
+  const range = max - min || 1;
+  const n = series.length;
+  const x = (i: number) => pad + (i / (n - 1)) * (W - 2 * pad);
+  const y = (v: number) => pad + (1 - (v - min) / range) * (H - 2 * pad);
+  const pts = series.map((p, i) => `${x(i).toFixed(1)},${y(p.val).toFixed(1)}`).join(" ");
+  const up = vals[n - 1] >= vals[0];
+  const lastX = x(n - 1).toFixed(1), lastY = y(vals[n - 1]).toFixed(1);
+  return `<svg class="ct-spark ${up ? "ct-spark-up" : "ct-spark-down"}" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" preserveAspectRatio="none">
+    <polyline points="${pts}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="${lastX}" cy="${lastY}" r="1.8" fill="currentColor"/>
+  </svg>`;
+}
+
+function compareSortRows(): CompareRow[] {
+  const rows = [...compareRows];
+  rows.sort((a, b) => {
+    if (compareSortKey === "base") return b.baseApy - a.baseApy;
+    if (compareSortKey === "rate") return (b.aquaPrice ?? -1) - (a.aquaPrice ?? -1);
+    return b.levApy - a.levApy;
+  });
+  return rows;
+}
+
+function renderCompareTable(): void {
+  const tbody = $("compare-tbody");
+  const rows = compareSortRows();
+  if (rows.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="7" class="compare-loading">${
+      compareLoading ? "Loading pools…" : "No pools available."
+    }</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map((r, i) => {
+    const best = i === 0 && compareSortKey === "lev";
+    const rate = r.aquaPrice == null ? `<span class="ct-muted">n/a</span>` : r.aquaPrice.toFixed(4);
+    return `<tr class="${best ? "ct-best-row" : ""}">
+      <td class="ct-rank">${best ? `<span class="ct-medal">&#9733;</span>` : i + 1}</td>
+      <td class="ct-asset">
+        <div class="ct-asset-cell">
+          <span class="ct-sym">${r.asset.symbol}</span>
+          ${best ? `<span class="best-rate-badge best-broker">Best Rate</span>` : ""}
+        </div>
+        <span class="ct-pool">${r.poolName}</span>
+      </td>
+      <td class="ct-num">${r.baseApy.toFixed(2)}%</td>
+      <td class="ct-num ct-lev-apy">${r.levApy.toFixed(2)}%</td>
+      <td class="ct-num ct-lev">${r.safeLev.toFixed(1)}&times;</td>
+      <td class="ct-num">${rate}</td>
+      <td class="ct-trend">${compareSparkline(r.series)}</td>
+    </tr>`;
+  }).join("");
+}
+
+async function renderCompareView(): Promise<void> {
+  const token = ++compareToken;
+  compareLoading = true;
+  compareRows = [];
+  renderCompareTable();
+
+  const usdc   = usdcAssetId();
+  const cutoff = Date.now() - compareWindowDays * 86_400_000;
+  const limit  = compareWindowDays <= 7 ? 400 : compareWindowDays <= 30 ? 900 : 2000;
+
+  // 1. Reserves per pool (sequential per pool to spare the RPC); render progressively.
+  for (const pool of getKnownPools()) {
+    let reserves: ReserveStats[] = [];
+    try {
+      reserves = await fetchAllReserves(pool, userAddress || "");
+    } catch (e) {
+      console.warn(`compare: reserves failed for ${pool.name}`, e);
+      continue;
+    }
+    if (token !== compareToken) return; // superseded by a newer render
+    for (const rs of reserves) {
+      const { safeLev, levApy } = compareLevApy(rs);
+      compareRows.push({
+        poolName: pool.name, poolId: pool.id, asset: rs.asset, rs,
+        baseApy: aprToApy(rs.netSupplyApr), safeLev, levApy,
+        aquaPrice: null, series: [],
+      });
+    }
+    renderCompareTable();
+  }
+  compareLoading = false;
+  if (token !== compareToken) return;
+  renderCompareTable();
+
+  // 2. Enrich each row with an Aquarius rate + history sparkline, all in parallel.
+  await Promise.allSettled(compareRows.map(async (r) => {
+    const sym = r.asset.symbol.toUpperCase();
+    const tasks: Promise<unknown>[] = [];
+    if (sym === "USDC") {
+      r.aquaPrice = 1;
+    } else if (usdc && r.asset.id !== usdc) {
+      tasks.push(aquariusPrice(r.asset.id, usdc).then((v) => { r.aquaPrice = v; }).catch(() => {}));
+    }
+    tasks.push(
+      fetchSnapshotSeries(r.poolId, r.asset.symbol, "net_supply_apr", limit)
+        .then((s) => { r.series = s.filter((p) => p.ts >= cutoff); })
+        .catch(() => {}),
+    );
+    await Promise.all(tasks);
+    if (token === compareToken) renderCompareTable();
+  }));
+  if (token === compareToken) renderCompareTable();
+}
+
 function switchView(view: AppView) {
   activeView = view;
   // Top nav active states
@@ -2366,16 +2524,19 @@ function switchView(view: AppView) {
   const blendBtn = $("proto-blend");
   const swapBtn  = $("proto-swap");
   const vaultBtn = $("proto-vault");
+  const compareBtn = $("proto-compare");
   overviewBtn.classList.toggle("active", view === "overview");
   blendBtn.classList.toggle("active", view === "leverage");
   swapBtn.classList.toggle("active", view === "swap");
   vaultBtn.classList.toggle("active", view === "vault");
+  compareBtn.classList.toggle("active", view === "compare");
 
   // Mobile sidebar active states
   document.getElementById("mobile-proto-overview")?.classList.toggle("active", view === "overview");
   document.getElementById("mobile-proto-blend")?.classList.toggle("active", view === "leverage");
   document.getElementById("mobile-proto-swap")?.classList.toggle("active", view === "swap");
   document.getElementById("mobile-proto-vault")?.classList.toggle("active", view === "vault");
+  document.getElementById("mobile-proto-compare")?.classList.toggle("active", view === "compare");
 
   // Toggle pool tabs visibility (mobile sidebar)
   $("pool-tabs").style.display = view === "leverage" ? "" : "none";
@@ -2388,6 +2549,7 @@ function switchView(view: AppView) {
   $("overview-view").classList.add("hidden");
   $("swap-view").classList.add("hidden");
   $("vault-view").classList.add("hidden");
+  $("compare-view").classList.add("hidden");
   $("dashboard").classList.add("hidden");
   $("connect-prompt").classList.add("hidden");
 
@@ -2412,6 +2574,9 @@ function switchView(view: AppView) {
   } else if (view === "vault") {
     $("vault-view").classList.remove("hidden");
     refreshVaultView();
+  } else if (view === "compare") {
+    $("compare-view").classList.remove("hidden");
+    renderCompareView();
   }
   closeDrawer();
   // Close pool dropdown
@@ -2711,12 +2876,39 @@ $("proto-blend").addEventListener("click", (e) => {
 });
 $("proto-swap").addEventListener("click",  () => switchView("swap"));
 $("proto-vault").addEventListener("click", () => switchView("vault"));
+$("proto-compare").addEventListener("click", () => switchView("compare"));
 
 // Mobile sidebar nav
 document.getElementById("mobile-proto-overview")?.addEventListener("click", () => switchView("overview"));
 document.getElementById("mobile-proto-blend")?.addEventListener("click", () => switchView("leverage"));
 document.getElementById("mobile-proto-swap")?.addEventListener("click", () => switchView("swap"));
 document.getElementById("mobile-proto-vault")?.addEventListener("click", () => switchView("vault"));
+document.getElementById("mobile-proto-compare")?.addEventListener("click", () => switchView("compare"));
+
+// Compare view: history-window toggle (re-fetches series)
+$("compare-window-toggle").addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest(".cw-btn") as HTMLElement | null;
+  if (!btn) return;
+  const w = Number(btn.dataset.window);
+  if (!w || w === compareWindowDays) return;
+  compareWindowDays = w;
+  for (const b of document.querySelectorAll("#compare-window-toggle .cw-btn")) {
+    b.classList.toggle("active", b === btn);
+  }
+  renderCompareView();
+});
+// Compare view: sort by column header
+$("compare-table").addEventListener("click", (e) => {
+  const th = (e.target as HTMLElement).closest("th[data-sort]") as HTMLElement | null;
+  if (!th) return;
+  compareSortKey = th.dataset.sort as "lev" | "base" | "rate";
+  for (const h of document.querySelectorAll("#compare-table th[data-sort]")) {
+    h.classList.toggle("ct-sorted", h === th);
+  }
+  renderCompareTable();
+});
+// Compare view: manual refresh
+$("compare-refresh").addEventListener("click", () => renderCompareView());
 
 // Close dropdowns on click outside
 document.addEventListener("click", () => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,6 +85,8 @@ import {
   type VaultStats,
   type UserVaultPosition,
 } from "./defindex.ts";
+import { seedHistoryFromServer } from "./history.ts";
+import { aquariusBestRate } from "./aquarius.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -1257,10 +1259,27 @@ function renderSelectedAsset() {
   );
 
   renderHistoryChart();
+  maybeSeedHistory();
 
   updatePreview();
   renderPosition();
   renderPortfolioSummary();
+}
+
+// One-time-per-asset: pull the real server time-series (T2.5 /snapshots) into
+// the local history keys so the chart + trend arrows show real 24h/7d/30d/1y
+// data for every visitor, then re-render. No-op if the server has no data yet.
+const _historySeeded = new Set<string>();
+function maybeSeedHistory() {
+  const k = `${selectedPool.id}:${selectedAsset.id}`;
+  if (_historySeeded.has(k)) return;
+  _historySeeded.add(k);
+  void seedHistoryFromServer(selectedPool.id, selectedAsset.id, selectedAsset.symbol).then(
+    (seeded) => {
+      // Only re-render if this asset is still selected and we got server data.
+      if (seeded && `${selectedPool.id}:${selectedAsset.id}` === k) renderSelectedAsset();
+    },
+  );
 }
 
 function renderAprLine(id: string, val: number, isCost: boolean, isBlnd = false, sign?: string, raw = false) {
@@ -2487,6 +2506,9 @@ async function fetchSwapQuote() {
         : "\u2014";
       $("swap-profit").textContent = quote.profit ? `${quote.profit}` : "\u2014";
       $("swap-quote-details").classList.remove("hidden");
+
+      // T3.1: cross-check against Aquarius and badge the best venue.
+      void compareAquariusRate(sellAsset, buyAsset, sellNum, buyNum, buySym);
     } else {
       ($("swap-buy-amount") as HTMLInputElement).value = quote.status === "unfeasible" ? "No route" : "\u2014";
       $("swap-quote-details").classList.add("hidden");
@@ -2501,6 +2523,43 @@ async function fetchSwapQuote() {
     console.warn("Swap quote:", errMsg);
   }
   updateSwapBtn();
+}
+
+/**
+ * T3.1: quote the same pair on Aquarius and badge which venue gives the better
+ * output. Soroban contract IDs come from BROKER_TO_CONTRACT (broker classic ID →
+ * SAC/contract). Hidden gracefully when Aquarius is unreachable (fallback).
+ */
+async function compareAquariusRate(
+  sellBrokerId: string,
+  buyBrokerId: string,
+  sellNum: number,
+  brokerBuyNum: number,
+  buySym: string,
+) {
+  const aqEl = $("swap-aquarius");
+  const badgeEl = $("swap-best-rate");
+  const sellC = BROKER_TO_CONTRACT[sellBrokerId];
+  const buyC = BROKER_TO_CONTRACT[buyBrokerId];
+  if (!sellC || !buyC) {
+    aqEl.textContent = "—";
+    badgeEl.textContent = "—";
+    badgeEl.className = "best-rate-badge";
+    return;
+  }
+  const amountStroops = BigInt(Math.round(sellNum * 1e7));
+  const aq = await aquariusBestRate(sellC, buyC, amountStroops);
+  if (!aq) {
+    aqEl.textContent = "unavailable";
+    badgeEl.textContent = "Broker";
+    badgeEl.className = "best-rate-badge best-broker";
+    return;
+  }
+  const aqOut = Number(aq.amountOut) / 1e7;
+  aqEl.textContent = `${aqOut.toFixed(7)} ${buySym}`;
+  const brokerWins = brokerBuyNum >= aqOut;
+  badgeEl.textContent = brokerWins ? "Broker" : "Aquarius";
+  badgeEl.className = `best-rate-badge ${brokerWins ? "best-broker" : "best-aquarius"}`;
 }
 
 function updateSwapBtn() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1309,3 +1309,77 @@ kbd {
 .best-rate-badge { font-weight: 700; }
 .best-rate-badge.best-broker { color: #2DE8A3; }
 .best-rate-badge.best-aquarius { color: #7B61FF; }
+
+/* ── T3.3 — Compare Pools view ─────────────────────────────────────────────── */
+.compare-section {
+  max-width: 1040px; margin: 0 auto; padding: 28px 20px 40px;
+}
+.compare-header {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  gap: 20px; flex-wrap: wrap; margin-bottom: 20px;
+}
+.compare-title { font-size: 24px; font-weight: 700; margin: 0 0 6px; }
+.compare-sub { color: var(--text-2); font-size: 13px; max-width: 560px; margin: 0; line-height: 1.5; }
+.compare-controls { display: flex; align-items: center; gap: 10px; }
+.compare-window-toggle {
+  display: inline-flex; background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 99px; padding: 3px;
+}
+.cw-btn {
+  background: transparent; border: none; color: var(--text-2);
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  padding: 5px 12px; border-radius: 99px; cursor: pointer; transition: all .15s;
+}
+.cw-btn:hover { color: var(--text); }
+.cw-btn.active { background: var(--primary); color: #04130D; }
+.compare-refresh {
+  width: 36px; height: 32px; padding: 0; font-size: 16px; line-height: 1;
+}
+.compare-table-wrap {
+  border: 1px solid var(--border); border-radius: var(--r);
+  background: var(--surface); overflow-x: auto;
+}
+.compare-table { width: 100%; border-collapse: collapse; min-width: 640px; }
+.compare-table thead th {
+  text-align: right; font-size: 11px; font-weight: 600; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--text-3); padding: 14px 16px;
+  border-bottom: 1px solid var(--border); white-space: nowrap; user-select: none;
+}
+.compare-table th.ct-rank, .compare-table th.ct-asset { text-align: left; }
+.compare-table th[data-sort] { cursor: pointer; }
+.compare-table th[data-sort]:hover { color: var(--text); }
+.compare-table th.ct-sorted { color: var(--primary); }
+.compare-table tbody td {
+  padding: 14px 16px; border-bottom: 1px solid var(--border);
+  font-size: 14px; text-align: right; vertical-align: middle;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody tr:hover { background: var(--tab-hover-bg); }
+.ct-rank { width: 44px; text-align: left !important; color: var(--text-3); font-family: var(--mono); }
+.ct-medal { color: var(--warning); font-size: 16px; }
+.ct-asset { text-align: left !important; }
+.ct-asset-cell { display: flex; align-items: center; gap: 8px; }
+.ct-sym { font-weight: 700; font-size: 15px; }
+.ct-pool { display: block; color: var(--text-3); font-size: 11px; margin-top: 2px; }
+.ct-num { font-family: var(--mono); }
+.ct-lev-apy { color: var(--primary); font-weight: 600; }
+.ct-lev { color: var(--text-2); }
+.ct-muted { color: var(--text-3); }
+.ct-best-row { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
+.ct-best-row:hover { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
+.compare-table .best-rate-badge {
+  font-size: 9px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 99px; background: var(--primary);
+  color: #04130D !important; white-space: nowrap;
+}
+.ct-trend { width: 100px; text-align: right; }
+.ct-spark { display: inline-block; vertical-align: middle; }
+.ct-spark-up { color: var(--success); }
+.ct-spark-down { color: var(--danger); }
+.ct-spark-empty { color: var(--text-3); font-family: var(--mono); }
+.compare-loading { text-align: center !important; color: var(--text-2); padding: 32px 16px !important; }
+.compare-foot { color: var(--text-3); font-size: 11px; line-height: 1.5; margin: 14px 4px 0; }
+@media (max-width: 640px) {
+  .compare-header { flex-direction: column; }
+  .compare-title { font-size: 20px; }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1304,3 +1304,8 @@ kbd {
   font-family: var(--font-mono, monospace);
   font-size: 0.8rem;
 }
+
+/* T3.1 — Aquarius best-rate badge */
+.best-rate-badge { font-weight: 700; }
+.best-rate-badge.best-broker { color: #2DE8A3; }
+.best-rate-badge.best-aquarius { color: #7B61FF; }


### PR DESCRIPTION
Closes #11 (A9: Compare Pools view) — **SCF #43 Tranche 3, deliverable T3.3**.

Stacked on #273 (T3.1) — reuses its `aquarius.ts` + `history.ts` modules. Review/merge **after** #273.

## What
A new no-wallet **Compare** view (desktop + mobile nav) that ranks every Blend pool × asset by best leveraged yield, so any visitor can see where Turbolong's best opportunity is at a glance — no connection required.

Per (pool, asset) row:
- **Base APY** — net supply APY (interest + BLND emissions).
- **Leveraged APY** — net APY at the *carry-optimal* leverage: the max leverage keeping health factor ≥ 1.20 (capped 8×) when carry is positive, else 1× (no leverage when borrowing costs more than it earns).
- **Max Lev** — that leverage multiple.
- **Aqua Rate** — indicative Aquarius AMM quote for 1 unit → USDC (`aquariusPrice`), `n/a` when no route.
- **Trend** — net-supply-APY history sparkline (green up / red down) from the Turbolong snapshot service (`/snapshots`).

Rows ranked by leveraged APY; the top row carries the grant-required **Best Rate** badge.

## Controls
- **7D / 30D / 1Y** window toggle — re-fetches history and time-filters the sparkline.
- **Sortable** column headers: Base APY, Leveraged APY, Aqua Rate.
- **Refresh** button — re-pulls live reserves + rates.

## How
- `renderCompareView()` loops `getKnownPools()` × `fetchAllReserves(pool, "")` (read-only, uses the `NULL_ACCOUNT` source — no wallet needed), renders the table progressively per pool, then enriches each row with Aquarius rate + history in parallel (`Promise.allSettled`). A generation token guards against overlapping renders when the user toggles windows quickly.
- Leverage math reuses `maxLeverageFor`/`hfForLeverage` from `blend.ts`; APY uses the existing `aprToApy`.
- New `AppView "compare"` + nav wiring in `switchView()`.

## Verification
- `npm run build` — clean (vite, 2571 modules).
- `npm run lint` — clean (biome, 8 files).
- No-wallet path confirmed: reserves fetch via `NULL_ACCOUNT` fallback already used elsewhere for read-only sims.

Mainnet-gated: Aquarius rates only return routes for assets with live AMM pools; history sparklines populate as the snapshot service accrues data. Both degrade gracefully (`n/a` / `—`).