### PR TITLE
fix(ui): pool-wide Account HF instead of scary per-asset HF (cross-asset positions)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -577,6 +577,7 @@
 
               <div id="position-data" class="hidden">
                 <div id="hf-pos-warning" class="hf-pos-warning hidden"></div>
+                <p id="cross-asset-note" class="cross-asset-note hidden"></p>
 
                 <!-- Position data as table rows -->
                 <div class="position-grid">
@@ -597,7 +598,7 @@
                     <span class="metric-value mono" id="pos-leverage">—</span>
                   </div>
                   <div class="position-metric">
-                    <span class="metric-label">Asset HF <span class="tooltip" data-tip="Health Factor for this asset only. HF = (collateral x c_factor) / (debt / l_factor). Below 1.0 = liquidatable.">?</span></span>
+                    <span class="metric-label">Loop HF <span class="tooltip" data-tip="Health factor of this single-asset loop. Your account is liquidated on the pool-wide Account Health, shown separately.">?</span></span>
                     <span class="metric-value" id="pos-hf">—</span>
                     <div class="hf-bar-wrap" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Health factor"><div class="hf-bar" id="hf-bar"></div></div>
                     <div class="hf-gauge-container"></div>

--- a/frontend/src/locales.ts
+++ b/frontend/src/locales.ts
@@ -280,6 +280,10 @@ const en: Dict = {
   "dashboard.over10y": ">10 years",
   "dashboard.daysApprox": "~{n} days",
   "dashboard.interestSpread": "Interest spread: {pct}%/yr (borrow − supply). Claim & convert BLND to extend runway.",
+  // #294 — cross-collateralized / account-wide HF
+  "pos.crossCollat": "Cross-collateralized",
+  "pos.crossExplainer": "Cross-collateralized position — your collateral and borrows are in different assets. Liquidation is based on your Account Health above, not the individual rows.",
+  "pos.loopHf": "Loop HF",
   // P4 — toasts
   "toast.demoMode": "Demo mode — connect a real wallet to transact",
   "toast.demoExplore": "Demo mode — explore the UI without a wallet",
@@ -590,6 +594,10 @@ const es: Dict = {
   "dashboard.over10y": ">10 años",
   "dashboard.daysApprox": "~{n} días",
   "dashboard.interestSpread": "Diferencial de interés: {pct}%/año (préstamo − suministro). Reclama y convierte BLND para ampliar el margen.",
+  // #294 — cross-collateralized / account-wide HF
+  "pos.crossCollat": "Con garantía cruzada",
+  "pos.crossExplainer": "Posición con garantía cruzada — tu garantía y tus préstamos están en activos diferentes. La liquidación se basa en la Salud de tu Cuenta de arriba, no en las filas individuales.",
+  "pos.loopHf": "HF del bucle",
   // P4 — toasts
   "toast.demoMode": "Modo demo — conecta una billetera real para operar",
   "toast.demoExplore": "Modo demo — explora la interfaz sin billetera",
@@ -900,6 +908,10 @@ const pt: Dict = {
   "dashboard.over10y": ">10 anos",
   "dashboard.daysApprox": "~{n} dias",
   "dashboard.interestSpread": "Spread de juros: {pct}%/ano (empréstimo − fornecimento). Reivindique e converta BLND para estender a margem.",
+  // #294 — cross-collateralized / account-wide HF
+  "pos.crossCollat": "Com garantia cruzada",
+  "pos.crossExplainer": "Posição com garantia cruzada — sua garantia e seus empréstimos estão em ativos diferentes. A liquidação é baseada na Saúde da sua Conta acima, não nas linhas individuais.",
+  "pos.loopHf": "HF do loop",
   // P4 — toasts
   "toast.demoMode": "Modo demo — conecte uma carteira real para operar",
   "toast.demoExplore": "Modo demo — explore a interface sem carteira",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1337,6 +1337,23 @@ function computePoolHF(): number {
   return totalDebt > 0 ? weightedCollateral / totalDebt : Number.POSITIVE_INFINITY;
 }
 
+// A position is "single-sided" when it has only collateral or only debt in this
+// asset. The account is cross-collateralized when debt in one asset is backed by
+// collateral in another. For those, the PER-ASSET HF is misleading (0 or ∞) — the
+// pool-wide HF is the real liquidation trigger.
+function isSingleSided(pos: AssetPosition): boolean {
+  return (pos.collateral > 0 && pos.debt === 0) || (pos.debt > 0 && pos.collateral === 0);
+}
+function isCrossAssetAccount(): boolean {
+  let coll = false, debt = false, sided = false;
+  for (const p of positions.byAsset.values()) {
+    if (p.collateral > 0) coll = true;
+    if (p.debt > 0) debt = true;
+    if (isSingleSided(p)) sided = true;
+  }
+  return sided && coll && debt; // debt backed by collateral in a different asset
+}
+
 // ── Portfolio summary (#8) ───────────────────────────────────────────────────
 
 function renderPortfolioSummary() {
@@ -1348,7 +1365,15 @@ function renderPortfolioSummary() {
     const rs = reserves.find(r => r.asset.id === assetId);
     const cardNetApr = rs ? rs.netSupplyApr * pos.leverage - rs.netBorrowCost * (pos.leverage - 1) : 0;
     const netApy = aprToApy(cardNetApr);
-    const hfColor = pos.hf > 1.1 ? "var(--success)" : pos.hf > 1.03 ? "var(--warning)" : "var(--danger)";
+    // Single-sided positions (cross-collateralized account) have a misleading
+    // per-asset HF — show a neutral tag and grey dot instead of a scary HF. (#294)
+    const sided = isSingleSided(pos);
+    const hfColor = sided
+      ? "var(--text-3)"
+      : pos.hf > 1.1 ? "var(--success)" : pos.hf > 1.03 ? "var(--warning)" : "var(--danger)";
+    const hfText = sided
+      ? t("pos.crossCollat")
+      : `HF ${fmt(pos.hf, 2)} (${hfZoneWord(pos.hf)})`;
     const card = document.createElement("div");
     card.className = `portfolio-card ${assetId === selectedAsset.id ? "active" : ""}`;
     card.title = `Approximate APY — Blend does not auto-compound. Actual net APR: ${fmt(cardNetApr, 2)}%`;
@@ -1357,7 +1382,7 @@ function renderPortfolioSummary() {
       <span class="portfolio-card-symbol">${pos.asset.symbol}</span>
       <span class="portfolio-card-details">
         <span>${fmt(pos.equity, 2)} equity \u00B7 ${fmt(pos.leverage, 1)}\u00D7</span>
-        <span>APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% \u00B7 HF ${fmt(pos.hf, 2)} (${hfZoneWord(pos.hf)})</span>
+        <span>APY ${netApy >= 0 ? "+" : ""}${fmt(netApy, 2)}% \u00B7 ${hfText}</span>
       </span>`;
     card.addEventListener("click", () => {
       const asset = assets.find(a => a.id === assetId);
@@ -1432,46 +1457,66 @@ function renderPosition() {
   // Animated leverage (#11)
   animateNumber($("pos-leverage"), pos.leverage, 200, n => `${fmt(n, 2)}\u00D7`);
 
-  // Hero metrics
-  const hf = pos.hf;
+  // Pool-wide health factor \u2014 Blend liquidates on the ACCOUNT-level (pool-wide)
+  // HF, not per-asset. Drive all the liquidation-relevant UI (hero, bar, gauge,
+  // warning, days-to-liq) off poolHF so a cross-collateralized account is not
+  // shown as "liquidation imminent" on a single-sided row. For a normal single
+  // self-contained loop, computePoolHF() === pos.hf, so the display is identical. (#294)
+  const hf     = pos.hf;
+  const poolHF = computePoolHF();
+  const sided  = isSingleSided(pos);
+
+  // Hero metrics \u2014 account-level HF
   const heroHf = $("hero-hf");
-  heroHf.textContent = Number.isFinite(hf) ? fmt(hf, 3) : "\u221E";
-  heroHf.className = `metric-hero-value ${hf > 1.1 ? "hf-ok" : hf > 1.03 ? "hf-warn" : "hf-bad"}`;
+  heroHf.textContent = Number.isFinite(poolHF) ? fmt(poolHF, 3) : "\u221E";
+  heroHf.className = `metric-hero-value ${poolHF > 1.1 ? "hf-ok" : poolHF > 1.03 ? "hf-warn" : "hf-bad"}`;
   $("hero-leverage").textContent = `${fmt(pos.leverage, 2)}\u00D7`;
 
-  // Per-asset health factor with icon (#22)
+  // Per-asset (loop) health factor with icon (#22). For single-sided positions the
+  // per-asset HF is misleading (0 or \u221E) \u2014 show a neutral cross-collat tag. (#294)
   const hfEl = $("pos-hf");
-  const hfIcon = hf > 1.1 ? "\u2713" : hf > 1.03 ? "\u26A0" : "\u2717";
-  const hfDec = expertMode ? 5 : 3;
-  hfEl.textContent = `${hfIcon} ${Number.isFinite(hf) ? fmt(hf, hfDec) : "\u221E"}`;
-  hfEl.className   = `metric-value ${hf > 1.1 ? "hf-ok" : hf > 1.03 ? "hf-warn" : "hf-bad"}`;
-  // Text zone word so risk isn't colour/icon-only (#9)
-  hfEl.setAttribute("aria-label", `Asset health factor ${Number.isFinite(hf) ? fmt(hf, 3) : "infinity"}, ${hfZoneWord(hf)}`);
-  const barPct = Math.min(100, Math.max(0, (hf - 1) / 0.3 * 100));
+  if (sided) {
+    hfEl.textContent = t("pos.crossCollat");
+    hfEl.className   = "metric-value";
+    const crossTip = "This asset is part of a cross-collateralized account; liquidation is based on your Account Health.";
+    hfEl.setAttribute("aria-label", crossTip);
+    hfEl.setAttribute("title", crossTip);
+  } else {
+    const hfIcon = hf > 1.1 ? "\u2713" : hf > 1.03 ? "\u26A0" : "\u2717";
+    const hfDec = expertMode ? 5 : 3;
+    hfEl.textContent = `${hfIcon} ${Number.isFinite(hf) ? fmt(hf, hfDec) : "\u221E"}`;
+    hfEl.className   = `metric-value ${hf > 1.1 ? "hf-ok" : hf > 1.03 ? "hf-warn" : "hf-bad"}`;
+    // Text zone word so risk isn't colour/icon-only (#9)
+    hfEl.setAttribute("aria-label", `Loop health factor ${Number.isFinite(hf) ? fmt(hf, 3) : "infinity"}, ${hfZoneWord(hf)}`);
+    hfEl.removeAttribute("title");
+  }
+
+  // HF bar \u2014 driven off the account-level (pool-wide) HF (#294)
+  const barPct = Math.min(100, Math.max(0, (poolHF - 1) / 0.3 * 100));
   const bar = $("hf-bar");
   bar.style.width      = `${barPct}%`;
-  bar.style.background = hf > 1.1 ? "var(--success)" : hf > 1.03 ? "var(--warning)" : "var(--danger)";
+  bar.style.background = poolHF > 1.1 ? "var(--success)" : poolHF > 1.03 ? "var(--warning)" : "var(--danger)";
 
   // ARIA on HF bar (#8) — role="meter" with live valuetext incl. zone word
-  const hfZone = hfZoneWord(hf);
+  const hfZone = hfZoneWord(poolHF);
   const barWrap = $("hf-bar").parentElement!;
   barWrap.setAttribute("aria-valuenow", String(Math.round(barPct)));
   barWrap.setAttribute(
     "aria-valuetext",
-    `Health factor ${Number.isFinite(hf) ? fmt(hf, 3) : "infinity"}, ${hfZone}`,
+    `Account health factor ${Number.isFinite(poolHF) ? fmt(poolHF, 3) : "infinity"}, ${hfZone}`,
   );
 
   // HF Gauge (#7)
   const gaugeEl = document.querySelector(".hf-gauge-container") as HTMLElement;
-  if (gaugeEl) gaugeEl.innerHTML = renderHFGauge(hf);
+  if (gaugeEl) gaugeEl.innerHTML = renderHFGauge(poolHF);
 
-  // HF warning banner (#2) — only show below 1.01
+  // HF warning banner (#2) — keyed off the account-level HF, only below 1.01 (#294)
   const warnEl = $("hf-pos-warning");
-  if (Number.isFinite(hf) && hf < 1.01) {
-    const isDanger = hf < 1.003;
+  if (Number.isFinite(poolHF) && poolHF < 1.01) {
+    const isDanger = poolHF < 1.003;
     warnEl.className = `hf-pos-warning ${isDanger ? "hf-danger-level" : "hf-warn-level"}`;
     warnEl.innerHTML = `
-      <span>${isDanger ? "\u2717" : "\u26A0"} Health Factor is ${fmt(hf, 3)} \u2014 ${isDanger ? "liquidation imminent!" : "approaching liquidation"}</span>
+      <span>${isDanger ? "\u2717" : "\u26A0"} Health Factor is ${fmt(poolHF, 3)} \u2014 ${isDanger ? "liquidation imminent!" : "approaching liquidation"}</span>
       <div class="hf-warn-actions">
         <button class="btn btn-sm btn-secondary" onclick="document.getElementById('resupply-btn').click()">Resupply</button>
       </div>`;
@@ -1480,8 +1525,16 @@ function renderPosition() {
     warnEl.classList.add("hidden");
   }
 
+  // Cross-asset explainer note (#294)
+  const crossNote = $("cross-asset-note");
+  if (isCrossAssetAccount()) {
+    crossNote.textContent = t("pos.crossExplainer");
+    crossNote.classList.remove("hidden");
+  } else {
+    crossNote.classList.add("hidden");
+  }
+
   // Pool-wide health factor with icon (#22)
-  const poolHF   = computePoolHF();
   const poolHFEl = $("pos-pool-hf");
   const poolIcon = poolHF > 1.1 ? "\u2713" : poolHF > 1.03 ? "\u26A0" : "\u2717";
   poolHFEl.textContent = `${poolIcon} ${Number.isFinite(poolHF) ? fmt(poolHF, 3) : "\u221E"}`;
@@ -1531,14 +1584,14 @@ function renderPosition() {
   // Days until liquidation with ring (#18)
   const liqDaysEl  = $("pos-liq-days");
   const liqNoteEl  = $("pos-liq-note");
-  if (rs && pos.leverage > 0 && Number.isFinite(pos.hf) && pos.hf > 1) {
+  if (rs && pos.leverage > 0 && Number.isFinite(poolHF) && poolHF > 1) {
     const spreadPct = rs.interestBorrowApr - rs.interestSupplyApr;
     if (spreadPct <= 0) {
       liqDaysEl.textContent = t("dashboard.liqNever");
       liqDaysEl.className   = "metric-value hf-ok";
       liqNoteEl.textContent = "";
     } else {
-      const daysLeft = Math.log(pos.hf) / (spreadPct / 100) * 365;
+      const daysLeft = Math.log(poolHF) / (spreadPct / 100) * 365;
       if (daysLeft <= 365) {
         liqDaysEl.innerHTML = `<span class="liq-countdown-wrap">${renderLiqCountdownRing(daysLeft)} <span>${t("dashboard.daysApprox", { n: Math.round(daysLeft) })}</span></span>`;
       } else {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -557,6 +557,9 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .hf-pos-warning.hf-danger-level { background: var(--danger-bg); border: 1px solid var(--danger-border); color: var(--danger); }
 .hf-pos-warning .hf-warn-actions { display: flex; gap: 6px; flex-shrink: 0; }
 
+/* #294 — cross-collateralized account explainer */
+.cross-asset-note { font-size: 12px; color: var(--text-2); background: var(--surface2); border-radius: var(--r-sm); padding: 8px 12px; margin-top: 8px; }
+
 /* Liquidation countdown ring */
 .liq-ring-pulse { animation: liq-pulse 1.5s ease-in-out infinite; }
 @keyframes liq-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .5; } }


### PR DESCRIPTION
Closes #294.

**Problem:** Blend liquidates on a **pool-wide** HF, but the position view drove the hero HF, HF bar/gauge, the liquidation warning and days-to-liquidation off **per-asset** `pos.hf`. A cross-asset account (deposit USDC, borrow XLM, sell XLM, resupply USDC) showed the **XLM row at HF≈0 'liquidation imminent'** — false + scary, because the USDC collateral backs the XLM debt.

**Fix:** all liquidation-relevant UI now reads **`computePoolHF()`** (the real trigger, already in the code). Per-asset HF is demoted to a **'Loop HF'** info metric; single-sided rows show **'Cross-collateralized'** (neutral, no red) instead of a scary 0; a one-line **explainer** appears for cross-asset accounts; overview cards do the same.

**No regression:** for a normal single self-contained loop, `computePoolHF() === pos.hf`, so the display is byte-identical for the common case.

Verified: build + lint clean; **headless `?e2e=1` boot clean**; diff-reviewed the HF semantics + the single-loop equivalence.