### PR TITLE
fix(blend): ignore expired BLND emissions in APR (EURC phantom yield)

### DIFF
--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -562,9 +562,15 @@ export async function fetchAllReserves(pool: PoolDef, userAddress: string): Prom
       const supplyCapture_fp  = Math.floor((SCALAR_F - BACKSTOP_FP) * curUtil_fp / SCALAR_F);
       const interestSupplyApr = (Math.floor(curIr_fp * supplyCapture_fp / SCALAR_F) / SCALAR_F) * 100;
 
-      // BLND emissions APR
-      const supplyEps = supplyEmissions?.eps != null ? BigInt(supplyEmissions.eps) : 0n;
-      const borrowEps = borrowEmissions?.eps != null ? BigInt(borrowEmissions.eps) : 0n;
+      // BLND emissions APR — only count emissions that are still ACTIVE. A reserve
+      // whose emission window has expired still returns a stale `eps`; using it
+      // shows a phantom BLND APR (e.g. EURC on YieldBlox, emissions expired ~3
+      // weeks ago, was showing thousands of % while other assets were fine).
+      const nowSec = Math.floor(Date.now() / 1000);
+      const supplyEps = supplyEmissions?.eps != null && Number(supplyEmissions.expiration ?? 0) > nowSec
+        ? BigInt(supplyEmissions.eps) : 0n;
+      const borrowEps = borrowEmissions?.eps != null && Number(borrowEmissions.expiration ?? 0) > nowSec
+        ? BigInt(borrowEmissions.eps) : 0n;
       const totalSupplyUsd = totalSupply * priceUsd;
 
       // BLND/yr = eps × seconds_per_year / 1e7 / 1e7


### PR DESCRIPTION
**Root cause of the wrong EURC/YieldBlox yield (verified on-chain).**

`fetchAllReserves` read the emissions `eps` but ignored its `expiration`. A reserve whose emission window has **ended** still returns a stale `eps`, so the app computed a **phantom BLND supply APR**. EURC on YieldBlox — emissions **expired ~3 weeks ago** (`expiration 1779344833` < now `~1781382600`) — showed thousands of %, while assets with **active** emissions (USDC, `expiration 1781849255` > now) were correct. That's exactly 'EURC wrong, others fine.'

Fix: count `eps` only when `expiration > now` (supply + borrow). Expired emissions → 0 APR → net supply APY = interest only. One-line guard at the extraction point, so both `fetchAllReserves` and `withBlndPriceAssumption` (which reads the stored eps) are corrected.

Verified: build + lint clean; headless `?e2e=1` boot clean.