### PR TITLE
feat(wallet): add Nido passkey smart-account wallet (testnet)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,12 +14,14 @@
   },
   "dependencies": {
     "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.1",
+    "@nidohq/stellar-wallets-kit-module": "^0.1.0",
     "@stellar-broker/client": "^0.6.14",
     "@stellar/stellar-sdk": "^14.6.1",
     "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "playwright": "^1.60.0",
     "typescript": "^5.7.3",
     "vite": "^6.2.0",
     "vitest": "^3.0.0"

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,6 +14,7 @@ import { AlbedoModule }      from "@creit-tech/stellar-wallets-kit/modules/albed
 import { LobstrModule }      from "@creit-tech/stellar-wallets-kit/modules/lobstr";
 import { HanaModule }        from "@creit-tech/stellar-wallets-kit/modules/hana";
 import { LedgerModule }      from "@creit-tech/stellar-wallets-kit/modules/ledger";
+import { NidoModule }        from "@nidohq/stellar-wallets-kit-module";
 import type { ModuleInterface } from "@creit-tech/stellar-wallets-kit/types";
 import { Networks }          from "@creit-tech/stellar-wallets-kit/types";
 import { estimateSwap }      from "@stellar-broker/client";
@@ -113,8 +114,13 @@ const WALLET_CONNECT_PROJECT_ID = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID
  * global — provided in `index.html`). WalletConnect is added asynchronously by
  * {@link initWalletKit} because constructing it spins up Reown AppKit.
  */
-function baseWalletModules(): ModuleInterface[] {
-  return [
+// Nido passkey smart-account wallet (https://nido.fyi). Currently testnet-only,
+// so it's offered only on testnet — picking it on mainnet would yield a testnet
+// C-address that can't sign for the active network.
+const NIDO_BASE = (import.meta.env.VITE_NIDO_BASE as string | undefined) ?? "https://nido.fyi";
+
+function baseWalletModules(net: NetworkMode): ModuleInterface[] {
+  const mods: ModuleInterface[] = [
     new FreighterModule(),
     new xBullModule(),
     new AlbedoModule(),
@@ -122,6 +128,10 @@ function baseWalletModules(): ModuleInterface[] {
     new HanaModule(),
     new LedgerModule(),
   ];
+  if (net === "testnet") {
+    mods.push(new NidoModule({ base: NIDO_BASE }) as unknown as ModuleInterface);
+  }
+  return mods;
 }
 
 /** Network passphrase → kit `Networks` enum value. */
@@ -165,11 +175,11 @@ async function maybeWalletConnectModule(net: NetworkMode): Promise<ModuleInterfa
  */
 function initWalletKit(net: NetworkMode): void {
   const network = kitNetwork(net);
-  StellarWalletsKit.init({ modules: baseWalletModules(), network });
+  StellarWalletsKit.init({ modules: baseWalletModules(net), network });
   // Best-effort async upgrade with the mobile deep-link / QR module.
   void maybeWalletConnectModule(net).then((wc) => {
     if (!wc) return;
-    StellarWalletsKit.init({ modules: [...baseWalletModules(), wc], network });
+    StellarWalletsKit.init({ modules: [...baseWalletModules(net), wc], network });
   });
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
     // Some Stellar SDK internals check for global
     global: "globalThis",
   },
+  resolve: {
+    alias: {
+      // The Nido wallet module peer-deps on the npm-registry kit name (`@creit.tech`,
+      // dot); we use the JSR distribution (`@creit-tech`, dash). Same v2 project —
+      // alias so NidoModule resolves to our single kit instance (it only imports
+      // ModuleType + the ModuleInterface type).
+      "@creit.tech/stellar-wallets-kit": "@creit-tech/stellar-wallets-kit",
+    },
+  },
   build: {
     target: "es2020",
     rollupOptions: {


### PR DESCRIPTION
Adds **Nido** (passkey smart-account wallet, https://nido.fyi) to the Stellar Wallets Kit picker via `@nidohq/stellar-wallets-kit-module`.

## What
- New dep `@nidohq/stellar-wallets-kit-module` → `NidoModule` added to the kit modules.
- **Vite alias** `@creit.tech/stellar-wallets-kit` → `@creit-tech/stellar-wallets-kit` (our JSR distribution). The Nido module peer-deps on the npm-registry kit name; it only imports `ModuleType` + the `ModuleInterface` type, so the alias makes it resolve to our single kit instance.
- **Registered on testnet only** (`net === 'testnet'`). Nido's hosted wallet is testnet-only, so offering it on mainnet would return a testnet C-address that can't sign for the active network. Base configurable via `VITE_NIDO_BASE` (default `nido.fyi`).

## Verification
- `npm run build` clean (alias resolves, Nido + deps bundle).
- `npm run lint` clean.
- Headless `?e2e=1` boot clean; **switching to testnet constructs `NidoModule` with zero errors**.

## Not runtime-verified (needs you)
The live **passkey connect → sign** ceremony needs a real WebAuthn authenticator on `nido.fyi` testnet — can't be done headlessly. Nido also ships a nested `@stellar/stellar-sdk` (surfaced a dev-optimizer interop warning, didn't reproduce on the testnet switch). **Please test the actual Connect → Nido → sign flow on Turbolong testnet** before relying on it. (Your team owns Nido, so you're best placed to confirm.)

Notes: adds a dependency (the means to the requested feature); Nido appears in the picker only in testnet mode until Nido ships mainnet (then drop the gate).
