### PR TITLE
feat(frontend): Aquarius receipt-token trade UX + listing runbook (SCF T3.2)

### DIFF
--- a/docs/aquarius-listing-runbook.md
+++ b/docs/aquarius-listing-runbook.md
@@ -1,0 +1,116 @@
+# Aquarius Listing & Trade Runbook — Turbolong Vault Receipt Tokens
+
+**SCF #43 Tranche 3, deliverable T3.2.** Lists each Turbolong vault's SEP-41
+receipt (share) token on Aquarius so depositors can trade their leveraged
+position against USDC permissionlessly — exiting without unwinding the loop
+on-chain.
+
+> **Mainnet-gated.** Pool creation, liquidity seeding, and the 5 verification
+> trades move real funds and require the mainnet vaults + share tokens from T1
+> D1 to be live first. This runbook is the procedure; execute it at launch.
+
+---
+
+## 0. What gets listed
+
+Every Turbolong vault mints a **separate SEP-41 token** (the `vault_share`
+contract, wired into each strategy via `set_share_token` in
+`scripts/deploy_strategy_mainnet.ts`). A holder's share balance is their claim on
+the leveraged position. Listing that token on Aquarius gives a secondary exit:
+sell shares for USDC instead of calling `withdraw` (which unwinds the loop).
+
+The frontend reads listings from `frontend/src/aquarius_listings.ts`
+(`AQUARIUS_LISTINGS`, keyed by vault `assetSymbol`). The vault view shows a
+"Trade on Aquarius" CTA + copyable token ID once a listing exists; until then it
+shows a "listing after mainnet" notice.
+
+## 1. Prerequisites
+
+- [ ] T1 D1 done: 4 mainnet vaults deployed, each with its share token deployed
+      and `set_share_token` confirmed (`deployed-vaults.mainnet.json`).
+- [ ] Listing wallet funded with **AQUA** for the pool-creation fee:
+      **300,000 AQUA per pool** (4 pools → 1,200,000 AQUA).
+- [ ] Listing wallet funded with seed liquidity: receipt tokens (obtained by
+      depositing into each vault) **and** matching USDC for the other side.
+- [ ] Signer via `op run` / `op read` (1Password) per repo guardrails — never
+      inline a secret key.
+
+## 2. Aquarius mainnet entry point
+
+| Item | Value |
+|------|-------|
+| AMM router / entry-point contract | `CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK` |
+| Pool type for receipt↔USDC | Constant-product (volatile) |
+| Fee tiers (volatile) | 0.1%, 0.3%, 1% — **use 0.3%** |
+| Pool-creation fee | 300,000 AQUA |
+
+Verified contract functions (Aquarius Soroban docs):
+
+```
+fn get_pools(e: Env, tokens: Vec<Address>) -> Vec<(BytesN<32>, Address)>
+fn deposit(e: Env, user: Address, tokens: Vec<Address>, pool_index: BytesN<32>,
+           desired_amounts: Vec<u128>, min_shares: u128)
+fn swap_chained(e: Env, user: Address, swaps_chain: Vec<(Vec<Address>, BytesN<32>, Address)>,
+                token_in: Address, in_amount: u128, out_min: u128)
+```
+
+> ⚠️ The pool-**creation** entrypoint signature (`init_*_pool`) is **not**
+> published in the Aquarius developer docs. Create pools through the Aquarius UI
+> (https://aqua.network) — which handles the create + AQUA fee — **or** confirm
+> the exact `init_standard_pool` ABI against the live contract before scripting
+> it. Do **not** ship a guessed money-path tx-builder.
+
+## 3. List each receipt token (per asset: USDC, USTRY, CETES, XLM)
+
+For each vault share token `S` and counter asset USDC `U`:
+
+1. **Create the pool** (Aquarius UI, recommended): connect the listing wallet,
+   create a Volatile pool for `S` / `U` at the 0.3% fee tier, pay the 300k AQUA
+   fee. Note the resulting **pool index** (`BytesN<32>`).
+   - Tokens vectors are **sorted by contract address** — keep `tokens`,
+     `desired_amounts` in the same canonical order Aquarius expects.
+2. **Look up the pool index** programmatically to confirm:
+   `get_pools([S, U])` → `Vec<(pool_index, pool_address)>`.
+3. **Seed liquidity**: `deposit(listingWallet, [S, U], pool_index,
+   [sharesAmount, usdcAmount], min_shares)`. Seed enough depth that a depositor
+   can realistically exit (size to expected position turnover).
+4. **Record** the listing in `frontend/src/aquarius_listings.ts`:
+   ```ts
+   export const AQUARIUS_LISTINGS: Record<string, AquariusListing> = {
+     USDC:  { shareToken: "C…", pairedWith: "C…USDC", poolIndex: "…" },
+     USTRY: { shareToken: "C…", pairedWith: "C…USDC", poolIndex: "…" },
+     CETES: { shareToken: "C…", pairedWith: "C…USDC", poolIndex: "…" },
+     XLM:   { shareToken: "C…", pairedWith: "C…USDC", poolIndex: "…" },
+   };
+   ```
+   Rebuild + deploy the frontend; the vault view CTA goes live automatically.
+
+## 4. Acceptance verification — 5 trades (grant requirement)
+
+For at least one listed pair (USDC receipt ↔ USDC recommended), execute **5
+swaps** with small live amounts and capture evidence:
+
+1. `swap_chained(trader, [([S,U], pool_index, U)], S, inAmount, out_min)` — sell
+   shares for USDC. (And the reverse `U → S` for buys.)
+2. Capture each **tx hash** and confirm on Stellar Expert: token deltas, the
+   pool's reserves moved, the trader received within `out_min`.
+3. Confirm the realized price aligns with the strategy's reported share price
+   (`fetchVaultStats` → share price) within slippage + fee.
+4. Record the 5 hashes in the **T3 completion report**.
+
+## 5. Safety
+
+- Real funds. Use **small** amounts for the verification trades.
+- Seed liquidity is at risk to impermanent loss vs. the share's NAV drift —
+  size deliberately; this is protocol-owned or team liquidity, document it.
+- Log any dev shortcut taken during listing to `SECURITY-TODO.md`.
+
+---
+
+### Status
+
+- ✅ Built now: receipt-token concept + `aquarius_listings.ts` registry; vault
+  view "Trade on Aquarius" CTA (copyable token ID, Explorer link) with graceful
+  pre-listing notice; this runbook.
+- ⛔ Mainnet-gated: pool creation (needs share tokens live + 300k AQUA/pool),
+  liquidity seeding, the 5 verification trades, populating `AQUARIUS_LISTINGS`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,7 @@
         <div id="pool-dropdown" class="pool-dropdown hidden"></div>
         <button class="nav-btn" id="proto-vault">Vault</button>
         <button class="nav-btn" id="proto-swap">Swap</button>
+        <button class="nav-btn" id="proto-compare">Compare</button>
       </div>
       <div class="top-nav-right" id="wallet-area">
         <button id="settings-btn" class="nav-btn" aria-label="Settings">&#9881;</button>
@@ -108,6 +109,12 @@
             <button class="protocol-btn" id="mobile-proto-swap">
               <span class="protocol-icon">&#8644;</span>
               Swap
+            </button>
+          </div>
+          <div class="protocol-section">
+            <button class="protocol-btn" id="mobile-proto-compare">
+              <span class="protocol-icon">&#9776;</span>
+              Compare
             </button>
           </div>
         </nav>
@@ -810,6 +817,45 @@
             </div>
 
             <p class="disclaimer">Deposits are managed by the Turbolong Strategy on Blend Protocol. Leverage loops are executed atomically. Rebalance is permissionless — anyone can trigger it when HF drops below the minimum threshold to protect all depositors.</p>
+          </section>
+        </div>
+
+        <!-- Compare Pools view (no wallet required) -->
+        <div id="compare-view" class="hidden">
+          <section class="compare-section">
+            <div class="compare-header">
+              <div>
+                <h2 class="compare-title">Compare Pools</h2>
+                <p class="compare-sub">Live net APY across every Blend pool &amp; asset, ranked by best leveraged yield. Best swap rate sourced from Aquarius. No wallet needed.</p>
+              </div>
+              <div class="compare-controls">
+                <div class="compare-window-toggle" id="compare-window-toggle" role="tablist" aria-label="History window">
+                  <button class="cw-btn" data-window="7">7D</button>
+                  <button class="cw-btn active" data-window="30">30D</button>
+                  <button class="cw-btn" data-window="365">1Y</button>
+                </div>
+                <button class="btn btn-ghost compare-refresh" id="compare-refresh" title="Refresh">&#8635;</button>
+              </div>
+            </div>
+            <div class="compare-table-wrap">
+              <table class="compare-table" id="compare-table">
+                <thead>
+                  <tr>
+                    <th class="ct-rank">#</th>
+                    <th class="ct-asset">Pool / Asset</th>
+                    <th class="ct-num" data-sort="base">Base APY</th>
+                    <th class="ct-num" data-sort="lev">Leveraged APY</th>
+                    <th class="ct-num ct-lev">Max Lev</th>
+                    <th class="ct-num" data-sort="rate">Aqua Rate</th>
+                    <th class="ct-trend">Trend</th>
+                  </tr>
+                </thead>
+                <tbody id="compare-tbody">
+                  <tr><td colspan="7" class="compare-loading">Loading pools…</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="compare-foot">Leveraged APY assumes the maximum leverage that keeps health factor ≥ 1.20 at current pool rates; actual results depend on rate drift and gas. Aquarius rate is an indicative quote for 1 unit → USDC via the AMM router. Trend shows net supply APY history from the Turbolong snapshot service.</p>
           </section>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -816,6 +816,18 @@
               <a id="vault-contract-link" class="mono vault-contract-addr" href="#" target="_blank" rel="noopener">--</a>
             </div>
 
+            <!-- T3.2 — Trade the receipt token on Aquarius -->
+            <div class="aqua-trade-card" id="aqua-trade-card">
+              <div class="aqua-trade-head">
+                <span class="aqua-trade-icon">&#8646;</span>
+                <div>
+                  <h4 class="aqua-trade-title">Trade your position on Aquarius</h4>
+                  <p class="aqua-trade-sub">Your vault deposit is a transferable SEP-41 receipt token. Once listed it trades against USDC on Aquarius, so you can exit without unwinding the leverage loop on-chain.</p>
+                </div>
+              </div>
+              <div class="aqua-trade-body" id="aqua-trade-body"></div>
+            </div>
+
             <p class="disclaimer">Deposits are managed by the Turbolong Strategy on Blend Protocol. Leverage loops are executed atomically. Rebalance is permissionless — anyone can trigger it when HF drops below the minimum threshold to protect all depositors.</p>
           </section>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -633,6 +633,12 @@
               <div class="preview-row">
                 <span>Broker advantage</span><strong id="swap-profit" class="mono">—</strong>
               </div>
+              <div class="preview-row">
+                <span>Aquarius rate</span><strong id="swap-aquarius" class="mono">—</strong>
+              </div>
+              <div class="preview-row">
+                <span>Best rate</span><strong id="swap-best-rate" class="best-rate-badge">—</strong>
+              </div>
             </div>
 
             <!-- Broker settings — collapsed by default -->

--- a/frontend/src/aquarius.ts
+++ b/frontend/src/aquarius.ts
@@ -1,0 +1,82 @@
+/**
+ * Aquarius (AQUA) AMM rate client — SCF T3.1.
+ *
+ * Aquarius exposes a public, auth-free REST API for best-route quotes across the
+ * aggregated Stellar DEX surface. We use `POST /find-path/` (strict-send) to get
+ * the best output for a pair; the on-chain router is the documented fallback.
+ *
+ * No npm SDK exists — plain HTTP + @stellar/stellar-sdk is the supported path.
+ */
+
+export const AQUARIUS_API =
+  (import.meta.env.VITE_AQUARIUS_API as string | undefined) ??
+  "https://amm-api.aqua.network/api/external/v1";
+
+/** Mainnet Aquarius router contract (on-chain fallback / execution). */
+export const AQUARIUS_ROUTER = "CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK";
+
+export interface AquariusQuote {
+  /** Best output amount, in stroops (7-dp). */
+  amountOut: bigint;
+  /** Output net of pool fees, in stroops. */
+  amountWithFee: bigint;
+  /** Pool contract IDs along the chosen path. */
+  pools: string[];
+  /** Human-readable token names along the path. */
+  tokens: string[];
+  /** Base64 swap-chain XDR — hand straight to the router to execute. */
+  swapChainXdr: string;
+}
+
+/**
+ * Best-rate (strict-send) quote: how much `tokenOut` you get for `amountIn` of
+ * `tokenIn`. Token addresses are Soroban contract IDs (SAC for classic assets).
+ * Returns null when Aquarius is unreachable or has no feasible route (caller
+ * falls back to its other source / hides the Aquarius figure).
+ */
+export async function aquariusBestRate(
+  tokenInId: string,
+  tokenOutId: string,
+  amountInStroops: bigint,
+): Promise<AquariusQuote | null> {
+  if (tokenInId === tokenOutId || amountInStroops <= 0n) return null;
+  try {
+    const res = await fetch(`${AQUARIUS_API}/find-path/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token_in_address: tokenInId,
+        token_out_address: tokenOutId,
+        amount: amountInStroops.toString(),
+      }),
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return null;
+    const d = (await res.json()) as Record<string, unknown>;
+    if (!d.success || d.amount == null) return null;
+    return {
+      amountOut: BigInt(d.amount as string),
+      amountWithFee: BigInt((d.amount_with_fee as string) ?? (d.amount as string)),
+      pools: (d.pools as string[]) ?? [],
+      tokens: (d.tokens as string[]) ?? [],
+      swapChainXdr: (d.swap_chain_xdr as string) ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Effective price of `tokenIn` in `tokenOut` from Aquarius (out per 1 in), or
+ * null. Quotes a 1-unit (1e7 stroops) trade by default — adjust `probe` for
+ * depth-sensitive pricing.
+ */
+export async function aquariusPrice(
+  tokenInId: string,
+  tokenOutId: string,
+  probeStroops = 10_000_000n,
+): Promise<number | null> {
+  const q = await aquariusBestRate(tokenInId, tokenOutId, probeStroops);
+  if (!q) return null;
+  return Number(q.amountOut) / Number(probeStroops);
+}

--- a/frontend/src/aquarius_listings.ts
+++ b/frontend/src/aquarius_listings.ts
@@ -1,0 +1,33 @@
+// T3.2 — Aquarius listing registry for Turbolong vault receipt (share) tokens.
+//
+// Each Turbolong vault mints a SEP-41 receipt token (the vault_share contract)
+// that represents a depositor's leveraged position. T3.2 lists those receipt
+// tokens on Aquarius so they trade permissionlessly against USDC — letting a
+// depositor exit without unwinding the leverage loop on-chain.
+//
+// This registry is populated AFTER the mainnet vaults + their share tokens are
+// deployed (T1 D1) and each is listed on Aquarius — see
+// docs/aquarius-listing-runbook.md. Until then the vault view shows a
+// "listing after mainnet" notice and degrades gracefully.
+
+/** Aquarius swap UI. The exact per-token deep-link param is not publicly
+ * documented, so the UI links here and surfaces the copyable token contract ID. */
+export const AQUARIUS_SWAP_URL = "https://aqua.network/swap";
+
+export interface AquariusListing {
+  /** SEP-41 receipt (share) token contract address. */
+  shareToken: string;
+  /** Counter asset the receipt token is paired against (usually USDC). */
+  pairedWith: string;
+  /** Aquarius constant-product pool index (BytesN<32> hex) once created, if known. */
+  poolIndex?: string;
+}
+
+/** Keyed by vault assetSymbol (e.g. "USDC", "CETES"). Empty until mainnet listing. */
+export const AQUARIUS_LISTINGS: Record<string, AquariusListing> = {
+  // "USDC": { shareToken: "C…", pairedWith: "USDC", poolIndex: "…" },
+};
+
+export function getAquariusListing(assetSymbol: string): AquariusListing | null {
+  return AQUARIUS_LISTINGS[assetSymbol] ?? null;
+}

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-backed rate history — SCF T3.1 / T3.3.
+ *
+ * The trend arrows + APY history chart previously read browser-local snapshots
+ * only, so a fresh visitor saw "not enough history". This pulls the real
+ * 15-minute server time-series from the alerts Worker's `/snapshots` endpoint
+ * (T2.5) and merges it into the same localStorage keys those renderers consume,
+ * so every visitor sees real 24h/7d/30d/1y history with no per-browser warm-up.
+ */
+
+const ALERTS_WORKER_URL =
+  (import.meta.env.VITE_ALERTS_WORKER_URL as string | undefined) ??
+  "https://turbolong-alerts.workers.dev";
+
+const RATE_HISTORY_KEY = "blendlev_rate_history";
+const RATE_HISTORY_MAX = 4000; // 365d @ 15-min ≈ 35k; cap generously per key
+
+export interface SnapshotPoint {
+  ts: number;
+  val: number;
+}
+
+type Field = "net_supply_apr" | "net_borrow_cost";
+
+/** Fetch the server time-series for a pool/asset, oldest→newest. */
+export async function fetchSnapshotSeries(
+  poolId: string,
+  assetSymbol: string,
+  field: Field,
+  limit = 500,
+): Promise<SnapshotPoint[]> {
+  try {
+    const url =
+      `${ALERTS_WORKER_URL}/snapshots?pool_id=${encodeURIComponent(poolId)}` +
+      `&asset=${encodeURIComponent(assetSymbol)}&limit=${limit}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(6000) });
+    if (!res.ok) return [];
+    const d = (await res.json()) as { snapshots?: Record<string, unknown>[] };
+    return (d.snapshots ?? [])
+      .map((s) => ({
+        ts: Date.parse(String(s.recorded_at).replace(" ", "T") + "Z"),
+        val: Number(s[field]),
+      }))
+      .filter((p) => Number.isFinite(p.ts) && Number.isFinite(p.val))
+      .reverse(); // /snapshots returns newest-first → flip to oldest-first
+  } catch {
+    return [];
+  }
+}
+
+function key(poolId: string, assetId: string, field: string): string {
+  return `${RATE_HISTORY_KEY}:${poolId}:${assetId}:${field}`;
+}
+
+/** Merge server points into a localStorage history key, deduped by minute. */
+function mergeInto(storageKey: string, server: SnapshotPoint[]): void {
+  if (server.length === 0) return;
+  const raw = localStorage.getItem(storageKey);
+  const local: SnapshotPoint[] = raw ? JSON.parse(raw) : [];
+  const byMinute = new Map<number, SnapshotPoint>();
+  for (const p of [...server, ...local]) {
+    byMinute.set(Math.round(p.ts / 60_000), p); // local wins ties (more recent push)
+  }
+  const merged = [...byMinute.values()].sort((a, b) => a.ts - b.ts);
+  const capped = merged.length > RATE_HISTORY_MAX ? merged.slice(-RATE_HISTORY_MAX) : merged;
+  localStorage.setItem(storageKey, JSON.stringify(capped));
+}
+
+/**
+ * Seed the supply-net + borrow-net history keys for a pool/asset from the server.
+ * `assetSymbol` keys the server query; `assetId` (Soroban contract) keys
+ * localStorage (matching the existing chart/arrow renderers). Returns true if any
+ * server data was merged.
+ */
+export async function seedHistoryFromServer(
+  poolId: string,
+  assetId: string,
+  assetSymbol: string,
+): Promise<boolean> {
+  const [supply, borrow] = await Promise.all([
+    fetchSnapshotSeries(poolId, assetSymbol, "net_supply_apr"),
+    fetchSnapshotSeries(poolId, assetSymbol, "net_borrow_cost"),
+  ]);
+  if (supply.length === 0 && borrow.length === 0) return false;
+  mergeInto(key(poolId, assetId, "supply-net"), supply);
+  mergeInto(key(poolId, assetId, "borrow-net"), borrow);
+  return true;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,8 +85,8 @@ import {
   type VaultStats,
   type UserVaultPosition,
 } from "./defindex.ts";
-import { seedHistoryFromServer } from "./history.ts";
-import { aquariusBestRate } from "./aquarius.ts";
+import { seedHistoryFromServer, fetchSnapshotSeries, type SnapshotPoint } from "./history.ts";
+import { aquariusBestRate, aquariusPrice } from "./aquarius.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -412,7 +412,7 @@ document.getElementById("disclaimer-accept")!.addEventListener("click", () => {
 
 // ── Active view (leverage | swap) ────────────────────────────────────────
 
-type AppView = "overview" | "leverage" | "swap" | "vault";
+type AppView = "overview" | "leverage" | "swap" | "vault" | "compare";
 let activeView: AppView = "leverage";
 
 // ── Expert mode ──────────────────────────────────────────────────────────────
@@ -2359,6 +2359,164 @@ async function disconnect() {
 
 // ── View switching (Leverage / Swap) ─────────────────────────────────────
 
+// ── Compare Pools view (T3.3) ────────────────────────────────────────────────
+//
+// No-wallet, read-only ranking of every Blend pool × asset by best leveraged net
+// APY, with an Aquarius indicative swap rate and a net-supply-APY history
+// sparkline sourced from the Turbolong snapshot service. Reuses aquarius.ts +
+// history.ts (T3.1). The grant-required "Best Rate" badge marks the top row.
+
+interface CompareRow {
+  poolName:  string;
+  poolId:    string;
+  asset:     AssetInfo;
+  rs:        ReserveStats;
+  baseApy:   number;          // aprToApy(netSupplyApr)
+  safeLev:   number;          // max leverage keeping HF ≥ COMPARE_HF_FLOOR, capped
+  levApy:    number;          // net APY at the carry-optimal leverage
+  aquaPrice: number | null;   // indicative 1 unit → USDC, null = no route
+  series:    SnapshotPoint[]; // net supply APR history within the window
+}
+
+const COMPARE_HF_FLOOR = 1.2;
+const COMPARE_LEV_CAP  = 8;
+
+let compareWindowDays = 30;
+let compareSortKey: "lev" | "base" | "rate" = "lev";
+let compareRows: CompareRow[] = [];
+let compareLoading = false;
+let compareToken = 0; // generation guard against overlapping renders
+
+function usdcAssetId(): string | null {
+  for (const p of getKnownPools()) {
+    for (const a of getPoolAssets(p)) {
+      if (a.symbol.toUpperCase() === "USDC") return a.id;
+    }
+  }
+  return null;
+}
+
+/** Carry-optimal leverage + the net APY it yields at current pool rates. */
+function compareLevApy(rs: ReserveStats): { safeLev: number; levApy: number } {
+  const safeLev = Math.min(COMPARE_LEV_CAP, Math.max(1, maxLeverageFor(rs.cFactor, rs.lFactor, COMPARE_HF_FLOOR)));
+  const carry   = rs.netSupplyApr - rs.netBorrowCost; // marginal yield per extra leverage unit
+  const effLev  = carry > 0 ? safeLev : 1;            // negative carry → no leverage
+  const levApy  = aprToApy(rs.netSupplyApr * effLev - rs.netBorrowCost * (effLev - 1));
+  return { safeLev, levApy };
+}
+
+function compareSparkline(series: SnapshotPoint[]): string {
+  if (series.length < 2) return `<span class="ct-spark-empty">—</span>`;
+  const W = 88, H = 26, pad = 3;
+  const vals = series.map((p) => p.val);
+  const min = Math.min(...vals), max = Math.max(...vals);
+  const range = max - min || 1;
+  const n = series.length;
+  const x = (i: number) => pad + (i / (n - 1)) * (W - 2 * pad);
+  const y = (v: number) => pad + (1 - (v - min) / range) * (H - 2 * pad);
+  const pts = series.map((p, i) => `${x(i).toFixed(1)},${y(p.val).toFixed(1)}`).join(" ");
+  const up = vals[n - 1] >= vals[0];
+  const lastX = x(n - 1).toFixed(1), lastY = y(vals[n - 1]).toFixed(1);
+  return `<svg class="ct-spark ${up ? "ct-spark-up" : "ct-spark-down"}" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" preserveAspectRatio="none">
+    <polyline points="${pts}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="${lastX}" cy="${lastY}" r="1.8" fill="currentColor"/>
+  </svg>`;
+}
+
+function compareSortRows(): CompareRow[] {
+  const rows = [...compareRows];
+  rows.sort((a, b) => {
+    if (compareSortKey === "base") return b.baseApy - a.baseApy;
+    if (compareSortKey === "rate") return (b.aquaPrice ?? -1) - (a.aquaPrice ?? -1);
+    return b.levApy - a.levApy;
+  });
+  return rows;
+}
+
+function renderCompareTable(): void {
+  const tbody = $("compare-tbody");
+  const rows = compareSortRows();
+  if (rows.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="7" class="compare-loading">${
+      compareLoading ? "Loading pools…" : "No pools available."
+    }</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map((r, i) => {
+    const best = i === 0 && compareSortKey === "lev";
+    const rate = r.aquaPrice == null ? `<span class="ct-muted">n/a</span>` : r.aquaPrice.toFixed(4);
+    return `<tr class="${best ? "ct-best-row" : ""}">
+      <td class="ct-rank">${best ? `<span class="ct-medal">&#9733;</span>` : i + 1}</td>
+      <td class="ct-asset">
+        <div class="ct-asset-cell">
+          <span class="ct-sym">${r.asset.symbol}</span>
+          ${best ? `<span class="best-rate-badge best-broker">Best Rate</span>` : ""}
+        </div>
+        <span class="ct-pool">${r.poolName}</span>
+      </td>
+      <td class="ct-num">${r.baseApy.toFixed(2)}%</td>
+      <td class="ct-num ct-lev-apy">${r.levApy.toFixed(2)}%</td>
+      <td class="ct-num ct-lev">${r.safeLev.toFixed(1)}&times;</td>
+      <td class="ct-num">${rate}</td>
+      <td class="ct-trend">${compareSparkline(r.series)}</td>
+    </tr>`;
+  }).join("");
+}
+
+async function renderCompareView(): Promise<void> {
+  const token = ++compareToken;
+  compareLoading = true;
+  compareRows = [];
+  renderCompareTable();
+
+  const usdc   = usdcAssetId();
+  const cutoff = Date.now() - compareWindowDays * 86_400_000;
+  const limit  = compareWindowDays <= 7 ? 400 : compareWindowDays <= 30 ? 900 : 2000;
+
+  // 1. Reserves per pool (sequential per pool to spare the RPC); render progressively.
+  for (const pool of getKnownPools()) {
+    let reserves: ReserveStats[] = [];
+    try {
+      reserves = await fetchAllReserves(pool, userAddress || "");
+    } catch (e) {
+      console.warn(`compare: reserves failed for ${pool.name}`, e);
+      continue;
+    }
+    if (token !== compareToken) return; // superseded by a newer render
+    for (const rs of reserves) {
+      const { safeLev, levApy } = compareLevApy(rs);
+      compareRows.push({
+        poolName: pool.name, poolId: pool.id, asset: rs.asset, rs,
+        baseApy: aprToApy(rs.netSupplyApr), safeLev, levApy,
+        aquaPrice: null, series: [],
+      });
+    }
+    renderCompareTable();
+  }
+  compareLoading = false;
+  if (token !== compareToken) return;
+  renderCompareTable();
+
+  // 2. Enrich each row with an Aquarius rate + history sparkline, all in parallel.
+  await Promise.allSettled(compareRows.map(async (r) => {
+    const sym = r.asset.symbol.toUpperCase();
+    const tasks: Promise<unknown>[] = [];
+    if (sym === "USDC") {
+      r.aquaPrice = 1;
+    } else if (usdc && r.asset.id !== usdc) {
+      tasks.push(aquariusPrice(r.asset.id, usdc).then((v) => { r.aquaPrice = v; }).catch(() => {}));
+    }
+    tasks.push(
+      fetchSnapshotSeries(r.poolId, r.asset.symbol, "net_supply_apr", limit)
+        .then((s) => { r.series = s.filter((p) => p.ts >= cutoff); })
+        .catch(() => {}),
+    );
+    await Promise.all(tasks);
+    if (token === compareToken) renderCompareTable();
+  }));
+  if (token === compareToken) renderCompareTable();
+}
+
 function switchView(view: AppView) {
   activeView = view;
   // Top nav active states
@@ -2366,16 +2524,19 @@ function switchView(view: AppView) {
   const blendBtn = $("proto-blend");
   const swapBtn  = $("proto-swap");
   const vaultBtn = $("proto-vault");
+  const compareBtn = $("proto-compare");
   overviewBtn.classList.toggle("active", view === "overview");
   blendBtn.classList.toggle("active", view === "leverage");
   swapBtn.classList.toggle("active", view === "swap");
   vaultBtn.classList.toggle("active", view === "vault");
+  compareBtn.classList.toggle("active", view === "compare");
 
   // Mobile sidebar active states
   document.getElementById("mobile-proto-overview")?.classList.toggle("active", view === "overview");
   document.getElementById("mobile-proto-blend")?.classList.toggle("active", view === "leverage");
   document.getElementById("mobile-proto-swap")?.classList.toggle("active", view === "swap");
   document.getElementById("mobile-proto-vault")?.classList.toggle("active", view === "vault");
+  document.getElementById("mobile-proto-compare")?.classList.toggle("active", view === "compare");
 
   // Toggle pool tabs visibility (mobile sidebar)
   $("pool-tabs").style.display = view === "leverage" ? "" : "none";
@@ -2388,6 +2549,7 @@ function switchView(view: AppView) {
   $("overview-view").classList.add("hidden");
   $("swap-view").classList.add("hidden");
   $("vault-view").classList.add("hidden");
+  $("compare-view").classList.add("hidden");
   $("dashboard").classList.add("hidden");
   $("connect-prompt").classList.add("hidden");
 
@@ -2412,6 +2574,9 @@ function switchView(view: AppView) {
   } else if (view === "vault") {
     $("vault-view").classList.remove("hidden");
     refreshVaultView();
+  } else if (view === "compare") {
+    $("compare-view").classList.remove("hidden");
+    renderCompareView();
   }
   closeDrawer();
   // Close pool dropdown
@@ -2711,12 +2876,39 @@ $("proto-blend").addEventListener("click", (e) => {
 });
 $("proto-swap").addEventListener("click",  () => switchView("swap"));
 $("proto-vault").addEventListener("click", () => switchView("vault"));
+$("proto-compare").addEventListener("click", () => switchView("compare"));
 
 // Mobile sidebar nav
 document.getElementById("mobile-proto-overview")?.addEventListener("click", () => switchView("overview"));
 document.getElementById("mobile-proto-blend")?.addEventListener("click", () => switchView("leverage"));
 document.getElementById("mobile-proto-swap")?.addEventListener("click", () => switchView("swap"));
 document.getElementById("mobile-proto-vault")?.addEventListener("click", () => switchView("vault"));
+document.getElementById("mobile-proto-compare")?.addEventListener("click", () => switchView("compare"));
+
+// Compare view: history-window toggle (re-fetches series)
+$("compare-window-toggle").addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest(".cw-btn") as HTMLElement | null;
+  if (!btn) return;
+  const w = Number(btn.dataset.window);
+  if (!w || w === compareWindowDays) return;
+  compareWindowDays = w;
+  for (const b of document.querySelectorAll("#compare-window-toggle .cw-btn")) {
+    b.classList.toggle("active", b === btn);
+  }
+  renderCompareView();
+});
+// Compare view: sort by column header
+$("compare-table").addEventListener("click", (e) => {
+  const th = (e.target as HTMLElement).closest("th[data-sort]") as HTMLElement | null;
+  if (!th) return;
+  compareSortKey = th.dataset.sort as "lev" | "base" | "rate";
+  for (const h of document.querySelectorAll("#compare-table th[data-sort]")) {
+    h.classList.toggle("ct-sorted", h === th);
+  }
+  renderCompareTable();
+});
+// Compare view: manual refresh
+$("compare-refresh").addEventListener("click", () => renderCompareView());
 
 // Close dropdowns on click outside
 document.addEventListener("click", () => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -87,6 +87,7 @@ import {
 } from "./defindex.ts";
 import { seedHistoryFromServer, fetchSnapshotSeries, type SnapshotPoint } from "./history.ts";
 import { aquariusBestRate, aquariusPrice } from "./aquarius.ts";
+import { getAquariusListing, AQUARIUS_SWAP_URL } from "./aquarius_listings.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -2910,6 +2911,17 @@ $("compare-table").addEventListener("click", (e) => {
 // Compare view: manual refresh
 $("compare-refresh").addEventListener("click", () => renderCompareView());
 
+// Vault view: copy the Aquarius receipt-token contract ID
+document.getElementById("aqua-trade-card")?.addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest(".aqua-copy-btn") as HTMLElement | null;
+  if (!btn?.dataset.copy) return;
+  navigator.clipboard?.writeText(btn.dataset.copy).then(() => {
+    const prev = btn.innerHTML;
+    btn.innerHTML = "&#10003;";
+    setTimeout(() => { btn.innerHTML = prev; }, 1200);
+  }).catch(() => {});
+});
+
 // Close dropdowns on click outside
 document.addEventListener("click", () => {
   $("pool-dropdown").classList.add("hidden");
@@ -3327,8 +3339,30 @@ let _lastVaultStats: VaultStats | null = null;
 let _userVaultBalance = 0;
 let _userWalletBalance = 0;
 
+// T3.2 — surface the vault receipt token's Aquarius listing in the vault view.
+function renderAquariusTradeCard(vault: VaultConfig) {
+  const body = document.getElementById("aqua-trade-body");
+  if (!body) return;
+  const listing = getAquariusListing(vault.assetSymbol);
+  if (listing?.shareToken) {
+    const id = listing.shareToken;
+    const short = `${id.slice(0, 6)}…${id.slice(-4)}`;
+    body.innerHTML = `
+      <a class="btn btn-primary aqua-trade-btn" href="${AQUARIUS_SWAP_URL}" target="_blank" rel="noopener">Trade on Aquarius &#8599;</a>
+      <div class="aqua-trade-token">
+        <span class="aqua-trade-token-label">Receipt token</span>
+        <code class="mono aqua-token-id" title="${id}">${short}</code>
+        <button type="button" class="aqua-copy-btn" data-copy="${id}" title="Copy contract ID">&#10697;</button>
+        <a class="aqua-token-expert" href="${expertUrl("contract", id)}" target="_blank" rel="noopener">Explorer &#8599;</a>
+      </div>`;
+  } else {
+    body.innerHTML = `<p class="aqua-trade-pending">Listing on Aquarius after the mainnet vault launch. The receipt token will trade against USDC, so you can exit your leveraged position without unwinding the loop on-chain.</p>`;
+  }
+}
+
 async function refreshVaultView() {
   const vault = getActiveVault();
+  renderAquariusTradeCard(vault);
   const vaultDepBtn = $("vault-deposit-btn") as HTMLButtonElement;
   const vaultWdBtn  = $("vault-withdraw-btn") as HTMLButtonElement;
   const rebalBtn    = $("vault-rebalance-btn") as HTMLButtonElement;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -85,6 +85,8 @@ import {
   type VaultStats,
   type UserVaultPosition,
 } from "./defindex.ts";
+import { seedHistoryFromServer } from "./history.ts";
+import { aquariusBestRate } from "./aquarius.ts";
 
 // ── Wallet kit ────────────────────────────────────────────────────────────────
 
@@ -1257,10 +1259,27 @@ function renderSelectedAsset() {
   );
 
   renderHistoryChart();
+  maybeSeedHistory();
 
   updatePreview();
   renderPosition();
   renderPortfolioSummary();
+}
+
+// One-time-per-asset: pull the real server time-series (T2.5 /snapshots) into
+// the local history keys so the chart + trend arrows show real 24h/7d/30d/1y
+// data for every visitor, then re-render. No-op if the server has no data yet.
+const _historySeeded = new Set<string>();
+function maybeSeedHistory() {
+  const k = `${selectedPool.id}:${selectedAsset.id}`;
+  if (_historySeeded.has(k)) return;
+  _historySeeded.add(k);
+  void seedHistoryFromServer(selectedPool.id, selectedAsset.id, selectedAsset.symbol).then(
+    (seeded) => {
+      // Only re-render if this asset is still selected and we got server data.
+      if (seeded && `${selectedPool.id}:${selectedAsset.id}` === k) renderSelectedAsset();
+    },
+  );
 }
 
 function renderAprLine(id: string, val: number, isCost: boolean, isBlnd = false, sign?: string, raw = false) {
@@ -2487,6 +2506,9 @@ async function fetchSwapQuote() {
         : "\u2014";
       $("swap-profit").textContent = quote.profit ? `${quote.profit}` : "\u2014";
       $("swap-quote-details").classList.remove("hidden");
+
+      // T3.1: cross-check against Aquarius and badge the best venue.
+      void compareAquariusRate(sellAsset, buyAsset, sellNum, buyNum, buySym);
     } else {
       ($("swap-buy-amount") as HTMLInputElement).value = quote.status === "unfeasible" ? "No route" : "\u2014";
       $("swap-quote-details").classList.add("hidden");
@@ -2501,6 +2523,43 @@ async function fetchSwapQuote() {
     console.warn("Swap quote:", errMsg);
   }
   updateSwapBtn();
+}
+
+/**
+ * T3.1: quote the same pair on Aquarius and badge which venue gives the better
+ * output. Soroban contract IDs come from BROKER_TO_CONTRACT (broker classic ID →
+ * SAC/contract). Hidden gracefully when Aquarius is unreachable (fallback).
+ */
+async function compareAquariusRate(
+  sellBrokerId: string,
+  buyBrokerId: string,
+  sellNum: number,
+  brokerBuyNum: number,
+  buySym: string,
+) {
+  const aqEl = $("swap-aquarius");
+  const badgeEl = $("swap-best-rate");
+  const sellC = BROKER_TO_CONTRACT[sellBrokerId];
+  const buyC = BROKER_TO_CONTRACT[buyBrokerId];
+  if (!sellC || !buyC) {
+    aqEl.textContent = "—";
+    badgeEl.textContent = "—";
+    badgeEl.className = "best-rate-badge";
+    return;
+  }
+  const amountStroops = BigInt(Math.round(sellNum * 1e7));
+  const aq = await aquariusBestRate(sellC, buyC, amountStroops);
+  if (!aq) {
+    aqEl.textContent = "unavailable";
+    badgeEl.textContent = "Broker";
+    badgeEl.className = "best-rate-badge best-broker";
+    return;
+  }
+  const aqOut = Number(aq.amountOut) / 1e7;
+  aqEl.textContent = `${aqOut.toFixed(7)} ${buySym}`;
+  const brokerWins = brokerBuyNum >= aqOut;
+  badgeEl.textContent = brokerWins ? "Broker" : "Aquarius";
+  badgeEl.className = `best-rate-badge ${brokerWins ? "best-broker" : "best-aquarius"}`;
 }
 
 function updateSwapBtn() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1309,3 +1309,77 @@ kbd {
 .best-rate-badge { font-weight: 700; }
 .best-rate-badge.best-broker { color: #2DE8A3; }
 .best-rate-badge.best-aquarius { color: #7B61FF; }
+
+/* ── T3.3 — Compare Pools view ─────────────────────────────────────────────── */
+.compare-section {
+  max-width: 1040px; margin: 0 auto; padding: 28px 20px 40px;
+}
+.compare-header {
+  display: flex; justify-content: space-between; align-items: flex-start;
+  gap: 20px; flex-wrap: wrap; margin-bottom: 20px;
+}
+.compare-title { font-size: 24px; font-weight: 700; margin: 0 0 6px; }
+.compare-sub { color: var(--text-2); font-size: 13px; max-width: 560px; margin: 0; line-height: 1.5; }
+.compare-controls { display: flex; align-items: center; gap: 10px; }
+.compare-window-toggle {
+  display: inline-flex; background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 99px; padding: 3px;
+}
+.cw-btn {
+  background: transparent; border: none; color: var(--text-2);
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  padding: 5px 12px; border-radius: 99px; cursor: pointer; transition: all .15s;
+}
+.cw-btn:hover { color: var(--text); }
+.cw-btn.active { background: var(--primary); color: #04130D; }
+.compare-refresh {
+  width: 36px; height: 32px; padding: 0; font-size: 16px; line-height: 1;
+}
+.compare-table-wrap {
+  border: 1px solid var(--border); border-radius: var(--r);
+  background: var(--surface); overflow-x: auto;
+}
+.compare-table { width: 100%; border-collapse: collapse; min-width: 640px; }
+.compare-table thead th {
+  text-align: right; font-size: 11px; font-weight: 600; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--text-3); padding: 14px 16px;
+  border-bottom: 1px solid var(--border); white-space: nowrap; user-select: none;
+}
+.compare-table th.ct-rank, .compare-table th.ct-asset { text-align: left; }
+.compare-table th[data-sort] { cursor: pointer; }
+.compare-table th[data-sort]:hover { color: var(--text); }
+.compare-table th.ct-sorted { color: var(--primary); }
+.compare-table tbody td {
+  padding: 14px 16px; border-bottom: 1px solid var(--border);
+  font-size: 14px; text-align: right; vertical-align: middle;
+}
+.compare-table tbody tr:last-child td { border-bottom: none; }
+.compare-table tbody tr:hover { background: var(--tab-hover-bg); }
+.ct-rank { width: 44px; text-align: left !important; color: var(--text-3); font-family: var(--mono); }
+.ct-medal { color: var(--warning); font-size: 16px; }
+.ct-asset { text-align: left !important; }
+.ct-asset-cell { display: flex; align-items: center; gap: 8px; }
+.ct-sym { font-weight: 700; font-size: 15px; }
+.ct-pool { display: block; color: var(--text-3); font-size: 11px; margin-top: 2px; }
+.ct-num { font-family: var(--mono); }
+.ct-lev-apy { color: var(--primary); font-weight: 600; }
+.ct-lev { color: var(--text-2); }
+.ct-muted { color: var(--text-3); }
+.ct-best-row { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
+.ct-best-row:hover { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
+.compare-table .best-rate-badge {
+  font-size: 9px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 99px; background: var(--primary);
+  color: #04130D !important; white-space: nowrap;
+}
+.ct-trend { width: 100px; text-align: right; }
+.ct-spark { display: inline-block; vertical-align: middle; }
+.ct-spark-up { color: var(--success); }
+.ct-spark-down { color: var(--danger); }
+.ct-spark-empty { color: var(--text-3); font-family: var(--mono); }
+.compare-loading { text-align: center !important; color: var(--text-2); padding: 32px 16px !important; }
+.compare-foot { color: var(--text-3); font-size: 11px; line-height: 1.5; margin: 14px 4px 0; }
+@media (max-width: 640px) {
+  .compare-header { flex-direction: column; }
+  .compare-title { font-size: 20px; }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1304,3 +1304,8 @@ kbd {
   font-family: var(--font-mono, monospace);
   font-size: 0.8rem;
 }
+
+/* T3.1 — Aquarius best-rate badge */
+.best-rate-badge { font-weight: 700; }
+.best-rate-badge.best-broker { color: #2DE8A3; }
+.best-rate-badge.best-aquarius { color: #7B61FF; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1383,3 +1383,30 @@ kbd {
   .compare-header { flex-direction: column; }
   .compare-title { font-size: 20px; }
 }
+
+/* ── T3.2 — Aquarius trade card (vault view) ───────────────────────────────── */
+.aqua-trade-card {
+  margin: 16px 0 0; padding: 16px; border: 1px solid var(--border);
+  border-radius: var(--r); background: var(--surface2);
+}
+.aqua-trade-head { display: flex; align-items: flex-start; gap: 12px; }
+.aqua-trade-icon { font-size: 20px; color: var(--blnd); line-height: 1.4; }
+.aqua-trade-title { margin: 0 0 4px; font-size: 15px; font-weight: 700; }
+.aqua-trade-sub { margin: 0; font-size: 12px; color: var(--text-2); line-height: 1.5; }
+.aqua-trade-body { margin-top: 14px; }
+.aqua-trade-pending { margin: 0; font-size: 12px; color: var(--text-3); line-height: 1.5; }
+.aqua-trade-btn { display: inline-flex; align-items: center; gap: 6px; }
+.aqua-trade-token {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 12px;
+  font-size: 12px;
+}
+.aqua-trade-token-label { color: var(--text-3); }
+.aqua-token-id { color: var(--text); background: var(--surface3); padding: 2px 8px; border-radius: var(--r-xs); }
+.aqua-copy-btn {
+  background: transparent; border: 1px solid var(--border); color: var(--text-2);
+  border-radius: var(--r-xs); padding: 2px 7px; cursor: pointer; font-size: 12px;
+  line-height: 1.2; transition: all .15s;
+}
+.aqua-copy-btn:hover { border-color: var(--border-h); color: var(--text); }
+.aqua-token-expert { color: var(--primary); text-decoration: none; }
+.aqua-token-expert:hover { text-decoration: underline; }


### PR DESCRIPTION
**SCF #43 Tranche 3, deliverable T3.2** (Aquarius SEP-41 listing + trade UX). No dedicated GitHub issue — tracked in the grant milestones. (#11 "A9: Compare Pools view" is T3.3, closed by #274.)

Stacked on #274 (T3.3) → #273 (T3.1). Review/merge last in the T3 stack.

## What
Each Turbolong vault mints a **separate SEP-41 receipt token** (the `vault_share` contract) representing a depositor's leveraged position. T3.2 makes that token tradable on Aquarius so a holder can exit by **selling shares for USDC** instead of unwinding the leverage loop on-chain.

This PR ships everything buildable ahead of mainnet:

- **Vault-view "Trade on Aquarius" card** — once a listing exists, shows a Trade CTA (to Aquarius swap), the **copyable** receipt-token contract ID, and an Explorer link. Until then, a graceful *"listing after mainnet"* notice explaining the receipt token.
- **Isolated listing registry** `frontend/src/aquarius_listings.ts` — `AQUARIUS_LISTINGS` keyed by vault `assetSymbol`, empty until mainnet. Standalone file (not a `VaultConfig` field) to avoid colliding with #272's `shareToken?` across the stack.
- **`docs/aquarius-listing-runbook.md`** — permissionless pool-creation steps (constant-product, **0.3%** fee tier, **300k AQUA** creation fee), the **verified** `deposit` / `swap_chained` / `get_pools` signatures, registry-population step, and the **5-trade acceptance verification**.

## Honesty / scope
The Aquarius pool-**creation** entrypoint (`init_*_pool`) signature is **not** in the public Aquarius developer docs, so I did **not** ship a guessed pool-creation tx-builder for a real money path. The runbook directs creation via the Aquarius UI or the live-verified ABI at listing time. The actual listing, liquidity seeding, and 5 verification trades are **mainnet-gated**.

## Verification
- `npm run build` — clean (vite, 2571 modules).
- `npm run lint` — clean (biome, 9 files).
- Pre-listing path verified: registry empty -> card renders graceful notice.