### PR TITLE
docs: SCF Tranche 1 completion report + revised-date notice (T1 Phase 4)

### DIFF
--- a/docs/evidence/gitleaks-block-demo.md
+++ b/docs/evidence/gitleaks-block-demo.md
@@ -1,0 +1,41 @@
+# Evidence — gitleaks blocks a planted secret (SCF T1 D5)
+
+Proof that the repo's secret-scanning gate (`.gitleaks.toml` custom rule
+`stellar-secret-key`, enforced by `secret-scan.yml` in CI and the
+`pre-commit` hook locally) detects a hardcoded Stellar secret key.
+
+The planted key below is **fake** (prefix `SDEMOGITLEAKS…`, random base32 tail,
+never funded) and is **redacted** here so this evidence file does not itself
+trip the scanner.
+
+## Command
+
+```
+# planted fake key in a throwaway file (NOT committed to the repo):
+#   DEPLOY_SECRET_KEY=SDEMOGITLEAKS<43 random base32 chars>   (56 chars, matches S[A-Z2-7]{55})
+gitleaks detect --no-git --source /tmp/gldemo -c .gitleaks.toml -v
+```
+
+## Result (gitleaks v8.30.1)
+
+```
+Finding:     DEPLOY_SECRET_KEY=SDEMOGITLEAKS<redacted>
+Secret:      SDEMOGITLEAKS<redacted>
+RuleID:      stellar-secret-key
+Entropy:     4.624057
+Tags:        [stellar key secret]
+File:        /tmp/gldemo/leaked.env
+Line:        1
+Fingerprint: /tmp/gldemo/leaked.env:stellar-secret-key:1
+
+INF scanned ~75 bytes (75 bytes) in 21.3ms
+WRN leaks found: 1
+```
+
+**Exit code: 1** — a non-zero exit fails the `secret-scan.yml` job, blocking the
+PR. The same rule runs in the local `pre-commit` hook (`pre-commit run gitleaks`)
+before a commit can be created.
+
+> Method: local block proof — relies on the security control, does not bypass
+> it (no `--no-verify`, nothing pushed). The planted file lived only in `/tmp`
+> and was deleted after the scan.

--- a/docs/scf-t1-completion-report.md
+++ b/docs/scf-t1-completion-report.md
@@ -21,7 +21,7 @@
 | D2 | Full SEP-41 receipt token ($4k) | ✅ Done | Separate `vault_share` SEP-41 contract (resolves the trait-`balance` vs SEP-41-`balance` collision). `transfer`/`approve`/`allowance`/`transfer_from`, `total_supply == Σ balances`. **15 unit tests** (`contracts/tokens/vault_share/src/test.rs`). Mainnet address captured at D1 deploy. |
 | D3 | In-place WASM upgrade + admin ($2k) | ✅ Done | `upgrade()` + admin role + `version()`; storage/positions preserved. Upgrade-parity tests assert Config, every `VaultPos`, `total_shares`, recomputed HF identical **within 1e-7** pre/post (`test_integration.rs`, **13 tests**). Runbook: `docs/migration-runbook.md`. |
 | D4 | Wallets Kit mobile + Ledger + E2E ($5k) | ✅ Code done / ⛔ device sign-off | Ledger module + WalletConnect mobile deep-link + Playwright e2e (5 wallets × {classic, Soroban}, mock seam) — PR #259. ⛔ Physical Ledger run + iOS/Android device runs (Lobstr/xBull) + wallet-team sign-off pending (external). |
-| D5 | CI / supply-chain hygiene ($2k) | ✅ Done | `dependabot.yml`, `cargo-audit.yml`, Clippy `-D warnings` + `cargo fmt --check` (`contracts.yml`), Biome + build + e2e (`frontend-ci.yml`), `secret-scan.yml` (gitleaks) + `.gitleaks.toml` + pre-commit. Dependabot actively opening PRs. ⛔ gitleaks planted-secret block screenshot (evidence demo) — in progress. |
+| D5 | CI / supply-chain hygiene ($2k) | ✅ Done | `dependabot.yml`, `cargo-audit.yml`, Clippy `-D warnings` + `cargo fmt --check` (`contracts.yml`), Biome + build + e2e (`frontend-ci.yml`), `secret-scan.yml` (gitleaks) + `.gitleaks.toml` + pre-commit. Dependabot actively opening PRs. ✅ gitleaks blocks a planted Stellar key (rule `stellar-secret-key`, exit 1) — local proof captured in `docs/evidence/gitleaks-block-demo.md`. |
 
 ## Verifiable now (on `main`)
 
@@ -42,7 +42,7 @@
 - [ ] Per-asset deposit → loop → withdraw tx hashes (Stellar Expert).
 - [ ] DeFindex co-sign of the 4 deployments.
 - [ ] Ledger hardware run + iOS/Android deep-link runs + wallet-team sign-off.
-- [ ] gitleaks planted-secret block screenshot.
+- [x] gitleaks planted-secret block — local proof captured (`docs/evidence/gitleaks-block-demo.md`).
 
 ## Revised dates / notice to SCF
 

--- a/docs/scf-t1-completion-report.md
+++ b/docs/scf-t1-completion-report.md
@@ -1,0 +1,60 @@
+# SCF #43 — Tranche 1 Completion Report (DRAFT)
+
+> **Status: draft.** Code/prep deliverables are complete and verifiable on
+> `main`. Items marked ⛔ are **mainnet-gated** or **external** and will be
+> filled at launch. **T1's stated completion date (08 Jun 2026) has passed** —
+> this report doubles as the proactive notice of revised dates (see bottom).
+> Do not file as *complete* until the ⛔ rows have captured evidence; file now
+> as a **status update + revised-date notice**.
+
+**Project:** Turbolong — leveraged-long protocol on Stellar/Blend.
+**Track:** Integration ($100k XLM). **Tranche 1 = $20,000 (20%).**
+**Original due:** 08 Jun 2026. **Report date:** _TBD at filing._
+
+---
+
+## Deliverables
+
+| # | Deliverable ($) | Status | Evidence |
+|---|-----------------|--------|----------|
+| D1 | 4-asset mainnet vault deployment ($7k) | ⛔ Prepped, not deployed | Deploy script `scripts/deploy_strategy_mainnet.ts` (4 strategy + 4 `vault_share`, `set_share_token` + `set_swap_account`, writes `deployed-vaults.mainnet.json`) — PR #271. Frontend wiring + `MAINNET_VAULTS` — PR #272. `docs/mainnet-go-live-runbook.md`. Config sourced (Soroswap router, live pool c_factors). ⛔ Deploy + per-asset deposit→loop→withdraw verification + DeFindex co-sign pending. |
+| D2 | Full SEP-41 receipt token ($4k) | ✅ Done | Separate `vault_share` SEP-41 contract (resolves the trait-`balance` vs SEP-41-`balance` collision). `transfer`/`approve`/`allowance`/`transfer_from`, `total_supply == Σ balances`. **15 unit tests** (`contracts/tokens/vault_share/src/test.rs`). Mainnet address captured at D1 deploy. |
+| D3 | In-place WASM upgrade + admin ($2k) | ✅ Done | `upgrade()` + admin role + `version()`; storage/positions preserved. Upgrade-parity tests assert Config, every `VaultPos`, `total_shares`, recomputed HF identical **within 1e-7** pre/post (`test_integration.rs`, **13 tests**). Runbook: `docs/migration-runbook.md`. |
+| D4 | Wallets Kit mobile + Ledger + E2E ($5k) | ✅ Code done / ⛔ device sign-off | Ledger module + WalletConnect mobile deep-link + Playwright e2e (5 wallets × {classic, Soroban}, mock seam) — PR #259. ⛔ Physical Ledger run + iOS/Android device runs (Lobstr/xBull) + wallet-team sign-off pending (external). |
+| D5 | CI / supply-chain hygiene ($2k) | ✅ Done | `dependabot.yml`, `cargo-audit.yml`, Clippy `-D warnings` + `cargo fmt --check` (`contracts.yml`), Biome + build + e2e (`frontend-ci.yml`), `secret-scan.yml` (gitleaks) + `.gitleaks.toml` + pre-commit. Dependabot actively opening PRs. ⛔ gitleaks planted-secret block screenshot (evidence demo) — in progress. |
+
+## Verifiable now (on `main`)
+
+- **Contracts:** 71 tests green (43 `test_leverage.rs`, 13 `test_integration.rs`
+  incl. upgrade-parity 1e-7, 15 `vault_share/test.rs`); clippy `-D warnings` +
+  `cargo fmt --check` enforced; wasm builds.
+- **Rate parity:** TS `projectRates` ↔ Rust `rate_calc` over ≥20 IR-kink
+  fixtures (`parity.yml`).
+- **Frontend/Worker:** Biome + Vite build + Playwright e2e (`frontend-ci.yml`).
+- **Supply-chain:** Dependabot PRs landing weekly; `cargo audit`; gitleaks gate
+  on every PR; main CI fully green.
+- **Receipt-token correctness:** unit-tested transfer/approve/allowance semantics.
+- **Upgrade safety:** parity within 1e-7 + documented migration runbook.
+
+## Mainnet-gated / external (fill at launch) ⛔
+
+- [ ] 4 mainnet vault contract IDs + receipt-token addresses.
+- [ ] Per-asset deposit → loop → withdraw tx hashes (Stellar Expert).
+- [ ] DeFindex co-sign of the 4 deployments.
+- [ ] Ledger hardware run + iOS/Android deep-link runs + wallet-team sign-off.
+- [ ] gitleaks planted-secret block screenshot.
+
+## Revised dates / notice to SCF
+
+- **D2, D3, D5** — complete and verifiable on `main` now.
+- **D1** — code/prep complete; deploy is gated on operational sign-offs (keeper +
+  admin keys, per-asset config, go-ahead) and DeFindex co-sign. **Revised target:
+  _set at filing_** (align with the T3 mainnet launch window, due 15 Sep 2026).
+- **D4** — code complete; device/hardware sign-offs are external. **Revised
+  target: _set at filing_**, tracked in parallel.
+
+## Links
+
+- Mainnet deploy: `docs/mainnet-go-live-runbook.md` · Migration: `docs/migration-runbook.md`
+- Launch runbook: `docs/launch-runbook.md` · Testing programme: `docs/testing-programme.md`
+- PRs: #271 (D1 deploy script), #272 (D1 wiring), #259 (D4 wallets)


### PR DESCRIPTION
**SCF #43 Tranche 1, Phase 4** — completion report + proactive revised-date notice. Docs-only, off `main`, independent of the T3 stack.

T1 was due **08 Jun 2026** (now past). This report serves as both the completion status and the notice of revised dates.

## Status
- **D2** (full SEP-41 receipt token) — ✅ done; separate `vault_share` contract, 15 unit tests.
- **D3** (in-place WASM upgrade + admin) — ✅ done; upgrade-parity within 1e-7 (13 integration tests), migration runbook.
- **D5** (CI / supply-chain) — ✅ done; dependabot, cargo-audit, clippy/fmt, gitleaks, frontend-ci. ⛔ planted-secret block screenshot (evidence demo in progress).
- **D1** (4-asset mainnet deploy) — ⛔ prepped (#271 deploy script, #272 wiring) + mainnet-gated (deploy + verify + DeFindex co-sign).
- **D4** (wallets mobile + Ledger + e2e) — ✅ code done (#259) / ⛔ external device sign-offs.

Verifiable-now evidence (71 contract tests, parity, CI-green) listed; mainnet/external rows flagged ⛔ to fill at launch. Revised D1/D4 targets to be set at filing (align with the T3 mainnet window, due 15 Sep 2026).

No code changes.