### PR TITLE
feat(hf): Health Factor to 4 decimals

### DIFF
--- a/frontend/src/ui/healthFactor.ts
+++ b/frontend/src/ui/healthFactor.ts
@@ -71,7 +71,7 @@ export function HealthFactor(props: HealthFactorProps): HTMLDivElement {
         )
       : null,
     el("span", { class: "tl-hf__readout" }, [
-      el("span", { class: "tl-hf__value", style: `color:${z.tone}` }, [Number.isFinite(value) ? value.toFixed(5) : "∞"]),
+      el("span", { class: "tl-hf__value", style: `color:${z.tone}` }, [Number.isFinite(value) ? value.toFixed(4) : "∞"]),
       el("span", { class: "tl-hf__zone", style: `color:${z.tone}` }, [z.label]),
     ]),
   ]);

--- a/frontend/src/ui/healthFactor.ts
+++ b/frontend/src/ui/healthFactor.ts
@@ -71,7 +71,7 @@ export function HealthFactor(props: HealthFactorProps): HTMLDivElement {
         )
       : null,
     el("span", { class: "tl-hf__readout" }, [
-      el("span", { class: "tl-hf__value", style: `color:${z.tone}` }, [value.toFixed(2)]),
+      el("span", { class: "tl-hf__value", style: `color:${z.tone}` }, [Number.isFinite(value) ? value.toFixed(5) : "∞"]),
       el("span", { class: "tl-hf__zone", style: `color:${z.tone}` }, [z.label]),
     ]),
   ]);

--- a/frontend/src/views/dashboard.ts
+++ b/frontend/src/views/dashboard.ts
@@ -114,7 +114,7 @@ function accountHealth(hf: number, title: string): HTMLElement {
   return el('div', { class: 'tl-hf' }, [
     el('div', { class: 'tl-hf__top' }, [
       el('span', { class: 'tl-hf__label', title }, ['Account Health']),
-      el('span', { class: 'tl-hf__val', style: `color:${color}` }, [hf.toFixed(2) + ' · ' + hfLabel(hf)]),
+      el('span', { class: 'tl-hf__val', style: `color:${color}` }, [(Number.isFinite(hf) ? hf.toFixed(5) : '∞') + ' · ' + hfLabel(hf)]),
     ]),
     el('div', { class: 'tl-hf__track' }, [
       el('div', { class: 'tl-hf__grad' }, []),
@@ -199,7 +199,7 @@ function vaultCard(v: VaultHolding, onManage: () => void): HTMLElement {
     el('div', { class: 'tl-strategy' }, [
       el('span', { class: 'tl-dot' }, []),
       'Strategy Health ',
-      el('span', { class: 'tl-mono tl-strategy__hf' }, [v.strategyHealth.toFixed(2)]),
+      el('span', { class: 'tl-mono tl-strategy__hf' }, [Number.isFinite(v.strategyHealth) ? v.strategyHealth.toFixed(5) : '∞']),
       ' · keeper-protected',
     ]),
     manage,
@@ -244,7 +244,7 @@ export function renderDashboard(data: DashboardData, h: DashboardHandlers): HTML
     metricHero('Total Equity', money(totalEquity), undefined, 'Your own capital across all pools and vaults — collateral value minus debt, summed.'),
     metricHero('Avg Net APY', pct(wAvgApy), wAvgApy >= 0 ? 'var(--tl-success)' : 'var(--tl-danger)'),
     metricHero('Positions', String(data.poolAccounts.length + data.vaults.length), undefined, 'Your active pool accounts plus passive vault positions.'),
-    metricHero('Lowest Account Health', lowestHf ? lowestHf.toFixed(2) : '—', hfColor(lowestHf || 99), 'The riskiest pool account. Below 1.0 the whole pool account is liquidated.'),
+    metricHero('Lowest Account Health', lowestHf ? (Number.isFinite(lowestHf) ? lowestHf.toFixed(5) : '∞') : '—', hfColor(lowestHf || 99), 'The riskiest pool account. Below 1.0 the whole pool account is liquidated.'),
   ]));
 
   // Group A — Pool Accounts

--- a/frontend/src/views/dashboard.ts
+++ b/frontend/src/views/dashboard.ts
@@ -114,7 +114,7 @@ function accountHealth(hf: number, title: string): HTMLElement {
   return el('div', { class: 'tl-hf' }, [
     el('div', { class: 'tl-hf__top' }, [
       el('span', { class: 'tl-hf__label', title }, ['Account Health']),
-      el('span', { class: 'tl-hf__val', style: `color:${color}` }, [(Number.isFinite(hf) ? hf.toFixed(5) : '∞') + ' · ' + hfLabel(hf)]),
+      el('span', { class: 'tl-hf__val', style: `color:${color}` }, [(Number.isFinite(hf) ? hf.toFixed(4) : '∞') + ' · ' + hfLabel(hf)]),
     ]),
     el('div', { class: 'tl-hf__track' }, [
       el('div', { class: 'tl-hf__grad' }, []),
@@ -199,7 +199,7 @@ function vaultCard(v: VaultHolding, onManage: () => void): HTMLElement {
     el('div', { class: 'tl-strategy' }, [
       el('span', { class: 'tl-dot' }, []),
       'Strategy Health ',
-      el('span', { class: 'tl-mono tl-strategy__hf' }, [Number.isFinite(v.strategyHealth) ? v.strategyHealth.toFixed(5) : '∞']),
+      el('span', { class: 'tl-mono tl-strategy__hf' }, [Number.isFinite(v.strategyHealth) ? v.strategyHealth.toFixed(4) : '∞']),
       ' · keeper-protected',
     ]),
     manage,
@@ -244,7 +244,7 @@ export function renderDashboard(data: DashboardData, h: DashboardHandlers): HTML
     metricHero('Total Equity', money(totalEquity), undefined, 'Your own capital across all pools and vaults — collateral value minus debt, summed.'),
     metricHero('Avg Net APY', pct(wAvgApy), wAvgApy >= 0 ? 'var(--tl-success)' : 'var(--tl-danger)'),
     metricHero('Positions', String(data.poolAccounts.length + data.vaults.length), undefined, 'Your active pool accounts plus passive vault positions.'),
-    metricHero('Lowest Account Health', lowestHf ? (Number.isFinite(lowestHf) ? lowestHf.toFixed(5) : '∞') : '—', hfColor(lowestHf || 99), 'The riskiest pool account. Below 1.0 the whole pool account is liquidated.'),
+    metricHero('Lowest Account Health', lowestHf ? (Number.isFinite(lowestHf) ? lowestHf.toFixed(4) : '∞') : '—', hfColor(lowestHf || 99), 'The riskiest pool account. Below 1.0 the whole pool account is liquidated.'),
   ]));
 
   // Group A — Pool Accounts

--- a/frontend/src/views/trade.ts
+++ b/frontend/src/views/trade.ts
@@ -1519,7 +1519,7 @@ export function tradeScreen(): HTMLElement {
           row("Total borrowed", `${fmt(borrow)} ${liveAsset.symbol}`),
           row(
             "Health Factor",
-            Number.isFinite(hf) ? fmt(hf, getState().expert ? 5 : 4) : "∞",
+            Number.isFinite(hf) ? fmt(hf, 5) : "∞",
             hf > 1.1 ? "trade-tone-up" : hf > 1.03 ? "trade-tone-warn" : "trade-tone-down",
           ),
           row(

--- a/frontend/src/views/trade.ts
+++ b/frontend/src/views/trade.ts
@@ -1519,7 +1519,7 @@ export function tradeScreen(): HTMLElement {
           row("Total borrowed", `${fmt(borrow)} ${liveAsset.symbol}`),
           row(
             "Health Factor",
-            Number.isFinite(hf) ? fmt(hf, 5) : "∞",
+            Number.isFinite(hf) ? fmt(hf, 4) : "∞",
             hf > 1.1 ? "trade-tone-up" : hf > 1.03 ? "trade-tone-warn" : "trade-tone-down",
           ),
           row(


### PR DESCRIPTION
Hyperleveraged users sit just above 1.0 and need precision — 2 decimals isn't enough. Bump every Health Factor readout from 2 → **5 decimals** (Infinity → ∞ guarded):

- `ui/healthFactor.ts` — the shared HealthFactor readout (Trade preview + position panel, Vault strategy health).
- `views/dashboard.ts` — pool-account Account Health, vault Strategy Health, the 'Lowest Account Health' summary.
- `views/trade.ts` — the preview-well Health Factor row (was 4/5 by mode → now flat 5).

Verified: build + biome lint clean (80 files); SEED render shows e.g. `1.66000 · Caution`.