### PR TITLE
feat(ui): polish dapp screens to design kit (overhaul P3)

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -9,60 +9,61 @@
 /* ── Theme variables ─────────────────────────────────────────────────────── */
 
 :root {
-  --mono:     'JetBrains Mono', monospace;
-  --sans:     'Inter', sans-serif;
-  --r:        12px;
-  --r-sm:     8px;
-  --r-xs:     6px;
-  --danger:   #FF4D6A;
-  --success:  #2DE8A3;
-  --warning:  #FFB547;
-  --blnd:     #A78BFA;
+  --mono:     var(--tl-font-mono);
+  --sans:     var(--tl-font-sans);
+  --r:        var(--tl-radius);
+  --r-sm:     var(--tl-radius-sm);
+  --r-xs:     var(--tl-radius-xs);
+  --r-pill:   var(--tl-radius-pill);
+  --danger:   var(--tl-danger);
+  --success:  var(--tl-success);
+  --warning:  var(--tl-warning);
+  --blnd:     var(--tl-blnd);
 }
 
 /* ── Dark theme ──────────────────────────────────────────────────────────── */
 
 :root, [data-theme="dark"] {
-  --bg:             #0B0E14;
+  --bg:             var(--tl-bg);
   --bg-gradient1:   rgba(45,232,163,.04);
   --bg-gradient2:   rgba(167,139,250,.02);
-  --surface:        #141820;
-  --surface2:       #1A1F2B;
-  --surface3:       #232A38;
-  --surface-solid:  #141820;
-  --border:         #1E2536;
-  --border-h:       #2A3348;
-  --primary:        #2DE8A3;
-  --primary-h:      #5EEDB8;
-  --primary-glow:   rgba(45,232,163,.15);
+  --surface:        var(--tl-surface);
+  --surface2:       var(--tl-surface-2);
+  --surface3:       var(--tl-surface-3);
+  --surface-solid:  var(--tl-surface);
+  --border:         var(--tl-border);
+  --border-h:       var(--tl-border-hover);
+  --primary:        var(--tl-primary);
+  --primary-h:      var(--tl-primary-hover);
+  --primary-glow:   var(--tl-primary-glow);
   --primary-btn-shadow: rgba(45,232,163,.2);
   --primary-btn-shadow-h: rgba(45,232,163,.35);
-  --primary-grad2:  #20D99A;
-  --primary-grad2-h: #2DE8A3;
-  --text:           #E8ECF4;
-  --text-2:         #8892A8;
-  --text-3:         #4A5568;
-  --shadow:         0 8px 40px rgba(0,0,0,.5);
-  --header-bg:      rgba(11,14,20,.95);
-  --input-bg:       #111621;
-  --metric-bg:      #111621;
+  --primary-grad2:  var(--tl-primary-deep);
+  --primary-grad2-h: var(--tl-primary);
+  --text:           var(--tl-text);
+  --text-2:         var(--tl-text-2);
+  --text-3:         var(--tl-text-3);
+  --shadow:         var(--tl-shadow-pop);
+  --header-bg:      var(--tl-header-bg);
+  --input-bg:       var(--tl-input-bg);
+  --metric-bg:      var(--tl-input-bg);
   --slider-bg:      rgba(255,255,255,.06);
   --slider-glow:    rgba(45,232,163,.3);
   --slider-glow-h:  rgba(45,232,163,.5);
-  --toast-bg:       #1A1F2B;
-  --tab-hover-bg:   rgba(45,232,163,.06);
-  --tab-active-bg:  rgba(45,232,163,.1);
+  --toast-bg:       var(--tl-surface-2);
+  --tab-hover-bg:   var(--tl-tab-hover-bg);
+  --tab-active-bg:  var(--tl-tab-active-bg);
   --tab-active-border: rgba(45,232,163,.3);
-  --btn-secondary-bg: #1A1F2B;
-  --btn-secondary-bg-h: #232A38;
-  --btn-ghost-hover: rgba(45,232,163,.06);
-  --danger-bg:      rgba(255,77,106,.08);
-  --danger-bg-h:    rgba(255,77,106,.15);
-  --danger-border:  rgba(255,77,106,.2);
+  --btn-secondary-bg: var(--tl-surface-2);
+  --btn-secondary-bg-h: var(--tl-surface-3);
+  --btn-ghost-hover: var(--tl-tab-hover-bg);
+  --danger-bg:      var(--tl-danger-bg);
+  --danger-bg-h:    var(--tl-danger-bg-h);
+  --danger-border:  var(--tl-danger-border);
   --danger-border-h:rgba(255,77,106,.35);
-  --warning-bg:     rgba(255,181,71,.05);
-  --warning-border: rgba(255,181,71,.2);
-  --success-border: rgba(45,232,163,.4);
+  --warning-bg:     var(--tl-warning-bg);
+  --warning-border: var(--tl-warning-border);
+  --success-border: var(--tl-success-border);
   --tooltip-bg:     rgba(255,255,255,.04);
   --tooltip-hover:  rgba(45,232,163,.12);
   --hf-bar-bg:      rgba(255,255,255,.06);
@@ -81,50 +82,50 @@
 /* ── Light theme ─────────────────────────────────────────────────────────── */
 
 [data-theme="light"] {
-  --bg:             #f4f5f9;
+  --bg:             var(--tl-bg);
   --bg-gradient1:   rgba(45,232,163,.04);
   --bg-gradient2:   rgba(167,139,250,.02);
-  --surface:        #ffffff;
-  --surface2:       #f0f1f5;
-  --surface3:       #e5e7ec;
-  --surface-solid:  #ffffff;
-  --border:         #e0e3ea;
-  --border-h:       #c8cdd6;
-  --primary:        #1aad7a;
-  --primary-h:      #169966;
-  --primary-glow:   rgba(26,173,122,.1);
+  --surface:        var(--tl-surface);
+  --surface2:       var(--tl-surface-2);
+  --surface3:       var(--tl-surface-3);
+  --surface-solid:  var(--tl-surface);
+  --border:         var(--tl-border);
+  --border-h:       var(--tl-border-hover);
+  --primary:        var(--tl-primary);
+  --primary-h:      var(--tl-primary-hover);
+  --primary-glow:   var(--tl-primary-glow);
   --primary-btn-shadow: rgba(26,173,122,.2);
   --primary-btn-shadow-h: rgba(26,173,122,.35);
-  --primary-grad2:  #15a070;
-  --primary-grad2-h: #1aad7a;
-  --text:           #111827;
-  --text-2:         #6b7280;
-  --text-3:         #9ca3af;
-  --shadow:         0 8px 40px rgba(0,0,0,.06);
-  --header-bg:      rgba(255,255,255,.95);
-  --input-bg:       #f4f5f9;
-  --metric-bg:      #f4f5f9;
+  --primary-grad2:  var(--tl-primary-deep);
+  --primary-grad2-h: var(--tl-primary);
+  --text:           var(--tl-text);
+  --text-2:         var(--tl-text-2);
+  --text-3:         var(--tl-text-3);
+  --shadow:         var(--tl-shadow-pop);
+  --header-bg:      var(--tl-header-bg);
+  --input-bg:       var(--tl-input-bg);
+  --metric-bg:      var(--tl-input-bg);
   --slider-bg:      rgba(0,0,0,.06);
   --slider-glow:    rgba(26,173,122,.3);
   --slider-glow-h:  rgba(26,173,122,.5);
-  --toast-bg:       #ffffff;
-  --tab-hover-bg:   rgba(26,173,122,.04);
-  --tab-active-bg:  rgba(26,173,122,.08);
+  --toast-bg:       var(--tl-surface);
+  --tab-hover-bg:   var(--tl-tab-hover-bg);
+  --tab-active-bg:  var(--tl-tab-active-bg);
   --tab-active-border: rgba(26,173,122,.25);
-  --btn-secondary-bg: #f0f1f5;
-  --btn-secondary-bg-h: #e5e7ec;
-  --btn-ghost-hover:rgba(26,173,122,.04);
-  --danger:         #dc2626;
-  --danger-bg:      rgba(220,38,38,.06);
-  --danger-bg-h:    rgba(220,38,38,.1);
-  --danger-border:  rgba(220,38,38,.15);
+  --btn-secondary-bg: var(--tl-surface-2);
+  --btn-secondary-bg-h: var(--tl-surface-3);
+  --btn-ghost-hover:var(--tl-tab-hover-bg);
+  --danger:         var(--tl-danger);
+  --danger-bg:      var(--tl-danger-bg);
+  --danger-bg-h:    var(--tl-danger-bg-h);
+  --danger-border:  var(--tl-danger-border);
   --danger-border-h:rgba(220,38,38,.3);
-  --success:        #16a34a;
-  --warning:        #d97706;
-  --blnd:           #7c3aed;
-  --warning-bg:     rgba(217,119,6,.04);
-  --warning-border: rgba(217,119,6,.15);
-  --success-border: rgba(22,163,74,.3);
+  --success:        var(--tl-success);
+  --warning:        var(--tl-warning);
+  --blnd:           var(--tl-blnd);
+  --warning-bg:     var(--tl-warning-bg);
+  --warning-border: var(--tl-warning-border);
+  --success-border: var(--tl-success-border);
   --tooltip-bg:     rgba(0,0,0,.03);
   --tooltip-hover:  rgba(26,173,122,.08);
   --hf-bar-bg:      rgba(0,0,0,.06);
@@ -179,7 +180,7 @@ body {
   position: relative;
   padding: 8px 14px; border-radius: var(--r-sm); border: none;
   background: transparent; color: var(--text-2); font-size: 13px; font-weight: 600;
-  cursor: pointer; transition: all .15s; font-family: var(--sans);
+  cursor: pointer; transition: all var(--tl-dur-fast) var(--tl-ease); font-family: var(--sans);
   white-space: nowrap;
 }
 .nav-btn:hover { background: var(--tab-hover-bg); color: var(--text); }
@@ -220,7 +221,7 @@ body {
   font-family: var(--sans); transition: all .1s;
 }
 .settings-dropdown-item:hover { background: var(--tab-hover-bg); color: var(--text); }
-.settings-badge { font-size: 10px; padding: 1px 6px; border-radius: 99px; background: var(--surface2); color: var(--text-3); }
+.settings-badge { font-size: 10px; padding: 1px 6px; border-radius: var(--r-pill); background: var(--surface2); color: var(--text-3); }
 .lang-submenu { display: flex; flex-direction: column; margin: 2px 0 2px 12px; border-left: 1px solid var(--border); padding-left: 4px; }
 .lang-submenu.hidden { display: none; }
 
@@ -345,14 +346,14 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .asset-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
 .asset-tab {
   display: flex; align-items: center; gap: 5px;
-  padding: 6px 14px; border-radius: 99px; border: 1px solid transparent;
+  padding: 6px 14px; border-radius: var(--r-pill); border: 1px solid transparent;
   background: transparent; color: var(--text-2); font-size: 13px; font-weight: 500;
-  cursor: pointer; transition: all .15s;
+  cursor: pointer; transition: all var(--tl-dur-fast) var(--tl-ease);
 }
 .asset-tab:hover { background: var(--tab-hover-bg); color: var(--text); }
 .asset-tab.active {
   background: var(--primary); color: var(--asset-active-color);
-  box-shadow: 0 2px 12px var(--primary-btn-shadow);
+  box-shadow: var(--tl-glow-primary);
 }
 .tab-symbol { font-family: var(--mono); font-weight: 600; font-size: 12px; }
 
@@ -498,7 +499,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .card {
   background: var(--surface); border: 1px solid var(--border);
   border-radius: var(--r); padding: 20px;
-  transition: border-color .3s, background .3s;
+  transition: border-color var(--tl-dur-slow) var(--tl-ease), background .3s;
 }
 .card:hover { border-color: var(--border-h); }
 .card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
@@ -613,7 +614,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 /* Role badges */
 .pb-badge {
   display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .02em;
-  padding: 2px 8px; border-radius: 99px; white-space: nowrap;
+  padding: 2px 8px; border-radius: var(--r-pill); white-space: nowrap;
 }
 .pb-badge-loop { background: var(--primary-glow); color: var(--primary); }
 .pb-badge-borrow { background: var(--warning-bg); color: var(--warning); }
@@ -702,7 +703,8 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .input {
   width: 100%; padding: 10px 14px; padding-right: 100px;
   background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--r);
-  color: var(--text); font-size: 15px; outline: none; transition: border-color .2s, box-shadow .2s;
+  color: var(--text); font-size: 15px; font-family: var(--mono); outline: none;
+  transition: border-color var(--tl-dur) var(--tl-ease), box-shadow var(--tl-dur) var(--tl-ease);
 }
 .input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-glow); }
 .input-suffix { position: absolute; right: 14px; top: 50%; transform: translateY(-50%); font-size: 12px; color: var(--text-3); pointer-events: none; font-family: var(--mono); }
@@ -881,20 +883,20 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   display: inline-flex; align-items: center; justify-content: center; gap: 6px;
   padding: 8px 16px; border-radius: var(--r-sm); border: none; cursor: pointer;
   font-size: 13px; font-weight: 600; font-family: var(--sans);
-  transition: all .2s; white-space: nowrap; outline: none;
+  transition: all var(--tl-dur) var(--tl-ease); white-space: nowrap; outline: none;
 }
 .btn:active:not(:disabled) { transform: scale(.97); }
 .btn:disabled { opacity: .3; cursor: not-allowed; }
 .btn-primary {
   background: linear-gradient(135deg, var(--primary), var(--primary-grad2));
-  color: #0B0E14; box-shadow: 0 2px 12px var(--primary-btn-shadow);
+  color: #0B0E14; box-shadow: var(--tl-glow-primary);
   font-weight: 700;
 }
 .btn-primary:hover:not(:disabled) {
-  box-shadow: 0 4px 20px var(--primary-btn-shadow-h);
+  box-shadow: var(--tl-glow-primary-h);
   filter: brightness(1.1);
 }
-.btn-connect { padding: 6px 16px; font-size: 13px; border-radius: 99px; }
+.btn-connect { padding: 6px 16px; font-size: 13px; border-radius: var(--r-pill); }
 .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); border: 1px solid var(--border); }
 .btn-secondary:hover:not(:disabled) { background: var(--btn-secondary-bg-h); border-color: var(--border-h); }
 .btn-danger { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger-border); }
@@ -917,7 +919,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .wallet-connected { display: flex; align-items: center; gap: 6px; }
 .wallet-info {
   display: flex; align-items: center; gap: 6px; padding: 5px 12px;
-  border-radius: 99px; background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r-pill); background: var(--surface); border: 1px solid var(--border);
 }
 .wallet-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); flex-shrink: 0; box-shadow: 0 0 6px var(--success); }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -400,10 +400,10 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 }
 .stat-card:hover { border-color: var(--border-h); }
 .stat-label {
-  display: block; font-size: 11px; color: var(--text-3); text-transform: uppercase;
-  letter-spacing: .5px; margin-bottom: 4px; font-weight: 600;
+  display: block; font-size: var(--tl-text-xs); color: var(--text-3); text-transform: uppercase;
+  letter-spacing: var(--tl-tracking-label); margin-bottom: 4px; font-weight: 600;
 }
-.stat-value { font-size: 17px; font-weight: 700; font-family: var(--mono); display: block; }
+.stat-value { font-size: var(--tl-text-xl); font-weight: 700; font-family: var(--mono); display: block; line-height: var(--tl-leading-tight); }
 
 /* Utilization bar */
 .util-bar-wrap { height: 3px; background: var(--hf-bar-bg); border-radius: 2px; margin-top: 6px; overflow: hidden; }
@@ -431,11 +431,13 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .apr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 12px; }
 .apr-card {
   background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--r); padding: 16px 18px;
+  border-radius: var(--r); padding: 14px 16px;
+  transition: border-color .2s;
 }
+.apr-card:hover { border-color: var(--border-h); }
 .apr-card-label {
-  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .8px;
-  color: var(--text-3); margin-bottom: 12px;
+  font-size: var(--tl-text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .8px;
+  color: var(--text-3); margin-bottom: 10px;
 }
 .apr-row { display: flex; justify-content: space-between; align-items: center; padding: 3px 0; font-size: 13px; }
 .apr-key { color: var(--text-2); }
@@ -461,9 +463,12 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .rate-trend-slot:empty { display: none; }
 
 /* ── APY history chart (B4) ──────────────────────────────────────────────── */
-.hist-chart-wrap { margin-top: 10px; }
-.hist-chart-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
-.hist-chart-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .7px; color: var(--text-3); }
+.hist-chart-wrap {
+  margin-top: 12px; padding: 12px 14px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--r);
+}
+.hist-chart-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.hist-chart-title { font-size: var(--tl-text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--text-3); }
 .hist-win-btns { display: flex; gap: 3px; }
 .hist-win-btn { background: none; border: 1px solid var(--border); border-radius: 4px; color: var(--text-2); font-size: 11px; padding: 2px 7px; cursor: pointer; transition: background .15s, color .15s; }
 .hist-win-btn:hover { border-color: var(--primary); color: var(--primary); }
@@ -490,8 +495,9 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 
 .two-col {
   display: grid;
-  grid-template-columns: minmax(340px, 380px) 1fr;
+  grid-template-columns: minmax(360px, 400px) 1fr;
   gap: 16px;
+  align-items: start;
 }
 
 /* ── Cards ───────────────────────────────────────────────────────────────── */
@@ -511,16 +517,17 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 16px;
 }
 .metric-hero {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--r); padding: 16px;
+  background: var(--input-bg); border: 1px solid var(--border);
+  border-radius: var(--r); padding: 14px 16px;
   text-align: center;
 }
 .metric-hero-label {
-  display: block; font-size: 11px; color: var(--text-3); text-transform: uppercase;
-  letter-spacing: .5px; font-weight: 600; margin-bottom: 6px;
+  display: block; font-size: var(--tl-text-xs); color: var(--text-3); text-transform: uppercase;
+  letter-spacing: var(--tl-tracking-label); font-weight: 600; margin-bottom: 6px;
 }
 .metric-hero-value {
-  font-size: 24px; font-weight: 700; font-family: var(--mono); display: block;
+  font-size: var(--tl-text-2xl); font-weight: 700; font-family: var(--mono); display: block;
+  line-height: var(--tl-leading-tight);
 }
 
 /* ── Position data table ─────────────────────────────────────────────────── */
@@ -641,8 +648,12 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   font-size: 13px;
 }
 .blnd-info { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
-.blnd-info .metric-label { color: var(--text-2); font-size: 11px; white-space: nowrap; margin-bottom: 0; }
-.blnd-info .metric-value { font-family: var(--mono); font-size: 14px; }
+.blnd-info::before {
+  content: ""; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  background: var(--blnd); box-shadow: 0 0 6px var(--blnd);
+}
+.blnd-info .metric-label { color: var(--text-2); font-size: var(--tl-text-xs); white-space: nowrap; margin-bottom: 0; text-transform: uppercase; letter-spacing: .4px; font-weight: 600; }
+.blnd-info .metric-value { font-family: var(--mono); font-size: var(--tl-text-md); font-weight: 700; color: var(--blnd); }
 .blnd-convert-hint { font-size: 11px; color: var(--text-3); }
 .blnd-actions { display: flex; gap: 6px; flex-shrink: 0; }
 
@@ -776,7 +787,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .preview-net-apr { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
 .prev-net-apr { font-size: 16px !important; font-weight: 700 !important; }
 
-.return-calc { margin-top: 12px; padding: 10px 14px; background: var(--metric-bg); border: 1px solid var(--border); border-radius: var(--r); }
+.return-calc { margin-top: 12px; padding: 12px 14px; background: var(--metric-bg); border: 1px solid var(--border); border-radius: var(--r); }
 .return-calc .form-group { margin-bottom: 6px; }
 
 .hf-ok   { color: var(--success) !important; }
@@ -1192,15 +1203,17 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 .overview-header h2 { font-size: 20px; font-weight: 800; letter-spacing: -.3px; }
 
 .overview-totals {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
   margin-bottom: 20px;
 }
+.overview-totals .stat-card { padding: 14px 16px; text-align: center; }
+.overview-totals .stat-value { font-size: var(--tl-text-2xl); line-height: var(--tl-leading-tight); }
 
 .overview-protocol-section { margin-bottom: 24px; }
 .overview-protocol-header {
   display: flex; align-items: center; gap: 8px;
-  margin-bottom: 10px; font-size: 13px; font-weight: 700;
-  color: var(--text-2); text-transform: uppercase; letter-spacing: .5px;
+  margin-bottom: 12px; font-size: var(--tl-text-md); font-weight: 700;
+  color: var(--text); letter-spacing: -.2px; text-transform: none;
 }
 .overview-protocol-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .overview-protocol-dot-blend { background: var(--success); box-shadow: 0 0 6px var(--success); }
@@ -1233,7 +1246,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   border-radius: var(--r); padding: 16px 18px;
   cursor: pointer; transition: all .15s;
 }
-.overview-pos-card:hover { border-color: var(--primary); background: var(--tab-active-bg); }
+.overview-pos-card:hover { border-color: var(--border-h); }
 .overview-pos-card-top {
   display: flex; align-items: center; justify-content: space-between;
   margin-bottom: 10px;
@@ -1255,7 +1268,7 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   border-radius: var(--r); padding: 16px 18px;
   cursor: pointer; transition: all .15s;
 }
-.overview-vault-card:hover { border-color: var(--primary); background: var(--tab-active-bg); }
+.overview-vault-card:hover { border-color: var(--border-h); }
 
 .overview-empty {
   text-align: center; padding: 40px 20px; color: var(--text-3); font-size: 14px;
@@ -1263,12 +1276,12 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
 
 /* ── Vault view ─────────────────────────────────────────────────────────── */
 
-.vault-card { max-width: 620px; margin: 0 auto; }
+.vault-card { max-width: 640px; margin: 0 auto; }
 
 .vault-badge {
-  font-size: 11px; font-weight: 600; letter-spacing: .5px; text-transform: uppercase;
-  color: var(--primary); background: rgba(45,232,163,.1); border-radius: 99px;
-  padding: 3px 10px;
+  font-size: var(--tl-text-xs); font-weight: 700; letter-spacing: .4px; text-transform: uppercase;
+  color: var(--blnd); background: rgba(167,139,250,.12); border: 1px solid rgba(167,139,250,.25);
+  border-radius: var(--r-pill); padding: 2px 9px;
 }
 
 .vault-stats { margin-bottom: 16px; }
@@ -1281,13 +1294,19 @@ main { flex: 1; max-width: 1200px; width: 100%; margin: 0 auto; padding: 20px 24
   border-top: 1px solid var(--border);
   padding-top: 16px; margin-bottom: 16px;
 }
-.vault-strategy-pos h3 { font-size: 14px; margin: 0 0 12px; color: var(--text-2); }
+.vault-strategy-pos h3 {
+  font-size: var(--tl-text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+  margin: 0 0 12px; color: var(--text-3);
+}
 
 .vault-user-pos {
   border-top: 1px solid var(--border);
   padding-top: 16px; margin-bottom: 20px;
 }
-.vault-user-pos h3 { font-size: 14px; margin: 0 0 12px; color: var(--text-2); }
+.vault-user-pos h3 {
+  font-size: var(--tl-text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+  margin: 0 0 12px; color: var(--text-3);
+}
 .vault-pos-grid { grid-template-columns: 1fr 1fr 1fr; }
 
 /* Vault tabs (deposit/withdraw) */
@@ -1480,8 +1499,8 @@ kbd {
   display: flex; justify-content: space-between; align-items: flex-start;
   gap: 20px; flex-wrap: wrap; margin-bottom: 20px;
 }
-.compare-title { font-size: 24px; font-weight: 700; margin: 0 0 6px; }
-.compare-sub { color: var(--text-2); font-size: 13px; max-width: 560px; margin: 0; line-height: 1.5; }
+.compare-title { font-size: 20px; font-weight: 800; letter-spacing: -.3px; margin: 0 0 6px; }
+.compare-sub { color: var(--text-2); font-size: var(--tl-text-base); max-width: 640px; margin: 0; line-height: var(--tl-leading-body); }
 .compare-controls { display: flex; align-items: center; gap: 10px; }
 .compare-window-toggle {
   display: inline-flex; background: var(--surface2); border: 1px solid var(--border);
@@ -1509,36 +1528,38 @@ kbd {
 }
 .compare-table { width: 100%; border-collapse: collapse; min-width: 640px; }
 .compare-table thead th {
-  text-align: right; font-size: 11px; font-weight: 600; letter-spacing: .04em;
-  text-transform: uppercase; color: var(--text-3); padding: 14px 16px;
-  border-bottom: 1px solid var(--border); white-space: nowrap; user-select: none;
+  text-align: right; font-size: var(--tl-text-xs); font-weight: 600; letter-spacing: var(--tl-tracking-label);
+  text-transform: uppercase; color: var(--text-3); padding: 12px 14px;
+  border-bottom: 1px solid var(--border-h); white-space: nowrap; user-select: none;
 }
 .compare-table th.ct-rank, .compare-table th.ct-asset { text-align: left; }
 .compare-table th[data-sort] { cursor: pointer; }
 .compare-table th[data-sort]:hover { color: var(--text); }
 .compare-table th.ct-sorted { color: var(--primary); }
 .compare-table tbody td {
-  padding: 14px 16px; border-bottom: 1px solid var(--border);
-  font-size: 14px; text-align: right; vertical-align: middle;
+  padding: 12px 14px; border-bottom: 1px solid var(--border);
+  font-size: var(--tl-text-base); text-align: right; vertical-align: middle;
 }
 .compare-table tbody tr:last-child td { border-bottom: none; }
 .compare-table tbody tr:hover { background: var(--tab-hover-bg); }
 .ct-rank { width: 44px; text-align: left !important; color: var(--text-3); font-family: var(--mono); }
 .ct-medal { color: var(--warning); font-size: 16px; }
 .ct-asset { text-align: left !important; }
-.ct-asset-cell { display: flex; align-items: center; gap: 8px; }
-.ct-sym { font-weight: 700; font-size: 15px; }
-.ct-pool { display: block; color: var(--text-3); font-size: 11px; margin-top: 2px; }
+.ct-asset-cell { display: inline-flex; align-items: center; gap: 8px; }
+.ct-asset { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ct-sym { font-family: var(--mono); font-weight: 700; font-size: var(--tl-text-md); }
+.ct-pool { color: var(--text-3); font-size: var(--tl-text-sm); }
 .ct-num { font-family: var(--mono); }
 .ct-lev-apy { color: var(--primary); font-weight: 600; }
 .ct-lev { color: var(--text-2); }
 .ct-muted { color: var(--text-3); }
-.ct-best-row { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
-.ct-best-row:hover { background: linear-gradient(90deg, var(--primary-glow), transparent 60%); }
+.ct-best-row { background: var(--tab-active-bg); }
+.ct-best-row:hover { background: var(--tab-active-bg); }
 .compare-table .best-rate-badge {
   font-size: 9px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
-  padding: 2px 7px; border-radius: 99px; background: var(--primary);
-  color: #04130D !important; white-space: nowrap;
+  padding: 2px 8px; border-radius: 99px;
+  background: var(--tl-tab-active-bg); border: 1px solid var(--success-border);
+  color: var(--success) !important; white-space: nowrap;
 }
 .ct-trend { width: 100px; text-align: right; }
 .ct-spark { display: inline-block; vertical-align: middle; }
@@ -1627,15 +1648,24 @@ kbd {
 .status-title { margin: 0; font-size: 20px; font-weight: 700; }
 .status-sub { margin: 2px 0 0; font-size: 13px; color: var(--text-2); }
 .status-overall {
-  text-align: center; font-weight: 600; font-size: 14px; padding: 12px;
-  border-radius: var(--r-sm); margin-bottom: 18px;
+  display: flex; align-items: center; gap: 10px;
+  font-weight: 600; font-size: var(--tl-text-md); padding: 14px 18px;
+  border-radius: var(--r); margin-bottom: 16px; border: 1px solid transparent;
 }
-.status-overall-good { background: var(--primary-glow); color: var(--primary); }
-.status-overall-bad { background: rgba(255,77,106,.12); color: var(--danger); }
+.status-overall::before {
+  content: ""; width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0;
+  background: currentColor; box-shadow: 0 0 8px currentColor;
+}
+.status-overall-good { background: var(--tl-tab-active-bg); border-color: var(--success-border); color: var(--success); }
+.status-overall-bad { background: var(--danger-bg); border-color: var(--danger-border); color: var(--danger); }
 .status-overall-checking { background: var(--surface2); color: var(--text-2); }
-.status-list { display: flex; flex-direction: column; gap: 2px; }
+.status-list {
+  display: flex; flex-direction: column; gap: 0;
+  border: 1px solid var(--border); border-radius: var(--r);
+  background: var(--surface); overflow: hidden;
+}
 .status-row {
-  display: flex; align-items: center; gap: 12px; padding: 14px 4px;
+  display: flex; align-items: center; gap: 12px; padding: 14px 18px;
   border-bottom: 1px solid var(--border);
 }
 .status-row:last-child { border-bottom: none; }


### PR DESCRIPTION
Phase 3 (final) — per-screen layout polish to the UI kit. Stacked on #301 (P2).

CSS-only across all 6 screens: Trade (metric wells, rate-cards, two-col), Vault (violet badges, section labels), Compare (flat best-rate tint + success-pill badge, inline pool/symbol), Swap (kept), Status (kit banner + boxed list), Dashboard (MetricHero totals). BLND rewards get the violet glow dot + mono amount.

**Only style.css touched** — no id/class/JS-logic change (grep-verified). Build + lint clean; **headless boot clean** across compare/vault/swap/overview/trade — the 3 console errors are **pre-existing** (proven via baseline stash), not introduced; pool-breakdown + metrics-hero intact.

Deferred (need HTML/main.ts restructure, not CSS): vault two-column rebuild, status per-row badge swap.

Completes the overhaul: P0 tokens (#299 ✅) · P1 landing (#300) · P2 shell (#301) · P3 screens (this).