### PR TITLE
fix(ui): boot crash on first visit — _modalState TDZ

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -403,6 +403,11 @@ window.matchMedia("(prefers-color-scheme: light)").addEventListener("change", ()
 
 // ── Disclaimer ───────────────────────────────────────────────────────────
 
+// Modal focus-management state. Declared BEFORE this top-level disclaimer block,
+// which calls openModal() during module init — a `const` defined later (next to
+// openModal) would be in the temporal dead zone and crash boot for new visitors.
+const _modalState = new WeakMap<HTMLElement, { trigger: HTMLElement | null; trap: (e: KeyboardEvent) => void }>();
+
 if (!localStorage.getItem("disclaimerAccepted")) {
   openModal(document.getElementById("disclaimer-overlay")!, {
     focus: document.getElementById("disclaimer-checkbox"),
@@ -3047,8 +3052,8 @@ function debounceQuote() {
 const FOCUSABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-// Per-overlay state: the element to restore focus to, and the active trap handler.
-const _modalState = new WeakMap<HTMLElement, { trigger: HTMLElement | null; trap: (e: KeyboardEvent) => void }>();
+// _modalState is declared near the top ($ helper) so it's initialized before the
+// top-level disclaimer block calls openModal() during module init (TDZ fix).
 
 function _focusable(overlay: HTMLElement): HTMLElement[] {
   return Array.from(overlay.querySelectorAll<HTMLElement>(FOCUSABLE))


### PR DESCRIPTION
**Hotfix — main is currently broken for new visitors.**

The top-level disclaimer block (`if (!disclaimerAccepted) openModal(...)`) runs during module init, but `const _modalState` (used by `openModal`) was declared ~2600 lines later. On a **first visit** the disclaimer shows → `openModal` → `_modalState` in the **temporal dead zone** → `ReferenceError` → the rest of `main.ts` never runs → **blank/dead app**. Returning users (disclaimer already accepted) skip the call, so it looked fine — which is why it wasn't caught, but the e2e 'boots + installs mock seam' test timed out (the failure on main).

Fix: declare the `_modalState` WeakMap **before** the disclaimer block. Verified headless on a fresh context: zero page errors, nav renders, disclaimer shows. Build + lint clean.

Root cause: introduced when the P3 modal-focus helper merged with the rest of the stack.