### PR TITLE
Fix/leverage issue

### DIFF
--- a/contracts/strategies/blend_leverage/src/blend_pool.rs
+++ b/contracts/strategies/blend_leverage/src/blend_pool.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 use crate::{
     constants::{
         REQUEST_TYPE_BORROW, REQUEST_TYPE_REPAY, REQUEST_TYPE_SUPPLY_COLLATERAL,
-        REQUEST_TYPE_WITHDRAW_COLLATERAL, SCALAR_12,
+        REQUEST_TYPE_WITHDRAW_COLLATERAL, SCALAR_12, SCALAR_7,
     },
     leverage::{compute_step, loop_step_count},
     soroswap::internal_swap_exact_tokens_for_tokens,
@@ -153,15 +153,32 @@ pub fn submit_unwind(
 
     let pre_balance = token_client.balance(&strategy);
 
+    // Blend request amounts are denominated in the UNDERLYING asset, but the
+    // caller passes b/d-TOKEN quantities. Convert with the current pool rates
+    // (underlying = tokens × rate / SCALAR_12). The two are only equal while the
+    // rates sit at 1.0; once interest accrues they diverge, so skipping this
+    // conversion makes the unwind repay/withdraw the wrong amounts.
+    let reserve = pool_client.get_reserve(&config.asset);
+    let b_rate = reserve.data.b_rate;
+    let d_rate = reserve.data.d_rate;
+    let d_underlying = d_tokens_to_remove
+        .checked_mul(d_rate)
+        .ok_or(StrategyError::ArithmeticError)?
+        / SCALAR_12;
+    let b_underlying = b_tokens_to_remove
+        .checked_mul(b_rate)
+        .ok_or(StrategyError::ArithmeticError)?
+        / SCALAR_12;
+
     // Build atomic unwind: [withdraw, repay] × N steps + [withdraw equity].
-    // Split d_tokens_to_remove evenly across target_loops steps.
+    // Split the underlying debt evenly across target_loops steps.
     // Each step withdraws and repays the same amount, maintaining HF.
     // The final withdraw extracts the equity (b - d difference).
     let mut requests: Vec<Request> = Vec::new(e);
     let mut total_repay = 0i128;
 
     let n_steps = config.target_loops.max(1);
-    let repay_per_step = d_tokens_to_remove / n_steps as i128;
+    let repay_per_step = d_underlying / n_steps as i128;
 
     // Check if this is a full close (removing all debt)
     let pool_client_inner = BlendPoolClient::new(e, &config.pool);
@@ -180,18 +197,15 @@ pub fn submit_unwind(
         let repay_amount = if is_last && is_full_close {
             i64::MAX as i128
         } else if is_last {
-            d_tokens_to_remove - repay_per_step * (n_steps as i128 - 1)
+            d_underlying - repay_per_step * (n_steps as i128 - 1)
         } else {
             repay_per_step
         };
 
         // Withdraw same amount as repay in each pair — this frees collateral to cover repayment.
-        // The equity portion (b_tokens - d_tokens) is withdrawn separately at the end.
-        let withdraw_amount = if is_last && is_full_close {
-            // For full close, withdraw same as the repay dust-cleaning amount
-            d_tokens_to_remove - repay_per_step * (n_steps as i128 - 1)
-        } else if is_last {
-            d_tokens_to_remove - repay_per_step * (n_steps as i128 - 1)
+        // The equity portion (b - d, in underlying) is withdrawn separately at the end.
+        let withdraw_amount = if is_last {
+            d_underlying - repay_per_step * (n_steps as i128 - 1)
         } else {
             repay_per_step
         };
@@ -209,10 +223,9 @@ pub fn submit_unwind(
         total_repay += repay_amount;
     }
 
-    // Final: withdraw equity portion (collateral minus debt that was removed)
-    let equity_withdraw = b_tokens_to_remove
-        .checked_sub(d_tokens_to_remove)
-        .unwrap_or(0);
+    // Final: withdraw equity portion (collateral minus debt that was removed),
+    // in underlying.
+    let equity_withdraw = b_underlying.checked_sub(d_underlying).unwrap_or(0);
 
     if equity_withdraw > 0 {
         requests.push_back(Request {
@@ -314,44 +327,51 @@ pub fn submit_deleverage(
         return Ok((0, 0));
     }
 
-    // Build all (withdraw, repay) pairs for a single atomic submit.
-    // Each layer amount = the borrow amount of the corresponding leverage step.
-    // Unwind in reverse order (last leverage step unwound first).
-    let count = loop_step_count(config.target_loops);
-    let mut layers: Vec<i128> = Vec::new(e);
-    let mut orig_balance = pre_b; // approximate with total collateral
-    for i in 0..count {
-        let is_final = i == config.target_loops.min(20);
-        let (_, borrow) = compute_step(orig_balance, config.c_factor, is_final);
-        if borrow > 0 {
-            layers.push_back(borrow);
-        }
-        orig_balance = borrow;
+    // Size one unwind layer as `debt × (1 - c_factor)`, in UNDERLYING — the same
+    // definition `compute_partial_unwind` uses to derive `unwind_loops`, so that
+    // unwinding N loops repays ≈ the intended `repay_underlying`. (The previous
+    // implementation seeded the layers from total collateral, producing layers
+    // several times larger than the position, which over-unwound or reverted.)
+    // Blend request amounts are denominated in the underlying asset, so convert
+    // the d-token debt with the current d_rate.
+    let reserve = pool_client.get_reserve(&config.asset);
+    let debt_underlying = pre_d
+        .checked_mul(reserve.data.d_rate)
+        .ok_or(StrategyError::ArithmeticError)?
+        / SCALAR_12;
+    let layer = debt_underlying
+        .checked_mul(SCALAR_7 - config.c_factor)
+        .ok_or(StrategyError::ArithmeticError)?
+        / SCALAR_7;
+    if layer <= 0 {
+        return Ok((0, 0));
     }
 
+    // Build all (withdraw, repay) pairs for a single atomic submit, each step
+    // HF-neutral (withdraw == repay). Cap the cumulative repay at the outstanding
+    // debt so we never over-repay or withdraw more collateral than exists.
     let mut requests: Vec<Request> = Vec::new(e);
     let mut total_repay = 0i128;
-    let n_layers = layers.len();
-    let loops_to_unwind = unwind_loops.min(n_layers);
+    let mut remaining_debt = debt_underlying;
 
-    for i in 0..loops_to_unwind {
-        let idx = n_layers - 1 - i;
-        let layer_amount = layers.get(idx).unwrap_or(0);
-        if layer_amount == 0 {
-            continue;
+    for _ in 0..unwind_loops.min(20) {
+        let amount = layer.min(remaining_debt);
+        if amount <= 0 {
+            break;
         }
 
         requests.push_back(Request {
             address: config.asset.clone(),
-            amount: layer_amount,
+            amount,
             request_type: REQUEST_TYPE_WITHDRAW_COLLATERAL,
         });
         requests.push_back(Request {
             address: config.asset.clone(),
-            amount: layer_amount,
+            amount,
             request_type: REQUEST_TYPE_REPAY,
         });
-        total_repay += layer_amount;
+        total_repay += amount;
+        remaining_debt -= amount;
     }
 
     if total_repay > 0 {

--- a/contracts/strategies/blend_leverage/src/lib.rs
+++ b/contracts/strategies/blend_leverage/src/lib.rs
@@ -289,15 +289,24 @@ impl DeFindexStrategyTrait for BlendLeverageStrategy {
         let token = ShareTokenClient::new(&e, &storage::get_share_token(&e));
         let user_shares = token.balance(&from);
 
-        // Calculate shares to burn + proportional b/d tokens to unwind.
-        let (shares_to_burn, b_to_remove, d_to_remove, updated_reserves) =
+        // Calculate shares to burn + the intended proportional b/d tokens to
+        // unwind. This does NOT persist the position (see `commit_withdraw`).
+        let (shares_to_burn, b_to_remove, d_to_remove, _preview) =
             reserves::withdraw(&e, user_shares, amount, &reserves)?;
 
         // Burn the caller's shares (minter burn — from already authorized above).
         token.burn_by_minter(&from, &shares_to_burn);
 
-        // Execute unwind on the pool — net equity flows to `to`
-        blend_pool::submit_unwind(&e, b_to_remove, d_to_remove, &to, &config)?;
+        // Execute unwind on the pool — net equity flows to `to`. The returned
+        // deltas are the b/d tokens the pool *actually* removed.
+        let (b_removed, d_removed) =
+            blend_pool::submit_unwind(&e, b_to_remove, d_to_remove, &to, &config)?;
+
+        // Persist using the measured pool deltas so stored reserves stay in
+        // lock-step with the real pool position (Finding ①), matching the
+        // measured-delta discipline of deposit/harvest/deleverage.
+        let updated_reserves =
+            reserves::commit_withdraw(&e, shares_to_burn, b_removed, d_removed, &reserves)?;
 
         let remaining_shares = user_shares
             .checked_sub(shares_to_burn)

--- a/contracts/strategies/blend_leverage/src/reserves.rs
+++ b/contracts/strategies/blend_leverage/src/reserves.rs
@@ -117,11 +117,18 @@ pub fn deposit(
 /// 2. Calculate proportional b/d tokens
 /// 3. Update totals
 ///
-/// Returns `(shares_to_burn, b_tokens_to_remove, d_tokens_to_remove, updated_reserves)`.
+/// Returns `(shares_to_burn, b_tokens_to_remove, d_tokens_to_remove, preview_reserves)`.
 ///
 /// `user_shares` is the caller's current token balance (read by `lib.rs` from
 /// the share token, not from strategy storage). This no longer writes
 /// `VaultPos`: the caller burns `shares_to_burn` from the token.
+///
+/// IMPORTANT: this function does **not** persist the position. The returned
+/// `b/d_tokens_to_remove` are the *intended* unwind amounts (fed to
+/// `submit_unwind`); the `preview_reserves` are the corresponding projected
+/// state and are exact only when token≈underlying. The real reserves are
+/// committed by `commit_withdraw` from the pool's *measured* deltas, so stored
+/// reserves stay in lock-step with the actual pool position (Finding ①).
 pub fn withdraw(
     e: &Env,
     user_shares: i128,
@@ -156,7 +163,8 @@ pub fn withdraw(
         .fixed_mul_floor(reserves.total_d_tokens, reserves.total_shares)
         .ok_or(StrategyError::ArithmeticError)?;
 
-    // Update totals
+    // Project the post-withdraw state for the caller's preview/return value.
+    // NOTE: not persisted here — see `commit_withdraw` (Finding ①).
     reserves.total_shares = reserves
         .total_shares
         .checked_sub(shares_to_burn)
@@ -170,15 +178,44 @@ pub fn withdraw(
         .checked_sub(d_tokens_to_remove)
         .ok_or(StrategyError::UnderflowOverflow)?;
 
-    // Persist
-    storage::set_strategy_reserves(e, reserves.clone());
-
     Ok((
         shares_to_burn,
         b_tokens_to_remove,
         d_tokens_to_remove,
         reserves,
     ))
+}
+
+/// Commit a withdrawal to storage using the b/d tokens the pool *actually*
+/// removed (returned by `submit_unwind`), keeping stored reserves in lock-step
+/// with the real pool position — the same measured-delta discipline used by
+/// `deposit`, `harvest` and `deleverage`.
+///
+/// `reserves` is the pre-withdraw snapshot (with refreshed rates). `shares_to_burn`
+/// is the amount burned from the share token; `b_removed`/`d_removed` are the
+/// measured pool deltas. Position totals use `saturating_sub` so a full close
+/// that clears a stroop more than was tracked (e.g. the `i64::MAX` dust sweep)
+/// floors at zero instead of reverting.
+///
+/// Returns the persisted, post-withdraw reserves.
+pub fn commit_withdraw(
+    e: &Env,
+    shares_to_burn: i128,
+    b_removed: i128,
+    d_removed: i128,
+    reserves: &LeverageReserves,
+) -> Result<LeverageReserves, StrategyError> {
+    let mut reserves = reserves.clone();
+
+    reserves.total_shares = reserves
+        .total_shares
+        .checked_sub(shares_to_burn)
+        .ok_or(StrategyError::UnderflowOverflow)?;
+    reserves.total_b_tokens = reserves.total_b_tokens.saturating_sub(b_removed);
+    reserves.total_d_tokens = reserves.total_d_tokens.saturating_sub(d_removed);
+
+    storage::set_strategy_reserves(e, reserves.clone());
+    Ok(reserves)
 }
 
 // ── Harvest accounting ───────────────────────────────────────────────────────

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -18,7 +18,7 @@ use blend_contract_sdk::{
 };
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    testutils::{Address as _, BytesN as _},
+    testutils::{Address as _, BytesN as _, Ledger as _},
     token::{StellarAssetClient, TokenClient},
     vec, Address, BytesN, Env, IntoVal, String, Val, Vec,
 };
@@ -27,7 +27,9 @@ use crate::constants::{
     REQUEST_TYPE_BORROW, REQUEST_TYPE_REPAY, REQUEST_TYPE_SUPPLY_COLLATERAL,
     REQUEST_TYPE_WITHDRAW_COLLATERAL, SCALAR_12, SCALAR_7,
 };
-use crate::leverage::{compute_health_factor, compute_loop_pairs, shares_to_underlying};
+use crate::leverage::{
+    compute_health_factor, compute_loop_pairs, compute_partial_unwind, shares_to_underlying,
+};
 use crate::storage::LeverageReserves;
 use crate::{blend_pool, reserves, storage};
 
@@ -914,6 +916,478 @@ fn test_split_harvest_rejects_non_keeper() {
             .try_harvest_reinvest(&stranger, &1_000, &true, &900)
             .is_err(),
         "harvest_reinvest: non-keeper rejected"
+    );
+}
+
+// ── Regression test: unwind must pay the correct equity after rates accrue ────
+//
+// Bug #1 (b/d-token ↔ underlying unit confusion). `reserves::withdraw` returns
+// proportional b/d-TOKEN quantities; `blend_pool::submit_unwind` feeds them
+// straight into Blend `Request.amount`, which Blend reads as UNDERLYING. Tokens
+// equal underlying ONLY when b_rate == d_rate == SCALAR_12 (what every other
+// test pins). Once Blend interest accrues, withdrawing X equity pays out the
+// WRONG amount of underlying, draining the vault.
+//
+// This test exercises the REAL production `submit_unwind` against the REAL Blend
+// pool after ~1 year of interest, and asserts the withdrawing user receives the
+// equity they are actually owed. It FAILS until `submit_unwind` converts token
+// amounts to underlying (× rate / SCALAR_12).
+#[test]
+fn test_unwind_pays_correct_equity_after_rates_accrue() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let config = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = e.register(TestStrategyContract, ());
+    let user = Address::generate(&e);
+    let token_admin = StellarAssetClient::new(&e, &token);
+    let token_client = TokenClient::new(&e, &token);
+
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&strategy, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    // Build the leveraged position (3 loops at c=0.90).
+    let (b_tokens, d_tokens) = execute_leverage_loop_stepped(
+        &e,
+        &pool_addr,
+        &strategy,
+        &token,
+        deposit,
+        config.c_factor,
+        config.target_loops,
+    );
+
+    // Seed reserves to match (1 share == 1 underlying at entry, rates 1.0).
+    e.as_contract(&strategy, || {
+        storage::set_strategy_reserves(
+            &e,
+            LeverageReserves {
+                total_shares: deposit,
+                total_b_tokens: b_tokens,
+                total_d_tokens: d_tokens,
+                b_rate: SCALAR_12,
+                d_rate: SCALAR_12,
+            },
+        );
+    });
+
+    // Advance ~1 year so Blend interest accrues (rates drift above 1.0).
+    e.ledger().with_mut(|li| {
+        li.timestamp += 31_536_000;
+        li.sequence_number += 6_000_000;
+    });
+    // Poke the reserve so the accrual is materialised in the stored rates.
+    let poker = Address::generate(&e);
+    token_admin.mint(&poker, &1_0000000);
+    pool::Client::new(&e, &pool_addr).submit(
+        &poker,
+        &poker,
+        &poker,
+        &vec![
+            &e,
+            pool::Request {
+                address: token.clone(),
+                amount: 1_0000000,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
+
+    let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
+    assert!(
+        d_rate > SCALAR_12,
+        "precondition: interest must accrue (d_rate={})",
+        d_rate
+    );
+
+    // Compute a 25%-equity withdrawal using the accrued rates, exactly like
+    // production: shares→(b_to_remove, d_to_remove) token quantities.
+    let (requested, b_to_remove, d_to_remove) = e.as_contract(&strategy, || {
+        let reserves = reserves::get_strategy_reserves_updated(&e, &config);
+        let equity = crate::leverage::compute_equity(&reserves).unwrap();
+        let requested = equity / 4;
+        let (_burned, b_rm, d_rm, _updated) =
+            reserves::withdraw(&e, reserves.total_shares, requested, &reserves).unwrap();
+        (requested, b_rm, d_rm)
+    });
+
+    let user_before = token_client.balance(&user);
+
+    // Run the REAL production unwind against the REAL pool.
+    e.as_contract(&strategy, || {
+        blend_pool::submit_unwind(&e, b_to_remove, d_to_remove, &user, &config).unwrap();
+    });
+
+    let received = token_client.balance(&user) - user_before;
+
+    std::println!(
+        "b_rate={} d_rate={} | requested(owed)={} received={} (b_rm={}, d_rm={})",
+        b_rate,
+        d_rate,
+        requested,
+        received,
+        b_to_remove,
+        d_to_remove
+    );
+
+    // The user must receive the equity they actually own — no more, no less.
+    // Allow 1% tolerance for pool/loop rounding. FAILS today because the unwind
+    // pays out ~ (b_to_remove - d_to_remove) of underlying, materially above the
+    // owed equity once rates have accrued.
+    let tolerance = requested / 100;
+    assert!(
+        (received - requested).abs() <= tolerance,
+        "withdrawing user should receive ~{} (owed equity) but got {} (diff {})",
+        requested,
+        received,
+        (received - requested).abs()
+    );
+}
+
+// Full-close sibling of the regression test above: withdrawing the ENTIRE
+// position after interest has accrued must (a) pay the user their full equity
+// and (b) leave no collateral/debt stranded in the pool. Before the unit-
+// confusion fix, the unwind under-withdrew collateral (token counts used as
+// underlying), leaving dust locked in the pool.
+#[test]
+fn test_full_close_returns_all_equity_after_rates_accrue() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let config = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = e.register(TestStrategyContract, ());
+    let user = Address::generate(&e);
+    let token_admin = StellarAssetClient::new(&e, &token);
+    let token_client = TokenClient::new(&e, &token);
+
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&strategy, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (b_tokens, d_tokens) = execute_leverage_loop_stepped(
+        &e,
+        &pool_addr,
+        &strategy,
+        &token,
+        deposit,
+        config.c_factor,
+        config.target_loops,
+    );
+
+    // Advance ~1 year and poke the reserve so interest is materialised.
+    e.ledger().with_mut(|li| {
+        li.timestamp += 31_536_000;
+        li.sequence_number += 6_000_000;
+    });
+    let poker = Address::generate(&e);
+    token_admin.mint(&poker, &1_0000000);
+    pool::Client::new(&e, &pool_addr).submit(
+        &poker,
+        &poker,
+        &poker,
+        &vec![
+            &e,
+            pool::Request {
+                address: token.clone(),
+                amount: 1_0000000,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
+
+    let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
+    assert!(d_rate > SCALAR_12, "precondition: interest must accrue");
+
+    // Equity owed for a FULL close, in underlying.
+    let owed = b_tokens * b_rate / SCALAR_12 - d_tokens * d_rate / SCALAR_12;
+
+    let user_before = token_client.balance(&user);
+    e.as_contract(&strategy, || {
+        blend_pool::submit_unwind(&e, b_tokens, d_tokens, &user, &config).unwrap();
+    });
+    let received = token_client.balance(&user) - user_before;
+
+    // Position should be essentially emptied.
+    let end = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let end_b = end.collateral.get(config.reserve_id).unwrap_or(0);
+    let end_d = end.liabilities.get(config.reserve_id).unwrap_or(0);
+
+    std::println!(
+        "owed={} received={} end_b={} end_d={}",
+        owed,
+        received,
+        end_b,
+        end_d
+    );
+
+    // User gets their full equity (1% tolerance for pool/loop rounding).
+    assert!(
+        (received - owed).abs() <= owed / 100,
+        "full close should return all equity ~{}, got {}",
+        owed,
+        received
+    );
+    // No material collateral left stranded (≤ 0.5% of the original collateral).
+    assert!(
+        end_b <= b_tokens / 200,
+        "collateral left stranded in pool: end_b={} (started {})",
+        end_b,
+        b_tokens
+    );
+    // All debt cleared.
+    assert!(end_d == 0, "debt not fully cleared: end_d={}", end_d);
+}
+
+// Coverage for the production `submit_deleverage` path (used by rebalance /
+// partial_unwind) at accrued rates — the third site of the unit-confusion fix.
+// Deleveraging must reduce both collateral and debt, improve the health factor,
+// and preserve equity (each layer withdraws == repays the same underlying).
+#[test]
+fn test_deleverage_improves_hf_and_preserves_equity_after_rates_accrue() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let config = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = e.register(TestStrategyContract, ());
+    let token_admin = StellarAssetClient::new(&e, &token);
+
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&strategy, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    execute_leverage_loop_stepped(
+        &e,
+        &pool_addr,
+        &strategy,
+        &token,
+        deposit,
+        config.c_factor,
+        config.target_loops,
+    );
+
+    // Advance ~1 year and poke the reserve so interest is materialised.
+    e.ledger().with_mut(|li| {
+        li.timestamp += 31_536_000;
+        li.sequence_number += 6_000_000;
+    });
+    let poker = Address::generate(&e);
+    token_admin.mint(&poker, &1_0000000);
+    pool::Client::new(&e, &pool_addr).submit(
+        &poker,
+        &poker,
+        &poker,
+        &vec![
+            &e,
+            pool::Request {
+                address: token.clone(),
+                amount: 1_0000000,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
+
+    let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
+    assert!(d_rate > SCALAR_12, "precondition: interest must accrue");
+
+    let pre = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let pre_b = pre.collateral.get(config.reserve_id).unwrap_or(0);
+    let pre_d = pre.liabilities.get(config.reserve_id).unwrap_or(0);
+    let pre_equity = pre_b * b_rate / SCALAR_12 - pre_d * d_rate / SCALAR_12;
+    let pre_hf = compute_health_factor(pre_b, pre_d, b_rate, d_rate, config.c_factor).unwrap();
+
+    // Unwind 2 loops through the REAL production deleverage path.
+    let (b_removed, d_removed) =
+        e.as_contract(&strategy, || blend_pool::submit_deleverage(&e, 2, &config).unwrap());
+
+    let post = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let post_b = post.collateral.get(config.reserve_id).unwrap_or(0);
+    let post_d = post.liabilities.get(config.reserve_id).unwrap_or(0);
+    let post_equity = post_b * b_rate / SCALAR_12 - post_d * d_rate / SCALAR_12;
+    let post_hf = compute_health_factor(post_b, post_d, b_rate, d_rate, config.c_factor).unwrap();
+
+    std::println!(
+        "b_removed={} d_removed={} pre_hf={} post_hf={} pre_eq={} post_eq={}",
+        b_removed,
+        d_removed,
+        pre_hf,
+        post_hf,
+        pre_equity,
+        post_equity
+    );
+
+    // Deleveraging reduces both sides of the position.
+    assert!(
+        b_removed > 0 && d_removed > 0,
+        "should remove collateral and debt: b_removed={}, d_removed={}",
+        b_removed,
+        d_removed
+    );
+    assert!(post_d < pre_d, "debt must decrease: pre={}, post={}", pre_d, post_d);
+
+    // Reducing leverage improves the health factor.
+    assert!(
+        post_hf > pre_hf,
+        "HF must improve after deleverage: pre={}, post={}",
+        pre_hf,
+        post_hf
+    );
+
+    // Equity is preserved (each layer withdraws == repays the same underlying);
+    // allow 1% for pool/loop rounding.
+    assert!(
+        (post_equity - pre_equity).abs() <= pre_equity / 100,
+        "equity must be preserved: pre={}, post={}",
+        pre_equity,
+        post_equity
+    );
+}
+
+// A single-loop deleverage must be a PARTIAL unwind, not a full close. With the
+// broken layer sizing, one "layer" exceeds the whole debt, so a 1-loop unwind
+// either reverts or repays the entire position — defeating partial protection.
+#[test]
+fn test_deleverage_one_loop_is_partial_not_full_close() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let config = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = e.register(TestStrategyContract, ());
+    let token_admin = StellarAssetClient::new(&e, &token);
+
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&strategy, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    execute_leverage_loop_stepped(
+        &e,
+        &pool_addr,
+        &strategy,
+        &token,
+        deposit,
+        config.c_factor,
+        config.target_loops,
+    );
+
+    let pre = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let pre_d = pre.liabilities.get(config.reserve_id).unwrap_or(0);
+
+    // Unwind exactly ONE loop through the real production path.
+    e.as_contract(&strategy, || {
+        blend_pool::submit_deleverage(&e, 1, &config).unwrap();
+    });
+
+    let post = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let post_d = post.liabilities.get(config.reserve_id).unwrap_or(0);
+
+    std::println!("pre_d={} post_d={}", pre_d, post_d);
+
+    // A single-loop unwind should clear only one layer (~debt × (1-c) ≈ 10%),
+    // so the bulk of the debt must remain. FAILS today: the oversized layer
+    // wipes (or over-shoots) the whole debt.
+    assert!(post_d > 0, "1-loop unwind should not fully close the position");
+    assert!(
+        post_d >= pre_d / 2,
+        "1-loop unwind must be partial: pre_d={}, post_d={} (over-unwound)",
+        pre_d,
+        post_d
+    );
+}
+
+// End-to-end protection round-trip (mirrors lib.rs::unwind_to): a position that
+// sits in the orange zone (HF < orange_hf) must be restored to >= orange_hf by
+// `compute_partial_unwind` → `submit_deleverage`. This proves the two pieces are
+// consistent: the loop count derived from the closed form actually achieves the
+// target HF on the real pool.
+#[test]
+fn test_rebalance_round_trip_restores_hf_to_target() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let mut config = make_config(&e, &pool_addr, &token, &blnd);
+    // High leverage so the freshly-built position starts inside the orange zone.
+    config.target_loops = 8;
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = e.register(TestStrategyContract, ());
+    let token_admin = StellarAssetClient::new(&e, &token);
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&strategy, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    execute_leverage_loop_stepped(
+        &e,
+        &pool_addr,
+        &strategy,
+        &token,
+        deposit,
+        config.c_factor,
+        config.target_loops,
+    );
+
+    let (b_rate, d_rate) = blend_pool::get_rates(&e, &config);
+    let pre = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let b = pre.collateral.get(config.reserve_id).unwrap_or(0);
+    let d = pre.liabilities.get(config.reserve_id).unwrap_or(0);
+
+    let target = config.orange_hf;
+    let before_hf = compute_health_factor(b, d, b_rate, d_rate, config.c_factor).unwrap();
+    assert!(
+        before_hf < target,
+        "fixture must start in the orange zone: before_hf={}, target={}",
+        before_hf,
+        target
+    );
+
+    // Production logic: derive the loop count needed to restore HF to target.
+    let (_, loops) =
+        compute_partial_unwind(b, d, b_rate, d_rate, config.c_factor, target).unwrap();
+    assert!(loops >= 1, "should need at least one unwind loop");
+
+    // Execute the real deleverage on the real pool.
+    e.as_contract(&strategy, || {
+        blend_pool::submit_deleverage(&e, loops, &config).unwrap();
+    });
+
+    let post = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let b2 = post.collateral.get(config.reserve_id).unwrap_or(0);
+    let d2 = post.liabilities.get(config.reserve_id).unwrap_or(0);
+    let after_hf = compute_health_factor(b2, d2, b_rate, d_rate, config.c_factor).unwrap();
+
+    std::println!(
+        "before_hf={} after_hf={} target={} loops={}",
+        before_hf,
+        after_hf,
+        target,
+        loops
+    );
+
+    // HF restored to at least the target …
+    assert!(
+        after_hf >= target,
+        "HF must be restored to >= target: after_hf={}, target={}",
+        after_hf,
+        target
+    );
+    // … without grossly over-unwinding (ceil rounding adds at most ~one layer).
+    assert!(
+        after_hf <= target + target * 30 / 100,
+        "over-unwound: after_hf={}, target={}",
+        after_hf,
+        target
     );
 }
 

--- a/contracts/strategies/blend_leverage/src/test_integration.rs
+++ b/contracts/strategies/blend_leverage/src/test_integration.rs
@@ -1408,3 +1408,204 @@ fn test_harvest_reinvest_soroswap_requires_min_out() {
         "soroswap path requires non-zero amount_out_min"
     );
 }
+
+// ── Finding ①: withdraw must keep stored reserves in sync with the pool ───────
+//
+// The strategy keeps TWO ledgers of the same position:
+//   A) stored `LeverageReserves.total_b/d_tokens`  — values shares (deposit /
+//      withdraw / balance / position)
+//   B) the real `pool.get_positions(strategy)`     — drives HF / rebalance
+//
+// `deposit`, `harvest` and `deleverage` all update A from the *measured* pool
+// delta, so A == B by construction. `withdraw` used to be the lone exception: it
+// subtracted the *intended* `b_to_remove`/`d_to_remove` (proportional token
+// counts) and DISCARDED the actual amounts `submit_unwind` removed, so A drifted
+// away from B and never reconciled. The fix routes the withdraw through
+// `reserves::commit_withdraw`, persisting the *measured* (b_removed, d_removed)
+// just like the other three paths.
+//
+// End-to-end guard for Finding ①, driven through the REAL `deposit`/`withdraw`
+// contract entrypoints (not the internal helpers). This is the test that
+// actually protects the production code path: it FAILS if lib.rs::withdraw is
+// reverted to subtract the intended deltas instead of committing the measured
+// ones. Uses the real strategy + real Blend pool + a mock share token.
+#[test]
+fn test_real_withdraw_entrypoint_keeps_reserves_in_sync() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let cfg = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+
+    // Wire the share token (the strategy is its minter).
+    let share = e.register(MockShareToken, ());
+    sclient.set_share_token(&share);
+
+    // Fund a user and deposit through the REAL entrypoint (runs the real
+    // submit_leverage_loop + reserves::deposit reconciliation).
+    let user = Address::generate(&e);
+    let token_admin = StellarAssetClient::new(&e, &token);
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&user, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    sclient.deposit(&deposit, &user);
+
+    // Post-deposit, stored reserves should already equal pool positions.
+    let after_dep = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let dep_b = after_dep.collateral.get(cfg.reserve_id).unwrap_or(0);
+    let dep_d = after_dep.liabilities.get(cfg.reserve_id).unwrap_or(0);
+    let stored_dep = e.as_contract(&strategy, || storage::get_strategy_reserves(&e));
+    assert_eq!(stored_dep.total_b_tokens, dep_b, "post-deposit b in sync");
+    assert_eq!(stored_dep.total_d_tokens, dep_d, "post-deposit d in sync");
+
+    // Accrue ~1 year and poke the reserve so rates drift above 1.0.
+    e.ledger().with_mut(|li| {
+        li.timestamp += 31_536_000;
+        li.sequence_number += 6_000_000;
+    });
+    let poker = Address::generate(&e);
+    token_admin.mint(&poker, &1_0000000);
+    pool::Client::new(&e, &pool_addr).submit(
+        &poker,
+        &poker,
+        &poker,
+        &vec![
+            &e,
+            pool::Request {
+                address: token.clone(),
+                amount: 1_0000000,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
+
+    // Withdraw ~30% of the user's balance through the REAL entrypoint, twice.
+    for _ in 0..2 {
+        let bal = sclient.balance(&user);
+        let amount = bal * 3 / 10;
+        sclient.withdraw(&amount, &user, &user);
+    }
+
+    // The invariant must hold through the production withdraw path.
+    let post = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let pool_b = post.collateral.get(cfg.reserve_id).unwrap_or(0);
+    let pool_d = post.liabilities.get(cfg.reserve_id).unwrap_or(0);
+    let stored = e.as_contract(&strategy, || storage::get_strategy_reserves(&e));
+
+    std::println!(
+        "e2e post-withdraw: stored_b={} pool_b={} (diff={}) | stored_d={} pool_d={} (diff={})",
+        stored.total_b_tokens,
+        pool_b,
+        stored.total_b_tokens - pool_b,
+        stored.total_d_tokens,
+        pool_d,
+        stored.total_d_tokens - pool_d,
+    );
+
+    assert_eq!(stored.total_b_tokens, pool_b, "post-withdraw b out of sync with pool");
+    assert_eq!(stored.total_d_tokens, pool_d, "post-withdraw d out of sync with pool");
+}
+
+// Full-close sibling of the e2e guard: a user withdrawing their ENTIRE balance
+// drives the near-full unwind (large repay + the `i64::MAX` dust sweep) and the
+// `commit_withdraw` `saturating_sub`. Asserts the stored==pool invariant still
+// holds, the user is paid ~their full balance, and only the inflation lockup is
+// left behind.
+#[test]
+fn test_real_full_withdraw_entrypoint_keeps_reserves_in_sync() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (pool_addr, token, blnd, _blend, _deployer) = setup_blend_env(&e);
+    let cfg = make_config(&e, &pool_addr, &token, &blnd);
+
+    seed_pool_liquidity(&e, &pool_addr, &token, 1_000_000_0000000);
+
+    let strategy = register_real_strategy(&e, &pool_addr, &token, &blnd);
+    let sclient = crate::BlendLeverageStrategyClient::new(&e, &strategy);
+    let share = e.register(MockShareToken, ());
+    sclient.set_share_token(&share);
+    let shclient = MockShareTokenClient::new(&e, &share);
+
+    let user = Address::generate(&e);
+    let token_admin = StellarAssetClient::new(&e, &token);
+    let token_client = TokenClient::new(&e, &token);
+    let deposit = 1_000_0000000_i128;
+    token_admin.mint(&user, &deposit);
+    e.cost_estimate().budget().reset_unlimited();
+
+    sclient.deposit(&deposit, &user);
+
+    // Accrue ~1 year and poke so rates drift above 1.0.
+    e.ledger().with_mut(|li| {
+        li.timestamp += 31_536_000;
+        li.sequence_number += 6_000_000;
+    });
+    let poker = Address::generate(&e);
+    token_admin.mint(&poker, &1_0000000);
+    pool::Client::new(&e, &pool_addr).submit(
+        &poker,
+        &poker,
+        &poker,
+        &vec![
+            &e,
+            pool::Request {
+                address: token.clone(),
+                amount: 1_0000000,
+                request_type: REQUEST_TYPE_SUPPLY_COLLATERAL,
+            },
+        ],
+    );
+
+    // Withdraw the user's ENTIRE reported balance through the real entrypoint.
+    let bal = sclient.balance(&user);
+    let user_before = token_client.balance(&user);
+    sclient.withdraw(&bal, &user, &user);
+    let received = token_client.balance(&user) - user_before;
+
+    // Invariant still holds across the near-full unwind (saturating_sub path).
+    let post = pool::Client::new(&e, &pool_addr).get_positions(&strategy);
+    let pool_b = post.collateral.get(cfg.reserve_id).unwrap_or(0);
+    let pool_d = post.liabilities.get(cfg.reserve_id).unwrap_or(0);
+    let stored = e.as_contract(&strategy, || storage::get_strategy_reserves(&e));
+
+    std::println!(
+        "full-close e2e: received={} (bal={}) | stored_b={} pool_b={} | stored_d={} pool_d={} | total_shares={} user_shares_left={}",
+        received,
+        bal,
+        stored.total_b_tokens,
+        pool_b,
+        stored.total_d_tokens,
+        pool_d,
+        stored.total_shares,
+        shclient.balance(&user),
+    );
+
+    assert_eq!(stored.total_b_tokens, pool_b, "full-close: stored b out of sync with pool");
+    assert_eq!(stored.total_d_tokens, pool_d, "full-close: stored d out of sync with pool");
+
+    // The user is paid ~their whole balance (1% tolerance for pool/loop rounding).
+    assert!(
+        (received - bal).abs() <= bal / 100,
+        "user should receive ~full balance: got {} want {}",
+        received,
+        bal
+    );
+
+    // Only the inflation lockup (held by the strategy) remains; the user's own
+    // shares are essentially gone (allow a few stroops of ceil/floor dust).
+    assert!(
+        shclient.balance(&user) <= 1_000,
+        "user shares should be ~fully burned, left {}",
+        shclient.balance(&user)
+    );
+    assert!(
+        (stored.total_shares - crate::constants::FIRST_DEPOSIT_LOCKUP).abs() <= 1_000,
+        "only the lockup should remain, total_shares={}",
+        stored.total_shares
+    );
+}


### PR DESCRIPTION
1. submit_unwind/submit_deleverage now convert b/d-token amounts into underlying via b_rate/d_rate before sending requests to Blend (they diverge once interest accrues), and submit_deleverage sizes its unwind layers from actual debt instead of total collateral (preventing over-unwind/reverts).

2. withdraw now persists the pool's measured b/d deltas via commit_withdraw instead of the intended proportional amounts, keeping stored reserves in lock-step with the real pool position.