### PR TITLE
fix(landing): remove bug-bounty link

### DIFF
--- a/landing/.well-known/security.txt
+++ b/landing/.well-known/security.txt
@@ -2,8 +2,6 @@ Contact: mailto:security@turbolong.app
 Contact: https://t.me/turbolong_security
 Expires: 2027-05-29T00:00:00.000Z
 Encryption: https://turbolong.app/.well-known/pgp-key.txt
-Acknowledgments: https://turbolong.app/bug-bounty#acknowledgements
-Policy: https://turbolong.app/bug-bounty
 Policy: https://github.com/kweb-drips/TurboLong/blob/main/SECURITY.md
 Preferred-Languages: en
 Canonical: https://turbolong.app/.well-known/security.txt

--- a/landing/index.html
+++ b/landing/index.html
@@ -441,7 +441,6 @@
           <a href="https://docs.blend.capital/" target="_blank" rel="noopener">Blend Docs</a>
           <a href="https://github.com/blend-capital" target="_blank" rel="noopener">GitHub</a>
           <a href="https://stellar.expert" target="_blank" rel="noopener">Stellar Expert</a>
-          <a href="bug-bounty.html">Bug Bounty</a>
         </div>
       </div>
       <p class="footer-disclaimer">Turbolong is an experimental DeFi tool. Leveraged positions carry significant financial risk, including the complete loss of deposited funds. Use at your own risk. Not available in jurisdictions where cryptocurrency is prohibited.</p>


### PR DESCRIPTION
The bug-bounty program isn't live and the page info is stale, so stop advertising it.

- Removed the **Bug Bounty** link from the landing footer (`landing/index.html`).
- Removed the two bug-bounty references from `.well-known/security.txt` (Acknowledgments + the bug-bounty Policy line); kept the valid `SECURITY.md` policy + the security contacts.

Note: `landing/bug-bounty.html` is now orphaned (not linked anywhere) but still directly reachable at /bug-bounty.html — say the word and I'll delete the page too.