### PR TITLE
fix(dashboard): Manage / Add leg deep-link to the real pool + asset

### DIFF
--- a/frontend/src/app/state.ts
+++ b/frontend/src/app/state.ts
@@ -9,6 +9,17 @@ export type View = "dashboard" | "trade" | "vault" | "compare" | "swap" | "statu
 export type Theme = "light" | "dark";
 export type Lang = "en" | "es" | "pt";
 
+/**
+ * One-shot deep-link target for the Trade screen. Set by the dashboard's
+ * Manage / Add leg buttons just before navigating to "trade"; the trade screen
+ * consumes it on mount (selecting the pool + asset) and clears it so a later
+ * manual visit starts on the default pool.
+ */
+export interface TradeTarget {
+  poolId: string;
+  assetId?: string;
+}
+
 export interface AppState {
   view: View;
   userAddress: string | null;
@@ -17,6 +28,7 @@ export interface AppState {
   theme: Theme;
   expert: boolean;
   lang: Lang;
+  tradeTarget: TradeTarget | null;
 }
 
 const state: AppState = {
@@ -27,6 +39,7 @@ const state: AppState = {
   theme: "dark",
   expert: false,
   lang: "en",
+  tradeTarget: null,
 };
 
 type Listener = (s: AppState) => void;

--- a/frontend/src/blend.ts
+++ b/frontend/src/blend.ts
@@ -761,6 +761,7 @@ export type PoolAccountRole = "loop" | "borrow" | "collateral";
 
 export interface PoolAccountRow {
   symbol:   string;
+  assetId:  string;   // asset contract ID — lets the dashboard deep-link to this leg
   supplied: number;   // full tokens supplied (collateral) in this asset, 0 if none
   borrowed: number;   // full tokens borrowed (debt) in this asset, 0 if none
   role:     PoolAccountRole;
@@ -829,6 +830,7 @@ export function aggregatePoolAccount(
 
     rows.push({
       symbol:   pos.asset.symbol,
+      assetId:  pos.asset.id,
       supplied: pos.collateral,
       borrowed: pos.debt,
       role,

--- a/frontend/src/views/dashboard.screen.ts
+++ b/frontend/src/views/dashboard.screen.ts
@@ -29,7 +29,7 @@ function legsFromRows(
     const price = priceBySymbol.get(r.symbol) ?? 0;
     const role: Role = r.role === "loop" ? "Looped" : r.role === "collateral" ? "Collateral" : "Borrow";
     const amountUsd = (r.role === "borrow" ? r.borrowed : r.supplied) * price;
-    const leg: Leg = { asset: r.symbol, role, amountUsd };
+    const leg: Leg = { asset: r.symbol, assetId: r.assetId, role, amountUsd };
     if (r.role === "loop") leg.loopX = r.leverage;
     return leg;
   });
@@ -52,6 +52,7 @@ export async function loadDashboardData(addr: string): Promise<DashboardData> {
         const priceBySymbol = new Map(reserves.map((rs) => [rs.asset.symbol, rs.priceUsd]));
         poolAccounts.push({
           pool: pool.name,
+          poolId: pool.id,
           legs: legsFromRows(agg.rows, priceBySymbol),
           equityUsd: agg.equityUsd,
           netApy: agg.netApy,
@@ -94,8 +95,11 @@ export async function loadDashboardData(addr: string): Promise<DashboardData> {
 }
 
 const handlers = {
-  onNewPosition: () => setState({ view: "trade" }),
-  onManagePool: () => setState({ view: "trade" }),
+  onNewPosition: () => setState({ view: "trade", tradeTarget: null }),
+  onManagePool: (poolId: string | undefined, assetId: string | undefined) =>
+    setState({ view: "trade", tradeTarget: poolId ? { poolId, assetId } : null }),
+  onAddLeg: (poolId: string | undefined) =>
+    setState({ view: "trade", tradeTarget: poolId ? { poolId } : null }),
   onGoVault: () => setState({ view: "vault" }),
 };
 

--- a/frontend/src/views/dashboard.ts
+++ b/frontend/src/views/dashboard.ts
@@ -19,6 +19,7 @@ export type Role = 'Looped' | 'Collateral' | 'Borrow';
 
 export interface Leg {
   asset: string;        // e.g. "USDC"
+  assetId?: string;     // asset contract ID — lets Manage deep-link to this exact leg
   role: Role;
   amountUsd: number;    // USD value of this leg
   loopX?: number;       // present for Looped legs, e.g. 5.0
@@ -26,7 +27,8 @@ export interface Leg {
 }
 
 export interface PoolAccount {
-  pool: string;         // e.g. "YieldBlox"
+  pool: string;         // e.g. "YieldBlox" (display name)
+  poolId?: string;      // pool contract ID — lets Manage / Add leg deep-link to this pool
   legs: Leg[];
   equityUsd: number;    // collateral − debt, summed for this pool
   netApy: number;       // %, can be negative
@@ -208,8 +210,12 @@ function vaultCard(v: VaultHolding, onManage: () => void): HTMLElement {
 
 // ── Screen ──────────────────────────────────────────────────────────────────
 export interface DashboardHandlers {
+  /** "+ New Position" header button — open Trade with no preset. */
   onNewPosition: () => void;
-  onManagePool: (pool: string) => void;
+  /** "Manage" — open Trade focused on this pool + the account's primary leg. */
+  onManagePool: (poolId: string | undefined, assetId: string | undefined) => void;
+  /** "Add leg" — open Trade focused on this pool so the user can add another asset. */
+  onAddLeg: (poolId: string | undefined) => void;
   onGoVault: () => void;
 }
 
@@ -251,7 +257,18 @@ export function renderDashboard(data: DashboardData, h: DashboardHandlers): HTML
   if (data.poolAccounts.length) {
     root.append(el('h2', { class: 'tl-group' }, ['Pool Accounts ', el('span', { class: 'tl-group__sub' }, ['active · self-managed'])]));
     root.append(el('div', { class: 'tl-grid tl-grid--2' },
-      data.poolAccounts.map((acc) => poolCard(acc, () => h.onManagePool(acc.pool), h.onNewPosition))));
+      data.poolAccounts.map((acc) => {
+        // Manage targets the account's primary leg: the looped one if present,
+        // else the largest leg by USD — so a single-asset account lands exactly
+        // on that asset rather than the pool's default tab.
+        const primary = acc.legs.find((l) => l.role === 'Looped')
+          ?? [...acc.legs].sort((a, b) => b.amountUsd - a.amountUsd)[0];
+        return poolCard(
+          acc,
+          () => h.onManagePool(acc.poolId, primary?.assetId),
+          () => h.onAddLeg(acc.poolId),
+        );
+      })));
   }
 
   // Group B — Vaults
@@ -290,7 +307,8 @@ export const SEED_DASHBOARD: DashboardData = {
    import { renderDashboard, SEED_DASHBOARD } from './dashboard';
    const view = renderDashboard(SEED_DASHBOARD, {
      onNewPosition: () => router.go('trade'),
-     onManagePool: (pool) => router.go('trade', { pool }),
+     onManagePool: (poolId, assetId) => router.go('trade', { poolId, assetId }),
+     onAddLeg: (poolId) => router.go('trade', { poolId }),
      onGoVault: () => router.go('vault'),
    });
    document.getElementById('app')!.replaceChildren(view);

--- a/frontend/src/views/trade.ts
+++ b/frontend/src/views/trade.ts
@@ -62,7 +62,7 @@ import {
   type PositionEvent,
 } from "../blend";
 import { fetchSnapshotSeries } from "../history";
-import { getState, subscribe } from "../app/state";
+import { getState, setState, subscribe } from "../app/state";
 import { signAndSubmit, signAndSubmitClassic } from "../app/wallet";
 import { toast, txShow, txStep, txHide } from "../app/chrome";
 
@@ -132,13 +132,19 @@ export function tradeScreen(): HTMLElement {
   const root = el("div", { class: "trade" });
 
   const pools = getKnownPools();
-  const pool = pools[0];
+  // Deep-link target from the dashboard's Manage / Add leg buttons (one-shot).
+  // Resolve the requested pool + asset, falling back to defaults if unknown,
+  // then clear it so a later manual visit starts on the default pool.
+  const target = getState().tradeTarget;
+  const pool = (target?.poolId && pools.find((p) => p.id === target.poolId)) || pools[0];
   const assets = getPoolAssets(pool);
+  const startAsset = (target?.assetId && assets.find((a) => a.id === target.assetId)) || assets[0];
+  if (target) setState({ tradeTarget: null });
 
   const ts: TradeState = {
     pool,
     assets,
-    asset: assets[0],
+    asset: startAsset,
     reserves: [],
     positions: { byAsset: new Map() },
     balance: 0,


### PR DESCRIPTION
## Problem
On the Dashboard, **Manage** and **Add leg** on an existing pool account always redirected to the **Etherfuse pool / XLM tab**, regardless of which position you clicked. Managing a USDC position in the Fixed pool dumped you on Etherfuse XLM.

## Root cause
- `dashboard.screen.ts` handlers ignored their arguments: `onManagePool: () => setState({ view: "trade" })` and Add leg reused `onNewPosition` — both bare `setState({ view: "trade" })`.
- `tradeScreen()` had no notion of a target, so it always started on `pools[0]` / `assets[0]` (Etherfuse / XLM).
- The view data was also lossy: `PoolAccount.pool` / `Leg.asset` carried only the display name + symbol, no contract ids.

## Fix
Thread a one-shot `AppState.tradeTarget { poolId, assetId }`, set by the dashboard buttons just before navigating and consumed (then cleared) by `tradeScreen()` on mount:
- **Manage** → that pool + the account's **primary leg** (the looped one if present, else the largest leg by USD) → a single-asset account lands exactly on that asset.
- **Add leg** → the same pool, default asset (so you can add a different leg).
- Ids flow end-to-end: `PoolAccountRow.assetId` (blend) → `Leg.assetId` / `PoolAccount.poolId` (dashboard view) → `tradeTarget`.
- Unknown / missing ids fall back to the default pool/asset (no regression for `+ New Position`).
- One-shot: cleared after consumption so a later manual visit to Trade still starts on the default pool.

## Files
- `app/state.ts` — `TradeTarget` type + `tradeTarget` field
- `blend.ts` — `PoolAccountRow.assetId`
- `views/dashboard.ts` — `Leg.assetId`, `PoolAccount.poolId`, handler signatures, primary-leg button wiring
- `views/dashboard.screen.ts` — populate ids + handlers set `tradeTarget`
- `views/trade.ts` — resolve + clear `tradeTarget` on mount

## Verification
- `npm run build` ✓ · `npm run lint` ✓
- Resolution checked against **real** pool data: `Fixed/USDC → Fixed/USDC`, no-target → `Etherfuse/XLM` (default preserved), unknown poolId → safe fallback.
- Playwright e2e boot suite green (3/3) — no TDZ/null regression from the state-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)